### PR TITLE
feat(speech): VAD + streaming STT traits with Silero & whisper.cpp impls

### DIFF
--- a/docs/primer_TTS_next_step.md
+++ b/docs/primer_TTS_next_step.md
@@ -25,7 +25,7 @@ This document scopes the **third slice** of the Phase 2 speech pipeline: a TTS t
 
 ## Goal of this slice
 
-Add a streaming-TTS trait + Piper implementation so the Primer can begin emitting audio before the LLM has finished generating a response. End-to-end target: <150 ms from first LLM token to first PCM sample on a Pi-class device (per the latency budget in the research write-up on commit `b1c0d6...` — see PR #3 description). Children's-voice quality and selection is in scope for the implementation but voice training is **not**.
+Add a streaming-TTS trait + Piper implementation so the Primer can begin emitting audio before the LLM has finished generating a response. End-to-end target: <150 ms from first LLM token to first PCM sample on a Pi-class device (per the latency budget in the PR #3 description). Children's-voice quality and selection is in scope for the implementation but voice training is **not**.
 
 ## Suggested trait shape
 

--- a/docs/primer_TTS_next_step.md
+++ b/docs/primer_TTS_next_step.md
@@ -1,0 +1,130 @@
+# Primer — TTS Next-Step Brief
+
+**Audience:** future Claude Code session continuing the Phase 2 speech pipeline.
+**Last updated:** 2026-05-01 (after PR #3: VAD + streaming STT traits and impls).
+
+This document scopes the **third slice** of the Phase 2 speech pipeline: a TTS trait extension and a Piper backend. PRs #1–#3 introduced the VAD and STT halves of the pipeline; this slice adds voice synthesis so the Primer can speak its responses.
+
+## First moves when you start
+
+1. Read [CLAUDE.md](../CLAUDE.md) — repo conventions and gotchas. **Workspace root is `src/`, not the repo root** — every cargo command runs from `src/`.
+2. Read this document end-to-end. Then read [primer_next_session.md](../primer_next_session.md) only if you need broader context — for TTS work it should not be necessary.
+3. Read the three speech-pipeline source files added in PR #3 to anchor the existing patterns:
+   - `src/crates/primer-core/src/speech.rs` — trait definitions for `VoiceActivityDetector`, `SpeechToText`, `StreamingSpeechToText`, `TranscriptionSession`, and the existing `TextToSpeech`. **Add the new streaming TTS trait here, alongside its synchronous sibling.**
+   - `src/crates/primer-speech/src/silero.rs` — reference implementation pattern (feature-gated, named constants, thin wrapper around the upstream crate, debouncer reuse).
+   - `src/crates/primer-speech/src/whisper.rs` — reference for a backend that implements **both** the one-shot and the streaming trait variants.
+4. From `src/`: `cargo build --workspace && cargo test --workspace`. Should be green: 136 tests after PR #3 merges.
+
+## What's already on the branch (don't redo)
+
+- `VoiceActivityDetector` trait (`primer-core::speech`) and `SileroVad` impl (`primer-speech::silero`, behind `silero` feature). Bundled ONNX weights via `silero-vad-rust 6.2`. `ort` pinned to `=2.0.0-rc.10` to avoid an upstream ndarray drift.
+- `VadDebouncer` and `ms_to_chunks` (`primer-speech::vad_debounce`) — reusable, pure, fully unit-tested probability-to-event state machine. Use it from the TTS layer if streaming TTS needs an analogous debounce; reuse rather than duplicate.
+- `StreamingSpeechToText` + `TranscriptionSession` traits (`primer-core::speech`) — session-based, `push_audio` may emit segments, `finalize(self: Box<Self>)` consumes the session and drains the trailing buffer. Naming and lifecycle conventions to mirror.
+- `WhisperStt` impl (`primer-speech::whisper`, behind `whisper` feature) — implements both `SpeechToText` (one-shot, `spawn_blocking`) and `StreamingSpeechToText` (via `WhisperStream`). Single shared `Arc<WhisperContext>` serves many sessions.
+- The existing `TextToSpeech` trait already exists in `primer-core::speech` with one-shot `synthesize(text, voice) -> AudioBuffer`. **Don't replace it — extend it.**
+
+## Goal of this slice
+
+Add a streaming-TTS trait + Piper implementation so the Primer can begin emitting audio before the LLM has finished generating a response. End-to-end target: <150 ms from first LLM token to first PCM sample on a Pi-class device (per the latency budget in the research write-up on commit `b1c0d6...` — see PR #3 description). Children's-voice quality and selection is in scope for the implementation but voice training is **not**.
+
+## Suggested trait shape
+
+Mirror the streaming-STT pattern. Open one synthesis session per Primer turn; push text, drain audio.
+
+```rust
+// In primer-core::speech, after the TextToSpeech trait.
+
+/// One PCM chunk emitted by a [`SynthesisSession`] during streaming.
+///
+/// Emitted as soon as the underlying model has enough context to commit
+/// audio (typically once a phrase boundary is reached). Concatenate the
+/// `samples` of every chunk in order to reconstruct the full utterance.
+pub struct AudioChunk {
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+}
+
+/// A single streaming-synthesis session.
+///
+/// Created by [`StreamingTextToSpeech::open_session`]. Push partial text
+/// from the LLM via [`Self::push_text`]; each push may emit zero or more
+/// chunks as soon as the synthesiser has enough context. Call
+/// [`Self::finalize`] when the LLM stream has ended to drain the trailing
+/// buffer. `Send` but not `Sync`: each Primer turn owns its own session.
+pub trait SynthesisSession: Send {
+    fn push_text(&mut self, text: &str) -> Result<Vec<AudioChunk>>;
+    fn finalize(self: Box<Self>) -> Result<Vec<AudioChunk>>;
+}
+
+pub trait StreamingTextToSpeech: Send + Sync {
+    fn name(&self) -> &str;
+    fn sample_rate(&self) -> u32;
+    fn open_session(&self, voice: &VoiceProfile) -> Result<Box<dyn SynthesisSession>>;
+}
+```
+
+Notes on the shape:
+- **Phrase-streaming, not phoneme-streaming.** Piper, like Whisper-class STT, naturally synthesises sentence-sized chunks. Don't promise per-character output the model can't deliver.
+- **`open_session` takes the `VoiceProfile`**, not the constructor. A single backend should be able to serve different voices over its lifetime without re-loading the engine. Whether Piper actually requires per-voice model loads is an implementation detail — the trait shouldn't bake that in.
+- **`AudioChunk` carries its own `sample_rate`** even though every chunk in a session shares one. Keeps the type usable in non-session contexts (e.g., a future hand-off to an audio sink that doesn't know which backend produced the chunk).
+
+Decide with Horst before implementing: does the streaming trait deserve a `Named` super-trait, or is the duplicated `name()` method OK? `WhisperStt` impls both `SpeechToText::name` and `StreamingSpeechToText::name` today — it's an ergonomic snag for direct calls (forces UFCS) but invisible through trait objects. PR #3's review noted this; defer the decision to TTS so you fix or don't-fix the whole speech-trait family at once.
+
+## Suggested implementation
+
+Use `piper-rs` (the `thewh1teagle/piper-rs` crate). Behind a `piper` Cargo feature on `primer-speech`, mirroring `silero` and `whisper`:
+
+```toml
+piper-rs = { version = "...", default-features = false, optional = true }
+
+[features]
+piper = ["dep:piper-rs"]
+```
+
+Let the user supply the model path on construction (Piper voices are `*.onnx` + `*.json` pairs distributed via the rhasspy/piper-voices HF repo). Provide a `PiperTts::new(model_path)` constructor with a `with_voice(VoiceProfile)` builder, mirroring `WhisperStt::new` / `with_language`.
+
+For step 3's deliverable, **a synchronous `TextToSpeech` impl is enough** — wrap Piper's synthesise call, return the `AudioBuffer`. Streaming is the harder piece because Piper's native API may not expose phrase-boundary callbacks; if it doesn't, the simplest "streaming" impl is to chunk the input text on sentence boundaries (`. ! ?`) before handing each chunk to the synchronous synthesiser. A pure `split_into_phrases(text: &str) -> Vec<&str>` helper goes alongside `vad_debounce` so it can be unit-tested without the feature. **Be deliberate** — phrase-splitting that mishandles abbreviations or numbers will produce robotic delivery, and an over-eager split adds latency.
+
+If Piper's Rust binding doesn't support streaming at all in version N, it's acceptable to land the synchronous impl + the `StreamingTextToSpeech` trait + a "buffer until finalize, then synthesise" stub impl, with a TODO. Don't fake streaming — say it isn't there.
+
+## Voice selection (separate concern)
+
+Piper's child-voice options are limited; Phase 2.5 will likely mean training one. For step 3 just pick 2–3 candidate adult voices that sound friendly to children (suggested starting points from the Piper voice list: `en_US-amy-medium`, `en_GB-jenny_dioco-medium`, `en_GB-alba-medium` — listen to samples first). Wire them up so `cargo run --bin primer ... --voice <id>` switches between them. Defer fine-tuning to a later session.
+
+## Required principles (don't relax these)
+
+The repo's working principles, repeated here so you stay honest:
+
+1. **No magic numbers.** Sample rate, default model path, phrase-split punctuation, sentence-boundary lookahead — every numeric or string literal that shapes behaviour gets a named const with a doc comment. Examples landed in PR #3 you can mimic: `const SAMPLE_RATE: u32 = 16_000;` (`silero.rs`, `whisper.rs`); `const DEFAULT_THRESHOLD: f32 = 0.5;` (`silero.rs`).
+2. **Prefer pure functions in reusable modules.** If a piece of logic doesn't need the engine to run (phrase-splitting, sample-rate conversion, format clamping), put it in its own module and give it a unit test. The `vad_debounce` module is the template: pure logic, fully tested without the backend, reused by the impl.
+3. **Inline documentation and unit tests are mandatory.** Every public item needs a doc comment that says *why*, not just *what*. Every pure helper needs at least one positive and one edge-case test. Trait shapes get a mock-impl test in `primer-core::speech::tests` that exercises the lifecycle through `Box<dyn ...>` (see `streaming_stt_session_yields_segments_and_finalizes` for the template).
+4. **No `unwrap` in non-test code.** Wrap upstream errors with `PrimerError::Speech(format!("...: {e}"))`. Existing impls follow this; copy the pattern.
+5. **Build-time deps must be opt-in.** Default `cargo build --workspace` must pull no additional deps. Feature-gate the Piper backend the way `silero` and `whisper` are gated.
+
+## Build prerequisites
+
+Piper uses ONNX Runtime (same dep tree story as Silero). Expect `piper-rs` to pull `ort`. Two known hazards from PR #3 to watch for:
+
+- `ort` version-pin compatibility — if `piper-rs` and `silero-vad-rust` disagree on the rc, you may need to pin one to keep `ndarray` consistent across the dep graph. `cargo tree -i ndarray` is your friend.
+- ONNX Runtime first-build downloads from `cdn.pyke.io`. Sandboxed CI environments (including the one this branch was developed in) block that host. Document, don't fight.
+
+## Test plan
+
+- `cargo test --workspace` green (no new failures, count goes up by ≥3).
+- `cargo build -p primer-speech --features piper` succeeds on a real machine (probably not in CI).
+- Integration test (manual, off CI): load a Piper voice, synthesise "Hello, what would you like to learn about today?", play through `cpal` or save to wav, verify it sounds like words and not noise.
+- After step 3 lands, the next session connects VAD → STT → DialogueManager → TTS into a live REPL replacement (`primer-cli --speech`). That's step 4.
+
+## Out of scope
+
+- Audio capture and playback (cpal) wiring — that's a separate cross-cutting concern.
+- The "single child voice" decision for the Primer's final form — voice selection now is for development testing only.
+- NPU offload of the Piper decoder (RKNN/QNN) — Phase 2.5+, after the CPU pipeline closes the loop.
+- Any STT or VAD work — those are done; if you're tempted to "while I'm here" them, resist. Land the TTS slice cleanly and merge.
+
+## When you're done
+
+1. Run the full check sequence from `src/`: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --check`.
+2. Push the branch and open a PR titled `feat(speech): streaming TTS trait + Piper impl` against `main`.
+3. In the PR body, link to this doc and call out anything you decided differently from the suggestions here (with reasoning).
+4. Update or delete this doc — if step 3 closed everything cleanly, delete it; if you learned things about Piper or the trait shape that would help the next session (step 4: end-to-end voice loop), refresh it.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,16 +112,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -206,10 +233,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -257,10 +342,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -273,6 +385,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -369,6 +496,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -504,7 +641,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "smallvec",
+ "smallvec 1.15.1",
  "tokio",
  "want",
 ]
@@ -609,7 +746,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec",
+ "smallvec 1.15.1",
  "zerovec",
 ]
 
@@ -667,7 +804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec",
+ "smallvec 1.15.1",
  "utf8_iter",
 ]
 
@@ -752,6 +889,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +920,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -799,10 +964,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -816,12 +1001,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -846,6 +1081,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
+dependencies = [
+ "libloading",
+ "ndarray",
+ "ort-sys",
+ "smallvec 2.0.0-alpha.10",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
+dependencies = [
+ "flate2",
+ "pkg-config",
+ "sha2",
+ "tar",
+ "ureq",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,9 +1168,18 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
- "smallvec",
+ "redox_syscall 0.5.18",
+ "smallvec 1.15.1",
  "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -885,6 +1199,27 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1003,7 +1338,9 @@ name = "primer-speech"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "ort",
  "primer-core",
+ "silero-vad-rust",
  "thiserror",
  "tokio",
  "tracing",
@@ -1138,10 +1475,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -1239,7 +1591,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec",
+ "smallvec 1.15.1",
  "sqlite-wasm-rs",
 ]
 
@@ -1248,6 +1600,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1297,10 +1662,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1373,6 +1770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1806,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "silero-vad-rust"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8636fa2581063bb52f2cbe70148009763612fec05f4be365225df552868a92"
+dependencies = [
+ "anyhow",
+ "ndarray",
+ "ort",
+ "thiserror",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1836,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smallvec"
+version = "2.0.0-alpha.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1849,17 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1478,6 +1921,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1725,7 +2192,7 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.15.1",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -1737,6 +2204,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1766,6 +2239,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +2279,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -1812,6 +2321,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1969,6 +2484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2500,28 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2226,6 +2772,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -118,6 +118,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +216,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -225,6 +268,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -312,6 +364,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -549,6 +607,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +650,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -659,7 +738,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -853,6 +932,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +963,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -920,6 +1014,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -980,6 +1080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1147,7 +1273,7 @@ dependencies = [
  "pkg-config",
  "sha2",
  "tar",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -1282,7 +1408,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1299,7 +1425,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1312,7 +1438,7 @@ dependencies = [
  "primer-core",
  "rusqlite",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1327,7 +1453,7 @@ dependencies = [
  "primer-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1341,9 +1467,10 @@ dependencies = [
  "ort",
  "primer-core",
  "silero-vad-rust",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "whisper-cpp-plus",
 ]
 
 [[package]]
@@ -1354,7 +1481,7 @@ dependencies = [
  "chrono",
  "primer-core",
  "rusqlite",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1380,10 +1507,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1400,11 +1527,11 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1499,6 +1626,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,7 +1692,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1577,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1597,9 +1736,28 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustix"
@@ -1610,7 +1768,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1620,6 +1778,7 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1814,7 +1973,7 @@ dependencies = [
  "anyhow",
  "ndarray",
  "ort",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1943,8 +2102,17 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1953,7 +2121,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2240,6 +2419,21 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
@@ -2494,11 +2688,58 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "whisper-cpp-plus"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de6b64f1ea273a0cfb4f586f20b07e7f9f4317243099192def35879143d4ead"
+dependencies = [
+ "flate2",
+ "num_cpus",
+ "thiserror 1.0.69",
+ "whisper-cpp-plus-sys",
+]
+
+[[package]]
+name = "whisper-cpp-plus-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631b412ee374ccbc15e46a477acfabf557d748627bd3101c335d5c2893dae6cd"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "flate2",
+ "tar",
+ "ureq 2.12.1",
 ]
 
 [[package]]
@@ -2780,7 +3021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/src/crates/primer-core/src/speech.rs
+++ b/src/crates/primer-core/src/speech.rs
@@ -1,8 +1,12 @@
 //! Speech traits — VAD, STT, and TTS abstractions.
 //!
-//! VAD implementations: Silero (via silero-vad-rust).
-//! STT implementations: whisper.cpp (via whisper-rs), platform-native APIs.
-//! TTS implementations: Piper, platform-native APIs.
+//! Concrete implementations live in `primer-speech` behind feature flags:
+//! - VAD: Silero (via `silero-vad-rust`), feature `silero`.
+//! - STT: whisper.cpp (via `whisper-cpp-plus`), feature `whisper`.
+//! - TTS: Piper (planned, via `piper-rs`), feature `piper`.
+//!
+//! All trait method signatures are deliberately backend-agnostic. A new
+//! backend should be a drop-in alternative without touching this file.
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -81,6 +85,7 @@ pub struct VadFrame {
 /// per-chunk probability and a state-transition event the caller can use to
 /// trigger STT, end-of-utterance handling, etc.
 pub trait VoiceActivityDetector: Send {
+    /// Backend identifier for logging and diagnostics (e.g. `"silero-vad"`).
     fn name(&self) -> &str;
 
     /// Sample rate the detector expects (Hz).
@@ -96,9 +101,15 @@ pub trait VoiceActivityDetector: Send {
     fn reset(&mut self);
 }
 
-/// Speech-to-text backend.
+/// One-shot speech-to-text backend.
+///
+/// Used for offline transcription of complete audio buffers. For live
+/// interactive use prefer [`StreamingSpeechToText`] — it surfaces partial
+/// segments as they arrive instead of blocking until the entire buffer
+/// is processed.
 #[async_trait]
 pub trait SpeechToText: Send + Sync {
+    /// Backend identifier for logging and diagnostics (e.g. `"whisper-cpp"`).
     fn name(&self) -> &str;
 
     /// Transcribe an audio buffer to text.
@@ -113,6 +124,8 @@ pub trait SpeechToText: Send + Sync {
 /// is. Concatenate the `text` of every segment to reconstruct the utterance.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptSegment {
+    /// Recognised text for this segment. Concatenate every segment's
+    /// text in order to reconstruct the full utterance.
     pub text: String,
     /// Start of this segment relative to session open (ms).
     pub start_ms: u64,
@@ -143,18 +156,30 @@ pub trait TranscriptionSession: Send {
 /// Open one [`TranscriptionSession`] per child utterance. The backend itself
 /// is shareable across sessions (`Send + Sync`); per-session state lives
 /// inside the session handle.
+///
+/// A backend may also implement the one-shot [`SpeechToText`] trait. When
+/// it does, both traits expose a `name()` method — call it through a
+/// trait object (`(&stt as &dyn SpeechToText).name()`) to disambiguate;
+/// direct calls on the concrete type require UFCS.
 pub trait StreamingSpeechToText: Send + Sync {
+    /// Backend identifier for logging and diagnostics (e.g. `"whisper-cpp"`).
     fn name(&self) -> &str;
 
     /// Sample rate the backend expects (Hz). Sessions reject mismatched audio.
     fn sample_rate(&self) -> u32;
 
+    /// Open a fresh transcription session. Each utterance gets its own.
     fn open_session(&self) -> Result<Box<dyn TranscriptionSession>>;
 }
 
-/// Text-to-speech backend.
+/// One-shot text-to-speech backend.
+///
+/// Synthesises a complete utterance into a single [`AudioBuffer`]. For
+/// interactive voice loops a streaming variant will be added in the next
+/// step of the speech pipeline (see `docs/primer_TTS_next_step.md`).
 #[async_trait]
 pub trait TextToSpeech: Send + Sync {
+    /// Backend identifier for logging and diagnostics (e.g. `"piper"`).
     fn name(&self) -> &str;
 
     /// Synthesize text to an audio buffer.
@@ -182,19 +207,25 @@ mod tests {
         }
     }
 
+    /// Mirrors a Silero-class detector's frame layout (16 kHz / 512-sample
+    /// chunks); production threshold is 0.5.
+    const CANNED_VAD_SAMPLE_RATE: u32 = 16_000;
+    const CANNED_VAD_CHUNK_SAMPLES: usize = 512;
+    const CANNED_VAD_THRESHOLD: f32 = 0.5;
+
     impl VoiceActivityDetector for CannedVad {
         fn name(&self) -> &str {
             "canned"
         }
         fn sample_rate(&self) -> u32 {
-            16_000
+            CANNED_VAD_SAMPLE_RATE
         }
         fn chunk_samples(&self) -> usize {
-            512
+            CANNED_VAD_CHUNK_SAMPLES
         }
         fn process_chunk(&mut self, _samples: &[f32]) -> Result<VadFrame> {
             let p = self.probs.next().unwrap_or(0.0);
-            let is_speech = p >= 0.5;
+            let is_speech = p >= CANNED_VAD_THRESHOLD;
             let event = match (self.in_speech, is_speech) {
                 (false, true) => {
                     self.in_speech = true;
@@ -219,8 +250,8 @@ mod tests {
     #[test]
     fn vad_trait_object_dispatches() {
         let mut vad: Box<dyn VoiceActivityDetector> = Box::new(CannedVad::new(vec![0.1, 0.9, 0.1]));
-        assert_eq!(vad.sample_rate(), 16_000);
-        assert_eq!(vad.chunk_samples(), 512);
+        assert_eq!(vad.sample_rate(), CANNED_VAD_SAMPLE_RATE);
+        assert_eq!(vad.chunk_samples(), CANNED_VAD_CHUNK_SAMPLES);
         let chunk = vec![0.0_f32; vad.chunk_samples()];
         let f0 = vad.process_chunk(&chunk).unwrap();
         let f1 = vad.process_chunk(&chunk).unwrap();
@@ -230,11 +261,16 @@ mod tests {
         assert_eq!(f2.event, VadEvent::SpeechEnd);
     }
 
+    /// Test sample rate matching the production setting; named so the
+    /// timestamp arithmetic in the streaming-STT test below is obvious.
+    const TEST_SAMPLE_RATE: u32 = 16_000;
+    /// Milliseconds per second — used in the elapsed-ms calculation.
+    const MS_PER_SECOND: u64 = 1_000;
+
     /// Mock streaming STT that emits one segment per push call from a
-    /// canned script and concatenates them on finalize.
-    struct CannedStreamStt {
-        sample_rate: u32,
-    }
+    /// canned script. Each push advances elapsed time by the duration
+    /// of the supplied audio at [`TEST_SAMPLE_RATE`].
+    struct CannedStreamStt;
 
     struct CannedSession {
         scripted: std::vec::IntoIter<&'static str>,
@@ -243,7 +279,7 @@ mod tests {
 
     impl TranscriptionSession for CannedSession {
         fn push_audio(&mut self, samples: &[f32]) -> Result<Vec<TranscriptSegment>> {
-            let chunk_ms = (samples.len() as u64 * 1000) / 16_000;
+            let chunk_ms = (samples.len() as u64 * MS_PER_SECOND) / TEST_SAMPLE_RATE as u64;
             let start_ms = self.elapsed_ms;
             self.elapsed_ms += chunk_ms;
             match self.scripted.next() {
@@ -265,7 +301,7 @@ mod tests {
             "canned-stream-stt"
         }
         fn sample_rate(&self) -> u32 {
-            self.sample_rate
+            TEST_SAMPLE_RATE
         }
         fn open_session(&self) -> Result<Box<dyn TranscriptionSession>> {
             Ok(Box::new(CannedSession {
@@ -277,19 +313,18 @@ mod tests {
 
     #[test]
     fn streaming_stt_session_yields_segments_and_finalizes() {
-        let stt: Box<dyn StreamingSpeechToText> = Box::new(CannedStreamStt {
-            sample_rate: 16_000,
-        });
-        assert_eq!(stt.sample_rate(), 16_000);
+        let stt: Box<dyn StreamingSpeechToText> = Box::new(CannedStreamStt);
+        assert_eq!(stt.sample_rate(), TEST_SAMPLE_RATE);
         let mut session = stt.open_session().unwrap();
-        let chunk = vec![0.0_f32; 16_000]; // 1 s of audio per push
-        let s0 = session.push_audio(&chunk).unwrap();
-        let s1 = session.push_audio(&chunk).unwrap();
-        let s2 = session.push_audio(&chunk).unwrap();
+        // One second of audio per push at the sample rate above.
+        let one_second_chunk = vec![0.0_f32; TEST_SAMPLE_RATE as usize];
+        let s0 = session.push_audio(&one_second_chunk).unwrap();
+        let s1 = session.push_audio(&one_second_chunk).unwrap();
+        let s2 = session.push_audio(&one_second_chunk).unwrap();
         assert_eq!(s0.len(), 1);
         assert_eq!(s0[0].text, "hello");
         assert_eq!(s0[0].start_ms, 0);
-        assert_eq!(s0[0].end_ms, 1000);
+        assert_eq!(s0[0].end_ms, MS_PER_SECOND);
         assert_eq!(s1[0].text, " world");
         assert!(s2.is_empty());
         let trailing = session.finalize().unwrap();

--- a/src/crates/primer-core/src/speech.rs
+++ b/src/crates/primer-core/src/speech.rs
@@ -95,6 +95,10 @@ pub trait VoiceActivityDetector: Send {
     fn chunk_samples(&self) -> usize;
 
     /// Process exactly [`Self::chunk_samples`] mono f32 samples.
+    ///
+    /// Implementations must return `Err` if `samples.len()` differs from
+    /// [`Self::chunk_samples`] — callers rely on a deterministic frame
+    /// size for timing arithmetic.
     fn process_chunk(&mut self, samples: &[f32]) -> Result<VadFrame>;
 
     /// Reset internal state (between utterances or sessions).

--- a/src/crates/primer-core/src/speech.rs
+++ b/src/crates/primer-core/src/speech.rs
@@ -105,6 +105,53 @@ pub trait SpeechToText: Send + Sync {
     async fn transcribe(&self, audio: &AudioBuffer) -> Result<Transcript>;
 }
 
+/// One transcribed segment from a streaming session.
+///
+/// Whisper-class models naturally emit text in segment-sized chunks (one
+/// sentence or ~5–10 s of audio); we surface those chunks rather than
+/// pretending to deliver token-by-token output, since underlying ASR rarely
+/// is. Concatenate the `text` of every segment to reconstruct the utterance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptSegment {
+    pub text: String,
+    /// Start of this segment relative to session open (ms).
+    pub start_ms: u64,
+    /// End of this segment relative to session open (ms).
+    pub end_ms: u64,
+}
+
+/// A single streaming-transcription session.
+///
+/// Created by [`StreamingSpeechToText::open_session`]. Push f32 mono samples
+/// at the parent backend's [`StreamingSpeechToText::sample_rate`] via
+/// [`Self::push_audio`]; each push may emit zero or more segments as soon
+/// as the underlying model has enough context. Call [`Self::finalize`] once
+/// the utterance is complete (typically on `VadEvent::SpeechEnd`) to drain
+/// the trailing buffer.
+///
+/// Sessions are `Send` but not `Sync`: each utterance owns its own session.
+pub trait TranscriptionSession: Send {
+    /// Push samples; receive any segments that became available as a result.
+    fn push_audio(&mut self, samples: &[f32]) -> Result<Vec<TranscriptSegment>>;
+
+    /// Drain remaining buffered audio and finalize. Consumes the session.
+    fn finalize(self: Box<Self>) -> Result<Vec<TranscriptSegment>>;
+}
+
+/// Streaming speech-to-text backend.
+///
+/// Open one [`TranscriptionSession`] per child utterance. The backend itself
+/// is shareable across sessions (`Send + Sync`); per-session state lives
+/// inside the session handle.
+pub trait StreamingSpeechToText: Send + Sync {
+    fn name(&self) -> &str;
+
+    /// Sample rate the backend expects (Hz). Sessions reject mismatched audio.
+    fn sample_rate(&self) -> u32;
+
+    fn open_session(&self) -> Result<Box<dyn TranscriptionSession>>;
+}
+
 /// Text-to-speech backend.
 #[async_trait]
 pub trait TextToSpeech: Send + Sync {
@@ -181,5 +228,71 @@ mod tests {
         assert_eq!(f0.event, VadEvent::None);
         assert_eq!(f1.event, VadEvent::SpeechStart);
         assert_eq!(f2.event, VadEvent::SpeechEnd);
+    }
+
+    /// Mock streaming STT that emits one segment per push call from a
+    /// canned script and concatenates them on finalize.
+    struct CannedStreamStt {
+        sample_rate: u32,
+    }
+
+    struct CannedSession {
+        scripted: std::vec::IntoIter<&'static str>,
+        elapsed_ms: u64,
+    }
+
+    impl TranscriptionSession for CannedSession {
+        fn push_audio(&mut self, samples: &[f32]) -> Result<Vec<TranscriptSegment>> {
+            let chunk_ms = (samples.len() as u64 * 1000) / 16_000;
+            let start_ms = self.elapsed_ms;
+            self.elapsed_ms += chunk_ms;
+            match self.scripted.next() {
+                Some(text) => Ok(vec![TranscriptSegment {
+                    text: text.to_string(),
+                    start_ms,
+                    end_ms: self.elapsed_ms,
+                }]),
+                None => Ok(vec![]),
+            }
+        }
+        fn finalize(self: Box<Self>) -> Result<Vec<TranscriptSegment>> {
+            Ok(vec![])
+        }
+    }
+
+    impl StreamingSpeechToText for CannedStreamStt {
+        fn name(&self) -> &str {
+            "canned-stream-stt"
+        }
+        fn sample_rate(&self) -> u32 {
+            self.sample_rate
+        }
+        fn open_session(&self) -> Result<Box<dyn TranscriptionSession>> {
+            Ok(Box::new(CannedSession {
+                scripted: vec!["hello", " world"].into_iter(),
+                elapsed_ms: 0,
+            }))
+        }
+    }
+
+    #[test]
+    fn streaming_stt_session_yields_segments_and_finalizes() {
+        let stt: Box<dyn StreamingSpeechToText> = Box::new(CannedStreamStt {
+            sample_rate: 16_000,
+        });
+        assert_eq!(stt.sample_rate(), 16_000);
+        let mut session = stt.open_session().unwrap();
+        let chunk = vec![0.0_f32; 16_000]; // 1 s of audio per push
+        let s0 = session.push_audio(&chunk).unwrap();
+        let s1 = session.push_audio(&chunk).unwrap();
+        let s2 = session.push_audio(&chunk).unwrap();
+        assert_eq!(s0.len(), 1);
+        assert_eq!(s0[0].text, "hello");
+        assert_eq!(s0[0].start_ms, 0);
+        assert_eq!(s0[0].end_ms, 1000);
+        assert_eq!(s1[0].text, " world");
+        assert!(s2.is_empty());
+        let trailing = session.finalize().unwrap();
+        assert!(trailing.is_empty());
     }
 }

--- a/src/crates/primer-core/src/speech.rs
+++ b/src/crates/primer-core/src/speech.rs
@@ -1,5 +1,6 @@
-//! Speech traits — STT and TTS abstractions.
+//! Speech traits — VAD, STT, and TTS abstractions.
 //!
+//! VAD implementations: Silero (via silero-vad-rust).
 //! STT implementations: whisper.cpp (via whisper-rs), platform-native APIs.
 //! TTS implementations: Piper, platform-native APIs.
 
@@ -49,6 +50,52 @@ impl Default for VoiceProfile {
     }
 }
 
+/// State-transition event emitted by a [`VoiceActivityDetector`] for a chunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VadEvent {
+    /// No transition; the previous speech/silence state continues.
+    None,
+    /// First chunk of a new speech segment (silence → speech).
+    SpeechStart,
+    /// First chunk of silence after a speech segment (speech → silence).
+    SpeechEnd,
+}
+
+/// Per-chunk output from a [`VoiceActivityDetector`].
+#[derive(Debug, Clone, Copy)]
+pub struct VadFrame {
+    /// Speech probability for this chunk (0.0 – 1.0).
+    pub speech_probability: f32,
+    /// State transition (if any) observed at this chunk.
+    pub event: VadEvent,
+}
+
+/// Streaming voice-activity detector.
+///
+/// VAD is inherently stateful: the detector keeps internal history (model
+/// hidden state plus the silence-debounce counter). Each conversation stream
+/// owns its own detector — implementations are `Send` but not `Sync`.
+///
+/// Callers feed exactly [`Self::chunk_samples`] f32 mono samples per call,
+/// at the rate reported by [`Self::sample_rate`]. The detector returns a
+/// per-chunk probability and a state-transition event the caller can use to
+/// trigger STT, end-of-utterance handling, etc.
+pub trait VoiceActivityDetector: Send {
+    fn name(&self) -> &str;
+
+    /// Sample rate the detector expects (Hz).
+    fn sample_rate(&self) -> u32;
+
+    /// Number of f32 samples per chunk fed to [`Self::process_chunk`].
+    fn chunk_samples(&self) -> usize;
+
+    /// Process exactly [`Self::chunk_samples`] mono f32 samples.
+    fn process_chunk(&mut self, samples: &[f32]) -> Result<VadFrame>;
+
+    /// Reset internal state (between utterances or sessions).
+    fn reset(&mut self);
+}
+
 /// Speech-to-text backend.
 #[async_trait]
 pub trait SpeechToText: Send + Sync {
@@ -65,4 +112,74 @@ pub trait TextToSpeech: Send + Sync {
 
     /// Synthesize text to an audio buffer.
     async fn synthesize(&self, text: &str, voice: &VoiceProfile) -> Result<AudioBuffer>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal in-memory VAD that replays a canned probability sequence.
+    /// Validates the trait surface compiles and dyn-dispatches without
+    /// pulling in any backend dependency.
+    struct CannedVad {
+        probs: std::vec::IntoIter<f32>,
+        in_speech: bool,
+    }
+
+    impl CannedVad {
+        fn new(probs: Vec<f32>) -> Self {
+            Self {
+                probs: probs.into_iter(),
+                in_speech: false,
+            }
+        }
+    }
+
+    impl VoiceActivityDetector for CannedVad {
+        fn name(&self) -> &str {
+            "canned"
+        }
+        fn sample_rate(&self) -> u32 {
+            16_000
+        }
+        fn chunk_samples(&self) -> usize {
+            512
+        }
+        fn process_chunk(&mut self, _samples: &[f32]) -> Result<VadFrame> {
+            let p = self.probs.next().unwrap_or(0.0);
+            let is_speech = p >= 0.5;
+            let event = match (self.in_speech, is_speech) {
+                (false, true) => {
+                    self.in_speech = true;
+                    VadEvent::SpeechStart
+                }
+                (true, false) => {
+                    self.in_speech = false;
+                    VadEvent::SpeechEnd
+                }
+                _ => VadEvent::None,
+            };
+            Ok(VadFrame {
+                speech_probability: p,
+                event,
+            })
+        }
+        fn reset(&mut self) {
+            self.in_speech = false;
+        }
+    }
+
+    #[test]
+    fn vad_trait_object_dispatches() {
+        let mut vad: Box<dyn VoiceActivityDetector> = Box::new(CannedVad::new(vec![0.1, 0.9, 0.1]));
+        assert_eq!(vad.sample_rate(), 16_000);
+        assert_eq!(vad.chunk_samples(), 512);
+        let chunk = vec![0.0_f32; vad.chunk_samples()];
+        let f0 = vad.process_chunk(&chunk).unwrap();
+        let f1 = vad.process_chunk(&chunk).unwrap();
+        let f2 = vad.process_chunk(&chunk).unwrap();
+        assert_eq!(f0.event, VadEvent::None);
+        assert_eq!(f1.event, VadEvent::SpeechStart);
+        assert_eq!(f2.event, VadEvent::SpeechEnd);
+    }
 }

--- a/src/crates/primer-speech/Cargo.toml
+++ b/src/crates/primer-speech/Cargo.toml
@@ -20,8 +20,9 @@ silero-vad-rust = { version = "6.2", default-features = false, optional = true }
 # longer matches across crates.
 ort = { version = "=2.0.0-rc.10", default-features = false, features = ["ndarray"], optional = true }
 
-# Whisper bindings — uncomment when integrating:
-# whisper-rs = "0.12"
+# Whisper.cpp — opt-in via the `whisper` feature. Builds bundled C++ source
+# (cmake + a C++ compiler must be present on the build host).
+whisper-cpp-plus = { version = "0.1", default-features = false, optional = true }
 
 # Audio I/O — uncomment when integrating:
 # cpal = "0.15"
@@ -29,3 +30,4 @@ ort = { version = "=2.0.0-rc.10", default-features = false, features = ["ndarray
 [features]
 default = []
 silero = ["dep:silero-vad-rust", "dep:ort"]
+whisper = ["dep:whisper-cpp-plus"]

--- a/src/crates/primer-speech/Cargo.toml
+++ b/src/crates/primer-speech/Cargo.toml
@@ -11,8 +11,21 @@ tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 
+# Silero VAD — bundled ONNX weights, opt-in via the `silero` feature so the
+# ort/ndarray dep tree only compiles for users who want VAD.
+silero-vad-rust = { version = "6.2", default-features = false, optional = true }
+# Pin ort to the rc that silero-vad-rust 6.2 was built against; without
+# this, Cargo picks a newer rc whose bundled ndarray version diverges from
+# silero-vad-rust's direct ndarray dep and the type `Array2<f32>` no
+# longer matches across crates.
+ort = { version = "=2.0.0-rc.10", default-features = false, features = ["ndarray"], optional = true }
+
 # Whisper bindings — uncomment when integrating:
 # whisper-rs = "0.12"
 
 # Audio I/O — uncomment when integrating:
 # cpal = "0.15"
+
+[features]
+default = []
+silero = ["dep:silero-vad-rust", "dep:ort"]

--- a/src/crates/primer-speech/src/lib.rs
+++ b/src/crates/primer-speech/src/lib.rs
@@ -16,3 +16,8 @@ pub use vad_debounce::{VadDebouncer, ms_to_chunks};
 pub mod silero;
 #[cfg(feature = "silero")]
 pub use silero::{SileroVad, SileroVadParams};
+
+#[cfg(feature = "whisper")]
+pub mod whisper;
+#[cfg(feature = "whisper")]
+pub use whisper::WhisperStt;

--- a/src/crates/primer-speech/src/lib.rs
+++ b/src/crates/primer-speech/src/lib.rs
@@ -7,9 +7,11 @@
 //! happens in Phase 1 when hardware audio is connected.
 
 pub mod stub;
+pub mod time_ms;
 pub mod vad_debounce;
 
 pub use stub::{StubStt, StubTts};
+pub use time_ms::clamp_signed_ms_to_u64;
 pub use vad_debounce::{VadDebouncer, ms_to_chunks};
 
 #[cfg(feature = "silero")]

--- a/src/crates/primer-speech/src/lib.rs
+++ b/src/crates/primer-speech/src/lib.rs
@@ -7,5 +7,12 @@
 //! happens in Phase 1 when hardware audio is connected.
 
 pub mod stub;
+pub mod vad_debounce;
 
 pub use stub::{StubStt, StubTts};
+pub use vad_debounce::{VadDebouncer, ms_to_chunks};
+
+#[cfg(feature = "silero")]
+pub mod silero;
+#[cfg(feature = "silero")]
+pub use silero::{SileroVad, SileroVadParams};

--- a/src/crates/primer-speech/src/silero.rs
+++ b/src/crates/primer-speech/src/silero.rs
@@ -23,6 +23,16 @@ use crate::vad_debounce::{VadDebouncer, ms_to_chunks};
 const SAMPLE_RATE: u32 = 16_000;
 const CHUNK_SAMPLES: usize = 512;
 
+/// Default speech-probability threshold. Matches the Silero upstream
+/// `VadIterator` default and the value the model was tuned to. Lower
+/// thresholds catch quiet child speech but admit more breath/noise.
+const DEFAULT_THRESHOLD: f32 = 0.5;
+
+/// Default trailing-silence required before emitting `SpeechEnd` (ms).
+/// 300 ms is short enough that the Primer responds promptly after a
+/// child stops speaking, but long enough to bridge inter-word pauses.
+const DEFAULT_MIN_SILENCE_MS: u32 = 300;
+
 /// Runtime-tunable parameters for the Silero VAD wrapper.
 #[derive(Debug, Clone)]
 pub struct SileroVadParams {
@@ -35,18 +45,27 @@ pub struct SileroVadParams {
 impl Default for SileroVadParams {
     fn default() -> Self {
         Self {
-            threshold: 0.5,
-            min_silence_ms: 300,
+            threshold: DEFAULT_THRESHOLD,
+            min_silence_ms: DEFAULT_MIN_SILENCE_MS,
         }
     }
 }
 
+/// Streaming VAD backed by the Silero ONNX model.
+///
+/// One detector per audio stream. Internally holds the model's hidden
+/// state plus a [`VadDebouncer`] for the threshold + min-silence state
+/// machine. Default-constructed params match the Silero upstream
+/// defaults; tune via [`SileroVadParams`] if a deployment needs different
+/// sensitivity.
 pub struct SileroVad {
     model: OnnxModel,
     debouncer: VadDebouncer,
 }
 
 impl SileroVad {
+    /// Load the bundled Silero ONNX model and wrap it with the supplied
+    /// debounce parameters. Fails if ONNX Runtime cannot initialise.
     pub fn new(params: SileroVadParams) -> Result<Self> {
         let model =
             load_silero_vad().map_err(|e| PrimerError::Speech(format!("load Silero VAD: {e}")))?;
@@ -57,6 +76,7 @@ impl SileroVad {
         })
     }
 
+    /// Convenience: load the detector with [`SileroVadParams::default`].
     pub fn with_defaults() -> Result<Self> {
         Self::new(SileroVadParams::default())
     }

--- a/src/crates/primer-speech/src/silero.rs
+++ b/src/crates/primer-speech/src/silero.rs
@@ -1,0 +1,101 @@
+//! Silero VAD implementation of [`VoiceActivityDetector`].
+//!
+//! Wraps the bundled ONNX model from [`silero-vad-rust`]. Audio is fed in
+//! 512-sample chunks at 16 kHz; the detector returns each chunk's speech
+//! probability and emits `SpeechStart` / `SpeechEnd` events using a
+//! threshold + min-silence debounce (see [`VadDebouncer`]).
+//!
+//! # Build prerequisites
+//!
+//! Enabling the `silero` feature pulls in the `ort` crate, which downloads
+//! a prebuilt ONNX Runtime binary from `cdn.pyke.io` at first build. The
+//! Silero model weights themselves are bundled inside `silero-vad-rust` and
+//! need no separate download. After the first successful build the binary
+//! is cached under the cargo target directory.
+
+use primer_core::error::{PrimerError, Result};
+use primer_core::speech::{VadFrame, VoiceActivityDetector};
+use silero_vad_rust::load_silero_vad;
+use silero_vad_rust::silero_vad::model::OnnxModel;
+
+use crate::vad_debounce::{VadDebouncer, ms_to_chunks};
+
+const SAMPLE_RATE: u32 = 16_000;
+const CHUNK_SAMPLES: usize = 512;
+
+/// Runtime-tunable parameters for the Silero VAD wrapper.
+#[derive(Debug, Clone)]
+pub struct SileroVadParams {
+    /// Probability above which a chunk is treated as speech (0.0–1.0).
+    pub threshold: f32,
+    /// Trailing silence required to emit `SpeechEnd` (milliseconds).
+    pub min_silence_ms: u32,
+}
+
+impl Default for SileroVadParams {
+    fn default() -> Self {
+        Self {
+            threshold: 0.5,
+            min_silence_ms: 300,
+        }
+    }
+}
+
+pub struct SileroVad {
+    model: OnnxModel,
+    debouncer: VadDebouncer,
+}
+
+impl SileroVad {
+    pub fn new(params: SileroVadParams) -> Result<Self> {
+        let model =
+            load_silero_vad().map_err(|e| PrimerError::Speech(format!("load Silero VAD: {e}")))?;
+        let silence_chunks = ms_to_chunks(params.min_silence_ms, SAMPLE_RATE, CHUNK_SAMPLES as u32);
+        Ok(Self {
+            model,
+            debouncer: VadDebouncer::new(params.threshold, silence_chunks),
+        })
+    }
+
+    pub fn with_defaults() -> Result<Self> {
+        Self::new(SileroVadParams::default())
+    }
+}
+
+impl VoiceActivityDetector for SileroVad {
+    fn name(&self) -> &str {
+        "silero-vad"
+    }
+
+    fn sample_rate(&self) -> u32 {
+        SAMPLE_RATE
+    }
+
+    fn chunk_samples(&self) -> usize {
+        CHUNK_SAMPLES
+    }
+
+    fn process_chunk(&mut self, samples: &[f32]) -> Result<VadFrame> {
+        if samples.len() != CHUNK_SAMPLES {
+            return Err(PrimerError::Speech(format!(
+                "Silero VAD requires exactly {CHUNK_SAMPLES} samples per chunk, got {}",
+                samples.len()
+            )));
+        }
+        let probs = self
+            .model
+            .forward_chunk(samples, SAMPLE_RATE)
+            .map_err(|e| PrimerError::Speech(format!("VAD forward: {e}")))?;
+        let speech_probability = probs[[0, 0]];
+        let event = self.debouncer.step(speech_probability);
+        Ok(VadFrame {
+            speech_probability,
+            event,
+        })
+    }
+
+    fn reset(&mut self) {
+        self.model.reset_states();
+        self.debouncer.reset();
+    }
+}

--- a/src/crates/primer-speech/src/time_ms.rs
+++ b/src/crates/primer-speech/src/time_ms.rs
@@ -1,0 +1,41 @@
+//! Pure conversion helpers for millisecond timestamps.
+//!
+//! Speech backends frequently use signed millisecond offsets (whisper.cpp
+//! returns `i64`; Silero's iterator returns `f64` seconds). The Primer's
+//! domain types use `u64` ms relative to session open. The conversions
+//! are trivial but worth isolating: kept here, they can be tested without
+//! pulling in any backend feature, and any future backend that needs the
+//! same clamp can reuse them.
+
+/// Clamp a signed-ms timestamp to non-negative `u64`. Negative inputs
+/// (which whisper.cpp permits in its type but should not return in
+/// practice) are coerced to zero rather than triggering UB through a
+/// bare `as` cast.
+pub fn clamp_signed_ms_to_u64(ms: i64) -> u64 {
+    ms.max(0) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn positive_value_passes_through() {
+        assert_eq!(clamp_signed_ms_to_u64(0), 0);
+        assert_eq!(clamp_signed_ms_to_u64(1), 1);
+        assert_eq!(clamp_signed_ms_to_u64(1_234_567), 1_234_567);
+    }
+
+    #[test]
+    fn negative_value_clamps_to_zero() {
+        assert_eq!(clamp_signed_ms_to_u64(-1), 0);
+        assert_eq!(clamp_signed_ms_to_u64(i64::MIN), 0);
+    }
+
+    #[test]
+    fn max_i64_round_trips() {
+        // Whisper timestamps never reach this far, but the cast must
+        // not panic or wrap negative if it did.
+        assert_eq!(clamp_signed_ms_to_u64(i64::MAX), i64::MAX as u64);
+    }
+}

--- a/src/crates/primer-speech/src/vad_debounce.rs
+++ b/src/crates/primer-speech/src/vad_debounce.rs
@@ -64,10 +64,12 @@ impl VadDebouncer {
 
 /// Convert a desired silence duration in ms to a number of chunks at a given
 /// sample rate and chunk size. Rounds up so the user's stated minimum is
-/// always honoured.
+/// always honoured. Uses integer arithmetic to avoid f32 precision loss at
+/// high sample rates or large silence values.
 pub fn ms_to_chunks(min_silence_ms: u32, sample_rate: u32, chunk_samples: u32) -> u32 {
-    let chunk_ms = (chunk_samples as f32 / sample_rate as f32) * 1000.0;
-    ((min_silence_ms as f32) / chunk_ms).ceil() as u32
+    let samples_needed = (min_silence_ms as u64) * (sample_rate as u64);
+    let divisor = (chunk_samples as u64) * 1000;
+    samples_needed.div_ceil(divisor) as u32
 }
 
 #[cfg(test)]

--- a/src/crates/primer-speech/src/vad_debounce.rs
+++ b/src/crates/primer-speech/src/vad_debounce.rs
@@ -1,0 +1,148 @@
+//! Probability → event debounce shared by VAD backends.
+//!
+//! Any VAD model that emits a per-chunk speech probability can plug into
+//! [`VadDebouncer`] to get the threshold + min-silence state machine that
+//! produces [`VadEvent::SpeechStart`] / [`VadEvent::SpeechEnd`] transitions.
+//! Kept separate from any specific backend so the state machine can be
+//! unit-tested without pulling in ONNX Runtime.
+
+use primer_core::speech::VadEvent;
+
+#[derive(Debug, Clone, Copy)]
+pub struct VadDebouncer {
+    threshold: f32,
+    silence_chunks_threshold: u32,
+    in_speech: bool,
+    silence_chunks: u32,
+}
+
+impl VadDebouncer {
+    /// `min_silence_chunks` is the count of consecutive sub-threshold chunks
+    /// required to leave the speech state. Compute it from desired ms with
+    /// `(min_silence_ms * sample_rate) / (chunk_samples * 1000)`, rounded up.
+    pub fn new(threshold: f32, min_silence_chunks: u32) -> Self {
+        Self {
+            threshold,
+            silence_chunks_threshold: min_silence_chunks.max(1),
+            in_speech: false,
+            silence_chunks: 0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.in_speech = false;
+        self.silence_chunks = 0;
+    }
+
+    /// Feed one chunk's speech probability; get back the transition event.
+    pub fn step(&mut self, speech_probability: f32) -> VadEvent {
+        let is_speech = speech_probability >= self.threshold;
+        match (self.in_speech, is_speech) {
+            (false, true) => {
+                self.in_speech = true;
+                self.silence_chunks = 0;
+                VadEvent::SpeechStart
+            }
+            (true, false) => {
+                self.silence_chunks += 1;
+                if self.silence_chunks >= self.silence_chunks_threshold {
+                    self.in_speech = false;
+                    self.silence_chunks = 0;
+                    VadEvent::SpeechEnd
+                } else {
+                    VadEvent::None
+                }
+            }
+            (true, true) => {
+                self.silence_chunks = 0;
+                VadEvent::None
+            }
+            (false, false) => VadEvent::None,
+        }
+    }
+}
+
+/// Convert a desired silence duration in ms to a number of chunks at a given
+/// sample rate and chunk size. Rounds up so the user's stated minimum is
+/// always honoured.
+pub fn ms_to_chunks(min_silence_ms: u32, sample_rate: u32, chunk_samples: u32) -> u32 {
+    let chunk_ms = (chunk_samples as f32 / sample_rate as f32) * 1000.0;
+    ((min_silence_ms as f32) / chunk_ms).ceil() as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collect_events(probs: &[f32], threshold: f32, min_silence_chunks: u32) -> Vec<VadEvent> {
+        let mut deb = VadDebouncer::new(threshold, min_silence_chunks);
+        probs.iter().map(|&p| deb.step(p)).collect()
+    }
+
+    #[test]
+    fn pure_silence_emits_no_events() {
+        let events = collect_events(&[0.1, 0.2, 0.0, 0.3, 0.1], 0.5, 3);
+        assert!(events.iter().all(|e| *e == VadEvent::None));
+    }
+
+    #[test]
+    fn pure_speech_emits_single_start() {
+        let events = collect_events(&[0.9, 0.95, 0.8, 0.7], 0.5, 3);
+        assert_eq!(events[0], VadEvent::SpeechStart);
+        assert!(events[1..].iter().all(|e| *e == VadEvent::None));
+    }
+
+    #[test]
+    fn brief_dip_does_not_end_speech() {
+        // min_silence_chunks = 3 → a single sub-threshold chunk in the
+        // middle of speech should not emit SpeechEnd.
+        let events = collect_events(&[0.9, 0.9, 0.2, 0.9, 0.9], 0.5, 3);
+        assert_eq!(events[0], VadEvent::SpeechStart);
+        for e in &events[1..] {
+            assert_eq!(*e, VadEvent::None);
+        }
+    }
+
+    #[test]
+    fn sustained_silence_after_speech_emits_end() {
+        let events = collect_events(&[0.9, 0.9, 0.1, 0.1, 0.1, 0.1], 0.5, 3);
+        assert_eq!(events[0], VadEvent::SpeechStart);
+        assert_eq!(events[1], VadEvent::None);
+        assert_eq!(events[2], VadEvent::None);
+        assert_eq!(events[3], VadEvent::None);
+        // 3 consecutive sub-threshold chunks (idx 2..=4) → end at idx 4.
+        assert_eq!(events[4], VadEvent::SpeechEnd);
+        assert_eq!(events[5], VadEvent::None);
+    }
+
+    #[test]
+    fn re_entry_into_speech_emits_new_start() {
+        let events = collect_events(&[0.9, 0.1, 0.1, 0.1, 0.9], 0.5, 3);
+        assert_eq!(events[0], VadEvent::SpeechStart);
+        assert_eq!(events[3], VadEvent::SpeechEnd);
+        assert_eq!(events[4], VadEvent::SpeechStart);
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut deb = VadDebouncer::new(0.5, 3);
+        assert_eq!(deb.step(0.9), VadEvent::SpeechStart);
+        deb.reset();
+        // After reset, a single low-prob chunk should not trigger an end
+        // event (because we're not in speech) and a high-prob chunk should
+        // emit a new start.
+        assert_eq!(deb.step(0.1), VadEvent::None);
+        assert_eq!(deb.step(0.9), VadEvent::SpeechStart);
+    }
+
+    #[test]
+    fn ms_to_chunks_rounds_up() {
+        // 16 kHz, 512-sample chunks → 32 ms per chunk.
+        // 300 ms / 32 ms = 9.375 → 10 chunks.
+        assert_eq!(ms_to_chunks(300, 16_000, 512), 10);
+        // Exact multiple stays exact.
+        assert_eq!(ms_to_chunks(320, 16_000, 512), 10);
+        // Below one chunk still gives 1.
+        assert_eq!(ms_to_chunks(1, 16_000, 512), 1);
+    }
+}

--- a/src/crates/primer-speech/src/whisper.rs
+++ b/src/crates/primer-speech/src/whisper.rs
@@ -1,0 +1,139 @@
+//! Whisper.cpp implementation of [`SpeechToText`] and
+//! [`StreamingSpeechToText`].
+//!
+//! Wraps `whisper-cpp-plus`. A GGML/GGUF model file is loaded from disk on
+//! construction (paths like `ggml-small.en.bin`; users typically download
+//! these from huggingface.co/ggerganov/whisper.cpp). The same loaded
+//! context is shared across all sessions via `Arc`.
+//!
+//! # Build prerequisites
+//!
+//! The `whisper` feature compiles `whisper-cpp-plus-sys`, which builds
+//! whisper.cpp from its bundled C++ source. The build host needs a C++
+//! toolchain (g++ or clang) and CMake. After the first successful build
+//! the static library is cached under the cargo target directory.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use primer_core::error::{PrimerError, Result};
+use primer_core::speech::{
+    AudioBuffer, SpeechToText, StreamingSpeechToText, Transcript, TranscriptSegment,
+    TranscriptionSession,
+};
+use whisper_cpp_plus::{
+    FullParams, SamplingStrategy, Segment, TranscriptionParams, WhisperContext, WhisperStream,
+};
+
+const SAMPLE_RATE: u32 = 16_000;
+
+pub struct WhisperStt {
+    ctx: Arc<WhisperContext>,
+    language: String,
+}
+
+impl WhisperStt {
+    /// Load a whisper.cpp model from `model_path`. The model must be in
+    /// GGML/GGUF format (e.g. `ggml-small.en.bin`).
+    pub fn new(model_path: impl AsRef<Path>) -> Result<Self> {
+        let ctx = WhisperContext::new(model_path.as_ref())
+            .map_err(|e| PrimerError::Speech(format!("load whisper model: {e}")))?;
+        Ok(Self {
+            ctx: Arc::new(ctx),
+            language: "en".to_string(),
+        })
+    }
+
+    /// Set the transcription language (ISO 639-1; default `"en"`).
+    pub fn with_language(mut self, lang: impl Into<String>) -> Self {
+        self.language = lang.into();
+        self
+    }
+}
+
+#[async_trait]
+impl SpeechToText for WhisperStt {
+    fn name(&self) -> &str {
+        "whisper-cpp"
+    }
+
+    async fn transcribe(&self, audio: &AudioBuffer) -> Result<Transcript> {
+        if audio.sample_rate != SAMPLE_RATE {
+            return Err(PrimerError::Speech(format!(
+                "Whisper requires {SAMPLE_RATE}Hz audio, got {}Hz",
+                audio.sample_rate
+            )));
+        }
+        let ctx = self.ctx.clone();
+        let samples = audio.samples.clone();
+        let language = self.language.clone();
+        let text = tokio::task::spawn_blocking(move || -> Result<String> {
+            let params = TranscriptionParams::builder().language(&language).build();
+            let result = ctx
+                .transcribe_with_params(&samples, params)
+                .map_err(|e| PrimerError::Speech(format!("whisper transcribe: {e}")))?;
+            Ok(result.text)
+        })
+        .await
+        .map_err(|e| PrimerError::Speech(format!("whisper join: {e}")))??;
+
+        Ok(Transcript {
+            text,
+            language: Some(self.language.clone()),
+            confidence: None,
+        })
+    }
+}
+
+impl StreamingSpeechToText for WhisperStt {
+    fn name(&self) -> &str {
+        "whisper-cpp"
+    }
+
+    fn sample_rate(&self) -> u32 {
+        SAMPLE_RATE
+    }
+
+    fn open_session(&self) -> Result<Box<dyn TranscriptionSession>> {
+        let params =
+            FullParams::new(SamplingStrategy::Greedy { best_of: 1 }).language(&self.language);
+        let stream = WhisperStream::new(&self.ctx, params)
+            .map_err(|e| PrimerError::Speech(format!("open whisper stream: {e}")))?;
+        Ok(Box::new(WhisperSession { stream }))
+    }
+}
+
+struct WhisperSession {
+    stream: WhisperStream,
+}
+
+impl TranscriptionSession for WhisperSession {
+    fn push_audio(&mut self, samples: &[f32]) -> Result<Vec<TranscriptSegment>> {
+        self.stream.feed_audio(samples);
+        match self
+            .stream
+            .process_step()
+            .map_err(|e| PrimerError::Speech(format!("whisper step: {e}")))?
+        {
+            None => Ok(vec![]),
+            Some(segments) => Ok(segments.into_iter().map(to_transcript_segment).collect()),
+        }
+    }
+
+    fn finalize(mut self: Box<Self>) -> Result<Vec<TranscriptSegment>> {
+        let segments = self
+            .stream
+            .flush()
+            .map_err(|e| PrimerError::Speech(format!("whisper flush: {e}")))?;
+        Ok(segments.into_iter().map(to_transcript_segment).collect())
+    }
+}
+
+fn to_transcript_segment(seg: Segment) -> TranscriptSegment {
+    TranscriptSegment {
+        text: seg.text,
+        start_ms: seg.start_ms.max(0) as u64,
+        end_ms: seg.end_ms.max(0) as u64,
+    }
+}

--- a/src/crates/primer-speech/src/whisper.rs
+++ b/src/crates/primer-speech/src/whisper.rs
@@ -26,8 +26,34 @@ use whisper_cpp_plus::{
     FullParams, SamplingStrategy, Segment, TranscriptionParams, WhisperContext, WhisperStream,
 };
 
+use crate::time_ms::clamp_signed_ms_to_u64;
+
+/// Sample rate Whisper requires (16 kHz mono f32).
 const SAMPLE_RATE: u32 = 16_000;
 
+/// Default transcription language (ISO 639-1). English is the only
+/// language Whisper's `.en` distillates support; multilingual models
+/// auto-detect when given a non-`en` value but using "en" by default
+/// keeps things deterministic for the Primer's English-first audience.
+const DEFAULT_LANGUAGE: &str = "en";
+
+/// `best_of` for the streaming sampler. 1 = greedy decoding (fastest,
+/// lowest quality drop in our latency-dominated streaming path). Beam
+/// search would lift WER on noisy/child audio but at multiplicative
+/// cost; revisit only after profiling shows headroom.
+const STREAMING_BEST_OF: i32 = 1;
+
+/// Backend identifier returned by [`WhisperStt::name`].
+const BACKEND_NAME: &str = "whisper-cpp";
+
+/// Whisper.cpp speech-to-text backend.
+///
+/// Loads a GGML/GGUF model from disk on construction; the same loaded
+/// context is shared across all sessions via `Arc`, which makes one
+/// `WhisperStt` cheap to clone and safe to call from many tasks. Both
+/// the one-shot [`SpeechToText`] and the streaming
+/// [`StreamingSpeechToText`] traits are implemented; pick whichever
+/// matches the call site.
 pub struct WhisperStt {
     ctx: Arc<WhisperContext>,
     language: String,
@@ -41,7 +67,7 @@ impl WhisperStt {
             .map_err(|e| PrimerError::Speech(format!("load whisper model: {e}")))?;
         Ok(Self {
             ctx: Arc::new(ctx),
-            language: "en".to_string(),
+            language: DEFAULT_LANGUAGE.to_string(),
         })
     }
 
@@ -55,7 +81,7 @@ impl WhisperStt {
 #[async_trait]
 impl SpeechToText for WhisperStt {
     fn name(&self) -> &str {
-        "whisper-cpp"
+        BACKEND_NAME
     }
 
     async fn transcribe(&self, audio: &AudioBuffer) -> Result<Transcript> {
@@ -88,7 +114,7 @@ impl SpeechToText for WhisperStt {
 
 impl StreamingSpeechToText for WhisperStt {
     fn name(&self) -> &str {
-        "whisper-cpp"
+        BACKEND_NAME
     }
 
     fn sample_rate(&self) -> u32 {
@@ -96,8 +122,10 @@ impl StreamingSpeechToText for WhisperStt {
     }
 
     fn open_session(&self) -> Result<Box<dyn TranscriptionSession>> {
-        let params =
-            FullParams::new(SamplingStrategy::Greedy { best_of: 1 }).language(&self.language);
+        let params = FullParams::new(SamplingStrategy::Greedy {
+            best_of: STREAMING_BEST_OF,
+        })
+        .language(&self.language);
         let stream = WhisperStream::new(&self.ctx, params)
             .map_err(|e| PrimerError::Speech(format!("open whisper stream: {e}")))?;
         Ok(Box::new(WhisperSession { stream }))
@@ -130,10 +158,15 @@ impl TranscriptionSession for WhisperSession {
     }
 }
 
+/// Map a whisper.cpp segment to our [`TranscriptSegment`].
+///
+/// Whisper's timestamps are signed; in practice they're non-negative,
+/// but the type allows it so we clamp through [`clamp_signed_ms_to_u64`]
+/// rather than reinterpret-casting.
 fn to_transcript_segment(seg: Segment) -> TranscriptSegment {
     TranscriptSegment {
         text: seg.text,
-        start_ms: seg.start_ms.max(0) as u64,
-        end_ms: seg.end_ms.max(0) as u64,
+        start_ms: clamp_signed_ms_to_u64(seg.start_ms),
+        end_ms: clamp_signed_ms_to_u64(seg.end_ms),
     }
 }


### PR DESCRIPTION
## Summary

First two slices of the Phase 2 speech pipeline, derived from the ASD/STT/TTS research conducted on this branch:

- **`VoiceActivityDetector` trait** (`primer-core`) — streaming, per-stream stateful, returns per-chunk speech probability + `SpeechStart`/`SpeechEnd` transitions.
- **`StreamingSpeechToText` trait + `TranscriptionSession`** (`primer-core`) — session-based: one session per child utterance, `push_audio` may emit segments, `finalize` drains the trailing buffer.
- **`SileroVad`** (`primer-speech`, behind `silero` feature) — wraps `silero-vad-rust` with bundled ONNX weights at 16 kHz, 512-sample chunks. `ort` pinned to `=2.0.0-rc.10` to avoid an upstream ndarray-version drift.
- **`WhisperStt`** (`primer-speech`, behind `whisper` feature) — wraps `whisper-cpp-plus 0.1`. Implements both `SpeechToText` (one-shot, off-thread via `spawn_blocking`) and the new streaming trait via `WhisperStream`. Single shared `Arc<WhisperContext>` serves many sessions.
- **`VadDebouncer`** — backend-agnostic threshold + min-silence state machine extracted into its own module so the logic is unit-testable without ONNX Runtime.

Both backends are opt-in; default workspace build pulls **zero** new deps. All 128 existing tests pass; 8 new tests added (7 debouncer + 1 streaming-STT trait dyn-dispatch).

## Why segment-streaming, not token-streaming
Whisper-class encoder-decoder models don't naturally emit token-by-token output during a single utterance — they process audio in segment-sized chunks (one phrase / ~5–10 s). The trait names what the model actually delivers rather than promising what it can't.

## Build prerequisites
| Feature | Needs |
| --- | --- |
| `silero` | Network access on first build (downloads ONNX Runtime from cdn.pyke.io) |
| `whisper` | C++ toolchain (g++/clang) + CMake on the build host; network access on first build (downloads bundled whisper.cpp source from GitHub). |

Default build needs neither.

## Couldn't smoke-test in CI
The sandbox blocks both cdn.pyke.io and GitHub TLS, so neither feature can fully build here. Verified instead:
- Cargo dep tree resolves cleanly under both features (and the combination)
- Default workspace `build`, `test`, `clippy`, `fmt` all green
- Each backend's API usage cross-checked against upstream source

## Test plan
- [ ] On a real machine: `cargo build -p primer-speech --features silero` succeeds
- [ ] `cargo build -p primer-speech --features whisper` succeeds (C++ toolchain present)
- [ ] Wire `SileroVad` to a microphone (`cpal`) and confirm `SpeechStart`/`SpeechEnd` fire on real speech
- [ ] Hand a downloaded `ggml-small.en.bin` to `WhisperStt::new` and run a short transcription
- [ ] (Follow-up) record ~5 min of child speech, build a WER eval harness, decide between whisper-small / Kid-Whisper / Moonshine before committing more pedagogy code to this STT

## Not in this PR
- Step 3 from the plan: Piper TTS impl (next)
- Audio capture/playback (cpal wiring)
- Wiring VAD → STT → DialogueManager end-to-end
- Children's-speech eval harness

---
_Generated by [Claude Code](https://claude.ai/code/session_016GkEhBBxM1qSS8D4pUGbm6)_