### PR TITLE
i18n PR 1: prompt-pack architecture, Locale, schema v6, --language

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1952,6 +1952,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "tracing",
  "uuid",
 ]

--- a/src/crates/primer-cli/src/main.rs
+++ b/src/crates/primer-cli/src/main.rs
@@ -70,6 +70,14 @@ struct Cli {
     #[arg(long, default_value_t = 8)]
     age: u8,
 
+    /// Locale (BCP-47 short pack id, e.g. "en"). Selects the prompt
+    /// pack and (in future) the speech pipeline + per-locale knowledge
+    /// index. Phase 0.1 ships only "en"; passing an unknown id is a
+    /// hard error at startup. Persisted with the learner — a returning
+    /// child does not re-specify their locale each session.
+    #[arg(long, default_value = "en")]
+    language: String,
+
     /// Path to knowledge base SQLite file.
     /// If omitted, uses an in-memory database.
     #[arg(long)]
@@ -631,13 +639,19 @@ fn validate_speech_assets(
     Ok(())
 }
 
-fn create_learner_with_id(id: Uuid, name: &str, age: u8) -> LearnerModel {
+fn create_learner_with_id(
+    id: Uuid,
+    name: &str,
+    age: u8,
+    locale: primer_core::i18n::Locale,
+) -> LearnerModel {
     LearnerModel {
         profile: LearnerProfile {
             id,
             name: name.to_string(),
             age,
-            languages: vec!["en".to_string()],
+            languages: vec![locale.pack_id().to_string()],
+            locale,
             created_at: Utc::now(),
             last_active: Utc::now(),
         },
@@ -789,9 +803,20 @@ async fn async_main() -> anyhow::Result<()> {
         }
     }
 
-    // Single locale-loading site for the future i18n PR to extend.
-    // Phase 0.1 ships only English; Locale::default() == Locale::English.
-    let cli_locale: Locale = Locale::default();
+    // Resolve the requested locale. An unknown pack id (e.g. a typo or
+    // a build that doesn't include the requested language yet) is a
+    // hard error at startup rather than a silent fall-back to English.
+    let cli_locale: Locale = match Locale::from_pack_id(&cli.language) {
+        Some(l) => l,
+        None => {
+            let known: Vec<&str> = Locale::ALL.iter().map(|l| l.pack_id()).collect();
+            eprintln!(
+                "Error: --language {:?} is not supported. Known locales: {:?}",
+                cli.language, known
+            );
+            std::process::exit(1);
+        }
+    };
 
     // Knowledge base — in-memory by default (empty, but functional).
     let knowledge_path = cli.knowledge_db.unwrap_or_else(|| PathBuf::from(IN_MEMORY));
@@ -903,7 +928,7 @@ async fn async_main() -> anyhow::Result<()> {
                     Uuid::new_v4()
                 }
             };
-            let fresh = create_learner_with_id(id, &cli.name, cli.age);
+            let fresh = create_learner_with_id(id, &cli.name, cli.age, cli_locale);
             if let Err(e) = session_store.save_learner(&fresh).await {
                 tracing::warn!("save_learner on startup failed: {e}");
             }
@@ -1705,7 +1730,8 @@ mod tests {
         let store = Arc::new(SqliteSessionStore::open(std::path::Path::new(":memory:")).unwrap());
         let original_id = Uuid::new_v4();
         let original_created = Utc::now() - chrono::Duration::days(365);
-        let mut original = create_learner_with_id(original_id, "Binti", 8);
+        let mut original =
+            create_learner_with_id(original_id, "Binti", 8, primer_core::i18n::Locale::English);
         original.profile.created_at = original_created;
         store.save_learner(&original).await.unwrap();
 
@@ -1740,7 +1766,12 @@ mod tests {
         use std::sync::Arc;
 
         let store = Arc::new(SqliteSessionStore::open(std::path::Path::new(":memory:")).unwrap());
-        let original = create_learner_with_id(Uuid::new_v4(), "Binti", 8);
+        let original = create_learner_with_id(
+            Uuid::new_v4(),
+            "Binti",
+            8,
+            primer_core::i18n::Locale::English,
+        );
         store.save_learner(&original).await.unwrap();
 
         let existing = store.load_learner().await.unwrap().expect("learner row");
@@ -1764,7 +1795,8 @@ mod tests {
         // The non-mismatch path: same name should be a pure age/last_active
         // refresh with no warn (covered by absence of stderr in this test).
         let original_id = Uuid::new_v4();
-        let original = create_learner_with_id(original_id, "Binti", 8);
+        let original =
+            create_learner_with_id(original_id, "Binti", 8, primer_core::i18n::Locale::English);
         let result = reconcile_persisted_learner(original, "Binti", 9);
         assert_eq!(result.profile.name, "Binti");
         assert_eq!(result.profile.id, original_id);

--- a/src/crates/primer-core/src/i18n.rs
+++ b/src/crates/primer-core/src/i18n.rs
@@ -30,12 +30,64 @@
 //!     makes sense.
 
 use crate::error::InferenceError;
+use serde::{Deserialize, Serialize};
 
 /// User-facing locale.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+///
+/// Closed enum: a new variant is the single source of truth for that
+/// language, and corresponding additions cascade to the prompt-pack
+/// dispatch (`primer-pedagogy::prompt_pack`), the `render_inference_error`
+/// match below, and `Locale::ALL` / `from_pack_id`. The lookup tables in
+/// SQLite (`learners.locale` etc.) round-trip via `pack_id()` —
+/// retired pack ids never get reused.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Locale {
     #[default]
     English,
+}
+
+impl Locale {
+    /// Every variant, in declaration order. Used by tests and by any
+    /// startup path that needs to enumerate available locales.
+    pub const ALL: &'static [Self] = &[Self::English];
+
+    /// Canonical machine-readable name. Stable identifier — do not
+    /// rename. Mirrors the `name()` pattern on `EngagementState` and
+    /// `UnderstandingDepth`.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::English => "English",
+        }
+    }
+
+    /// BCP 47 language tag for downstream services (Whisper, Piper,
+    /// future TTS backends). Region-suffixed because most speech
+    /// models accept region codes for accent selection.
+    pub fn bcp47(self) -> &'static str {
+        match self {
+            Self::English => "en-US",
+        }
+    }
+
+    /// Short pack id used for prompt-pack lookup and as the SQLite
+    /// `learners.locale` / `concepts.concept_language_tag` column value.
+    /// Stable identifier — never renamed, never reused for a different
+    /// language.
+    pub fn pack_id(self) -> &'static str {
+        match self {
+            Self::English => "en",
+        }
+    }
+
+    /// Parse a short pack id back to a `Locale`. Returns `None` for
+    /// unknown ids (caller decides whether that's a hard error or a
+    /// fall-back to `Locale::default()`).
+    pub fn from_pack_id(s: &str) -> Option<Self> {
+        match s {
+            "en" => Some(Self::English),
+            _ => None,
+        }
+    }
 }
 
 /// Translate an `InferenceError` into a user-facing message in the
@@ -90,6 +142,30 @@ mod tests {
     #[test]
     fn locale_default_is_english() {
         assert_eq!(Locale::default(), Locale::English);
+    }
+
+    #[test]
+    fn locale_all_lists_every_variant() {
+        assert_eq!(Locale::ALL.len(), 1);
+        assert!(Locale::ALL.contains(&Locale::English));
+    }
+
+    #[test]
+    fn locale_pack_id_round_trips_via_from_pack_id() {
+        for &l in Locale::ALL {
+            assert_eq!(Locale::from_pack_id(l.pack_id()), Some(l));
+        }
+    }
+
+    #[test]
+    fn locale_from_pack_id_unknown_returns_none() {
+        assert_eq!(Locale::from_pack_id("zz"), None);
+        assert_eq!(Locale::from_pack_id(""), None);
+    }
+
+    #[test]
+    fn locale_bcp47_includes_region() {
+        assert_eq!(Locale::English.bcp47(), "en-US");
     }
 
     #[test]

--- a/src/crates/primer-core/src/learner.rs
+++ b/src/crates/primer-core/src/learner.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::classifier::EngagementAssessment;
+use crate::i18n::Locale;
 
 /// Default threshold for the session-length-aware Disengaging branch.
 /// Below this, Disengaging routes to Encouragement; at or above, SessionClose.
@@ -34,7 +35,17 @@ pub struct LearnerProfile {
     /// Age in years (used for developmental-stage adaptation).
     pub age: u8,
     /// Preferred language(s) — ISO 639-1 codes, ordered by preference.
+    /// Open-vocabulary preference list, distinct from the closed-enum
+    /// `locale` below which is the bound dispatch key for prompt packs,
+    /// speech-pipeline routing, and per-locale knowledge-base lookups.
     pub languages: Vec<String>,
+    /// Bound locale used to dispatch the prompt pack and (eventually)
+    /// the speech pipeline + per-locale knowledge index. Persists with
+    /// the learner so a returning child does not re-specify it each
+    /// session. `#[serde(default)]` so existing serialised profiles
+    /// without this field deserialise as `Locale::English`.
+    #[serde(default)]
+    pub locale: Locale,
     /// When the profile was created.
     pub created_at: DateTime<Utc>,
     /// When the profile was last active.

--- a/src/crates/primer-pedagogy/Cargo.toml
+++ b/src/crates/primer-pedagogy/Cargo.toml
@@ -14,6 +14,7 @@ tokio.workspace = true
 futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+toml.workspace = true
 chrono.workspace = true
 uuid.workspace = true
 tracing.workspace = true

--- a/src/crates/primer-pedagogy/prompts/en.toml
+++ b/src/crates/primer-pedagogy/prompts/en.toml
@@ -1,0 +1,184 @@
+# English Prompt Pack — the reference pack.
+#
+# This file contains every load-bearing piece of pedagogical text the
+# Primer sends to the LLM. It is the ONLY place language-specific
+# content lives for English. The Rust prompt builder reads from this
+# file; it contains no English strings.
+#
+# TRANSLATORS: Do not translate mechanically. Read the section
+# annotations, understand what each block is trying to achieve, and
+# write the equivalent in your language's natural pedagogical register.
+# If a concept doesn't translate directly, adapt it — the pedagogy
+# matters more than word-for-word fidelity.
+#
+# Placeholder syntax: `{name}`, `{age}`, `{language_guidance}` are
+# substituted at render time. Each field has a fixed allowlist of
+# placeholders — `TomlPromptPack::load` validates and panics on
+# unknown tokens.
+
+[meta]
+language = "en"
+language_name = "English"
+bcp47 = "en-US"
+
+# --- BASE SYSTEM PROMPT ---
+# Allowed placeholders: {name}, {age}, {language_guidance}
+[system_prompt]
+base = """\
+You are the Primer — a patient, curious, Socratic learning companion for a child named {name}, age {age}.
+
+Your core principles:
+- NEVER give a direct answer when you can ask a guiding question instead.
+- Ask questions that lead {name} toward discovering the answer themselves.
+- When {name} answers, assess whether they genuinely understand or are guessing/parroting.
+- If they understand: acknowledge it, then extend — "Good. Now what if...?"
+- If they're struggling: offer a concrete example, analogy, or story. Reduce abstraction.
+- If they ask a pure factual question ("How far is the moon?"): answer it directly, THEN pivot to a Socratic follow-up ("Now that you know it's 384,000 km, how long would it take to drive there?").
+- Be warm. Be patient. Never condescend. Treat every question as worthy.
+- You are NOT trying to keep {name} engaged. If they want to stop, let them stop. Say "That's enough for today" without guilt.
+- You do not use emojis or exclamation marks excessively.
+
+Language for a {age}-year-old — read carefully:
+{language_guidance}
+
+Vocabulary discipline (applies at every age):
+- Before using any technical or unusual word (examples at this age: "plasma", "molecule", "conductor", "insulator", "shockwave", "vibration", "frequency", "voltage", "current", "atom", "particle"), first explain the idea in plain everyday words using a concrete analogy {name} already knows (food, toys, animals, weather, family, body). Only use the technical word once the plain-language idea is clear — and even then, the technical word is optional, never required.
+- If {name} asks "what does X mean?" (like asking what "repel" means), that is a signal that X was introduced too soon. First, explain X in plain everyday words. For the next sentence or two, use the plain-language version on its own. Then start weaving X back in alongside the plain meaning ("the air pushes the charges away — it repels them"), so {name} ends the conversation having *gained* the new word, not had it taken away. Re-use newly-introduced words a few more times before the session ends — short, casual repetition is how vocabulary actually sticks.
+- One new idea per sentence. If a sentence introduces two unfamiliar things, split it.
+- After two or three sentences of explanation, stop and ask a question. Do not lecture.\
+"""
+
+# --- AGE-BAND LANGUAGE GUIDANCE ---
+# These are the most language-dependent sections. Each language pack
+# needs ITS OWN complexity metrics — do not translate the English
+# syllable rules. Rewrite from scratch based on what constitutes
+# age-appropriate language in the target language.
+# No placeholders allowed.
+[language_guidance]
+ages_0_6 = """\
+- Use only words a young child uses at home or kindergarten.
+- Sentences are short — aim for 6 to 10 words.
+- Never use a word with more than three syllables unless you have just defined it through a concrete everyday example, and the child has shown they grasped the example.
+- Anchor every idea to something the child can see, touch, hear, or do: food, toys, pets, body, weather, family.
+- Avoid abstract nouns ("energy", "matter", "force") unless you have grounded them in a physical thing first.\
+"""
+
+ages_7_9 = """\
+- Use everyday words a young child uses at home or in primary school.
+- Short, clear sentences — usually 8 to 15 words. Break longer thoughts into separate sentences.
+- Common everyday words only. Treat words like "molecule", "plasma", "conductor", "insulator", "vibration", "shockwave", "eardrum", "pressure wave", "electron" as TECHNICAL — they require the plain-language introduction described in the Vocabulary discipline section below.
+- Anchor abstract ideas to something the child can see, touch, or do — kitchen, playground, bath, bed, pets, family — before introducing the abstract version.
+- It is better to say something twice in plain words than once correctly with a hard word.\
+"""
+
+ages_10_12 = """\
+- Use clear everyday vocabulary; moderate sentence length is fine.
+- New technical terms are acceptable, but always define them briefly with a concrete example the first time they appear.
+- You can introduce one moderately abstract idea per response, but always tie it back to something concrete.\
+"""
+
+ages_13_plus = """\
+- Adult-level vocabulary is acceptable, but still introduce specialised jargon with a brief plain-language gloss the first time it appears.
+- Sentence length and complexity may match an articulate teenager.\
+"""
+
+# --- PEDAGOGICAL INTENT INSTRUCTIONS ---
+# Keys must match `PedagogicalIntent` enum variants in snake_case.
+# No placeholders allowed.
+[intent]
+socratic_question = "Your next response should be a guiding question that leads toward understanding."
+
+comprehension_check = """\
+Your next response should probe whether the child truly understands \
+or is repeating what they've heard. Ask them to explain it differently, \
+apply it to a new situation, or find a flaw in a deliberately wrong statement.\
+"""
+
+scaffolding = """\
+The child is struggling. Your next response should offer a concrete \
+example, a story, or an analogy that makes the concept tangible. \
+Reduce the abstraction level.\
+"""
+
+encouragement = """\
+The child is frustrated. Your next response should be encouraging \
+without being patronising. Acknowledge the difficulty. Normalise confusion. \
+Suggest a different angle of approach.\
+"""
+
+extension = """\
+The child has demonstrated understanding. Your next response should \
+extend the concept — introduce a complication, a counterexample, \
+or a connection to a different domain.\
+"""
+
+direct_answer = """\
+This is a factual question. Answer it directly and clearly, \
+then follow with a Socratic question that builds on the answer.\
+"""
+
+answer_then_pivot = """\
+Provide the factual answer briefly, then pivot to a question \
+that makes the child think about *why* the fact matters or \
+what would change if it were different.\
+"""
+
+session_close = """\
+Suggest that this is a good stopping point. Summarise what was \
+explored today (not what was 'learned' — what was *explored*). \
+Leave the child with one question to think about until next time.\
+"""
+
+# --- ENGAGEMENT-STATE NOTES ---
+# Appended to the system prompt only when the learner is in the
+# corresponding state. No placeholders allowed.
+[engagement]
+frustrated = """\
+IMPORTANT: The child appears frustrated. Be especially gentle. \
+Offer to approach the topic differently or switch topics entirely.\
+"""
+
+disengaging = """\
+NOTE: The child may be losing interest. Consider suggesting a \
+break or pivoting to a topic they find more engaging.\
+"""
+
+# --- KNOWLEDGE / MEMORY SECTION INTROS ---
+# Single-line headers shown only when the corresponding section is
+# non-empty. The body (passages / summary / retrieved turns) is
+# appended by the renderer.
+[sections]
+# Allowed placeholders: {age}
+knowledge_intro = "Relevant factual context (use to ground your responses, but do not quote directly — rephrase for a {age}-year-old):"
+summary_intro = "Earlier in this conversation (long-term memory across many turns):"
+retrieved_intro = "Relevant prior moments from this same session (retrieved by topic, not in time order; use as background, not as the active conversation):"
+
+# --- SPEAKER LABELS ---
+# Used in the retrieved-prior-moments section for "[Child]" / "[Primer]".
+# No placeholders allowed.
+[labels]
+child = "Child"
+primer = "Primer"
+
+# --- FACTUAL-QUESTION DETECTION ---
+# Lowercased prefixes that mark a child's input as a direct factual
+# lookup; routed to DirectAnswer (or AnswerThenPivot if the prior
+# Primer turn was already a DirectAnswer). The trailing space prevents
+# partial-word matches ("whatever", "howdy"). Exploratory forms
+# ("what if", "what about") and "why" questions are intentionally
+# excluded — those are Socratic-richer.
+#
+# For languages where prefix-matching doesn't work (Japanese particles,
+# Mandarin tone-disambiguation, etc.) set this to an empty array; the
+# routing falls back to the LLM-based engagement classifier.
+[question_detection]
+factual_prefixes = [
+    "what is ",
+    "what are ",
+    "what's ",
+    "what does ",
+    "how does ",
+    "how do ",
+    "how is ",
+    "how are ",
+]

--- a/src/crates/primer-pedagogy/src/dialogue_manager.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager.rs
@@ -38,6 +38,7 @@ use primer_extractor::{ConceptExtractor, ExtractorSettings};
 use tokio::task::JoinHandle;
 
 use crate::prompt_builder;
+use crate::prompt_pack::{self, PromptPack};
 
 /// Optional persistence stores for a `DialogueManager`.
 ///
@@ -147,6 +148,12 @@ pub struct DialogueManager<'a> {
     /// extraction lands and starts populating `learner.concepts` per-turn,
     /// it just sets the flag — no save-site changes needed.
     learner_dirty: bool,
+    /// Locale-specific prompt pack used to render every system-prompt
+    /// section, intent instruction, engagement note, and section intro.
+    /// Selected from `learner.profile.locale` at construction time —
+    /// the locale is bound for the lifetime of this manager (no
+    /// in-session locale switching today).
+    prompt_pack: Arc<dyn PromptPack>,
 }
 
 /// Output of the spawned post-response task: the extracted concepts
@@ -353,6 +360,8 @@ impl<'a> DialogueManager<'a> {
         config: PedagogyConfig,
     ) -> Self {
         let session = Session::new(learner.profile.id);
+        let prompt_pack = prompt_pack::load(learner.profile.locale)
+            .expect("prompt pack load failed; this should be impossible at runtime");
         Self {
             learner,
             session,
@@ -372,6 +381,7 @@ impl<'a> DialogueManager<'a> {
             config,
             last_extraction: None,
             learner_dirty: false,
+            prompt_pack,
         }
     }
 
@@ -509,10 +519,15 @@ impl<'a> DialogueManager<'a> {
         // 2. Decide intent, retrieve knowledge, retrieve relevant older
         //    turns from the FTS index (when there are turns outside the
         //    active window), build prompt.
-        let intent = prompt_builder::decide_intent(&self.learner, &self.session);
+        let intent = prompt_builder::decide_intent_with_pack(
+            &*self.prompt_pack,
+            &self.learner,
+            &self.session,
+        );
         let knowledge_context = self.retrieve_knowledge(child_input).await;
         let (summary, retrieved_older) = self.retrieve_long_term_memory(child_input).await;
-        let prompt = prompt_builder::build_prompt(
+        let prompt = prompt_builder::build_prompt_with_pack(
+            &*self.prompt_pack,
             &self.learner,
             &self.session,
             intent,
@@ -1498,6 +1513,7 @@ mod tests {
                 name: "Tester".to_string(),
                 age: 8,
                 languages: vec!["en".to_string()],
+                locale: primer_core::i18n::Locale::English,
                 created_at: Utc::now(),
                 last_active: Utc::now(),
             },

--- a/src/crates/primer-pedagogy/src/dialogue_manager.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager.rs
@@ -360,7 +360,12 @@ impl<'a> DialogueManager<'a> {
         config: PedagogyConfig,
     ) -> Self {
         let session = Session::new(learner.profile.id);
-        let prompt_pack = prompt_pack::load(learner.profile.locale)
+        // `load_cached` returns a process-wide shared `Arc<dyn PromptPack>`
+        // so successive `DialogueManager::new` calls in the same process
+        // (tests, future multi-session flows) don't re-parse the embedded
+        // TOML. PRIMER_PROMPTS_DIR bypasses the cache for translator
+        // iteration.
+        let prompt_pack = prompt_pack::load_cached(learner.profile.locale)
             .expect("prompt pack load failed; this should be impossible at runtime");
         Self {
             learner,

--- a/src/crates/primer-pedagogy/src/lib.rs
+++ b/src/crates/primer-pedagogy/src/lib.rs
@@ -17,5 +17,7 @@
 pub mod consts;
 pub mod dialogue_manager;
 pub mod prompt_builder;
+pub mod prompt_pack;
 
 pub use dialogue_manager::{DialogueManager, DialogueManagerStores, DialogueManagerSubsystems};
+pub use prompt_pack::{PromptPack, TomlPromptPack};

--- a/src/crates/primer-pedagogy/src/prompt_builder.rs
+++ b/src/crates/primer-pedagogy/src/prompt_builder.rs
@@ -7,12 +7,30 @@
 //! This is where the Socratic method is encoded — not in the model's weights,
 //! but in the instructions we give it.
 
+use std::sync::OnceLock;
+
 use primer_core::conversation::{PedagogicalIntent, Session, Speaker, Turn};
+use primer_core::i18n::Locale;
 use primer_core::inference::{Message, Prompt, Role};
 use primer_core::knowledge::Passage;
-use primer_core::learner::{EngagementState, LearnerModel, UnderstandingDepth};
+use primer_core::learner::{LearnerModel, UnderstandingDepth};
 
-/// Build the system prompt for the next LLM call.
+use crate::prompt_pack::{self, PromptPack};
+
+/// Process-wide cached English pack used by the no-pack convenience
+/// wrappers (`decide_intent`, `is_factual_question`, and the
+/// existing-signature `build_system_prompt` / `build_prompt`). The
+/// dialogue manager constructs and threads its own locale-specific
+/// pack through `*_with_pack` variants instead of consulting this
+/// singleton — same code, different entry point.
+fn english_pack() -> &'static dyn PromptPack {
+    static CELL: OnceLock<std::sync::Arc<dyn PromptPack>> = OnceLock::new();
+    CELL.get_or_init(|| prompt_pack::load(Locale::English).expect("english pack loads"))
+        .as_ref()
+}
+
+/// Build the system prompt for the next LLM call using the locale's
+/// [`PromptPack`] for every piece of pedagogical text.
 ///
 /// The system prompt varies based on:
 /// - The child's age and developmental stage
@@ -26,7 +44,8 @@ use primer_core::learner::{EngagementState, LearnerModel, UnderstandingDepth};
 /// inside the active window so neither is needed. When non-empty they
 /// live as system-prompt sections so the chat-message timeline (the
 /// last N turns) stays linear and coherent.
-pub fn build_system_prompt(
+pub fn build_system_prompt_with_pack(
+    pack: &dyn PromptPack,
     learner: &LearnerModel,
     intent: PedagogicalIntent,
     knowledge_context: &[Passage],
@@ -35,82 +54,15 @@ pub fn build_system_prompt(
 ) -> String {
     let age = learner.profile.age;
     let name = &learner.profile.name;
-    let language_guidance = language_guidance_for_age(age);
 
-    let base = format!(
-        r#"You are the Primer — a patient, curious, Socratic learning companion for a child named {name}, age {age}.
+    let base = pack.render_base(name, age);
+    let intent_instruction = pack.intent_instruction(intent);
 
-Your core principles:
-- NEVER give a direct answer when you can ask a guiding question instead.
-- Ask questions that lead {name} toward discovering the answer themselves.
-- When {name} answers, assess whether they genuinely understand or are guessing/parroting.
-- If they understand: acknowledge it, then extend — "Good. Now what if...?"
-- If they're struggling: offer a concrete example, analogy, or story. Reduce abstraction.
-- If they ask a pure factual question ("How far is the moon?"): answer it directly, THEN pivot to a Socratic follow-up ("Now that you know it's 384,000 km, how long would it take to drive there?").
-- Be warm. Be patient. Never condescend. Treat every question as worthy.
-- You are NOT trying to keep {name} engaged. If they want to stop, let them stop. Say "That's enough for today" without guilt.
-- You do not use emojis or exclamation marks excessively.
-
-Language for a {age}-year-old — read carefully:
-{language_guidance}
-
-Vocabulary discipline (applies at every age):
-- Before using any technical or unusual word (examples at this age: "plasma", "molecule", "conductor", "insulator", "shockwave", "vibration", "frequency", "voltage", "current", "atom", "particle"), first explain the idea in plain everyday words using a concrete analogy {name} already knows (food, toys, animals, weather, family, body). Only use the technical word once the plain-language idea is clear — and even then, the technical word is optional, never required.
-- If {name} asks "what does X mean?" (like asking what "repel" means), that is a signal that X was introduced too soon. First, explain X in plain everyday words. For the next sentence or two, use the plain-language version on its own. Then start weaving X back in alongside the plain meaning ("the air pushes the charges away — it repels them"), so {name} ends the conversation having *gained* the new word, not had it taken away. Re-use newly-introduced words a few more times before the session ends — short, casual repetition is how vocabulary actually sticks.
-- One new idea per sentence. If a sentence introduces two unfamiliar things, split it.
-- After two or three sentences of explanation, stop and ask a question. Do not lecture."#
-    );
-
-    let intent_instruction = match intent {
-        PedagogicalIntent::SocraticQuestion => {
-            "Your next response should be a guiding question that leads toward understanding."
-        }
-        PedagogicalIntent::ComprehensionCheck => {
-            "Your next response should probe whether the child truly understands \
-             or is repeating what they've heard. Ask them to explain it differently, \
-             apply it to a new situation, or find a flaw in a deliberately wrong statement."
-        }
-        PedagogicalIntent::Scaffolding => {
-            "The child is struggling. Your next response should offer a concrete \
-             example, a story, or an analogy that makes the concept tangible. \
-             Reduce the abstraction level."
-        }
-        PedagogicalIntent::Encouragement => {
-            "The child is frustrated. Your next response should be encouraging \
-             without being patronising. Acknowledge the difficulty. Normalise confusion. \
-             Suggest a different angle of approach."
-        }
-        PedagogicalIntent::Extension => {
-            "The child has demonstrated understanding. Your next response should \
-             extend the concept — introduce a complication, a counterexample, \
-             or a connection to a different domain."
-        }
-        PedagogicalIntent::DirectAnswer => {
-            "This is a factual question. Answer it directly and clearly, \
-             then follow with a Socratic question that builds on the answer."
-        }
-        PedagogicalIntent::AnswerThenPivot => {
-            "Provide the factual answer briefly, then pivot to a question \
-             that makes the child think about *why* the fact matters or \
-             what would change if it were different."
-        }
-        PedagogicalIntent::SessionClose => {
-            "Suggest that this is a good stopping point. Summarise what was \
-             explored today (not what was 'learned' — what was *explored*). \
-             Leave the child with one question to think about until next time."
-        }
-    };
-
-    let engagement_note = match learner.current_engagement {
-        EngagementState::FrustratedStuck | EngagementState::FrustratedTrying => {
-            "\n\nIMPORTANT: The child appears frustrated. Be especially gentle. \
-             Offer to approach the topic differently or switch topics entirely."
-        }
-        EngagementState::Disengaging => {
-            "\n\nNOTE: The child may be losing interest. Consider suggesting a \
-             break or pivoting to a topic they find more engaging."
-        }
-        _ => "",
+    let engagement_note_body = pack.engagement_note(learner.current_engagement);
+    let engagement_note: String = if engagement_note_body.is_empty() {
+        String::new()
+    } else {
+        format!("\n\n{engagement_note_body}")
     };
 
     let knowledge_section = if knowledge_context.is_empty() {
@@ -121,18 +73,15 @@ Vocabulary discipline (applies at every age):
             .map(|p| format!("[Source: {}]\n{}", p.source, p.text))
             .collect::<Vec<_>>()
             .join("\n\n");
-        format!(
-            "\n\nRelevant factual context (use to ground your responses, \
-             but do not quote directly — rephrase for a {age}-year-old):\n\n{passages}"
-        )
+        let intro = pack.knowledge_intro(age);
+        format!("\n\n{intro}\n\n{passages}")
     };
 
     let summary_section = if summary.trim().is_empty() {
         String::new()
     } else {
-        format!(
-            "\n\nEarlier in this conversation (long-term memory across many turns):\n\n{summary}"
-        )
+        let intro = pack.summary_intro();
+        format!("\n\n{intro}\n\n{summary}")
     };
 
     let retrieved_section = if retrieved_older.is_empty() {
@@ -142,21 +91,38 @@ Vocabulary discipline (applies at every age):
             .iter()
             .map(|t| {
                 let who = match t.speaker {
-                    Speaker::Child => "Child",
-                    Speaker::Primer => "Primer",
+                    Speaker::Child => pack.child_label(),
+                    Speaker::Primer => pack.primer_label(),
                 };
                 format!("- [{who}] {}", t.text)
             })
             .collect::<Vec<_>>()
             .join("\n");
-        format!(
-            "\n\nRelevant prior moments from this same session (retrieved by topic, \
-             not in time order; use as background, not as the active conversation):\n\n{lines}"
-        )
+        let intro = pack.retrieved_intro();
+        format!("\n\n{intro}\n\n{lines}")
     };
 
     format!(
         "{base}\n\n{intent_instruction}{engagement_note}{summary_section}{retrieved_section}{knowledge_section}"
+    )
+}
+
+/// Convenience wrapper consulting the process-wide cached English pack.
+/// Used by tests and by any caller that hasn't been threaded a locale.
+pub fn build_system_prompt(
+    learner: &LearnerModel,
+    intent: PedagogicalIntent,
+    knowledge_context: &[Passage],
+    summary: &str,
+    retrieved_older: &[Turn],
+) -> String {
+    build_system_prompt_with_pack(
+        english_pack(),
+        learner,
+        intent,
+        knowledge_context,
+        summary,
+        retrieved_older,
     )
 }
 
@@ -175,7 +141,8 @@ pub fn build_messages(session: &Session, context_turns: usize) -> Vec<Message> {
         .collect()
 }
 
-/// Assemble the complete prompt from components.
+/// Assemble the complete prompt from components using the supplied
+/// [`PromptPack`].
 ///
 /// `summary` and `retrieved_older` carry long-term memory: the rolling
 /// LLM-generated condensation of pre-window turns and the FTS5-retrieved
@@ -183,6 +150,31 @@ pub fn build_messages(session: &Session, context_turns: usize) -> Vec<Message> {
 /// into the system prompt; the chat `messages` list stays exactly equal
 /// to `session.recent_turns(context_turns)` so the timeline the model
 /// sees as "the conversation" is linear.
+#[allow(clippy::too_many_arguments)]
+pub fn build_prompt_with_pack(
+    pack: &dyn PromptPack,
+    learner: &LearnerModel,
+    session: &Session,
+    intent: PedagogicalIntent,
+    knowledge_context: &[Passage],
+    summary: &str,
+    retrieved_older: &[Turn],
+    context_turns: usize,
+) -> Prompt {
+    Prompt {
+        system: build_system_prompt_with_pack(
+            pack,
+            learner,
+            intent,
+            knowledge_context,
+            summary,
+            retrieved_older,
+        ),
+        messages: build_messages(session, context_turns),
+    }
+}
+
+/// Convenience wrapper using the process-wide cached English pack.
 #[allow(clippy::too_many_arguments)]
 pub fn build_prompt(
     learner: &LearnerModel,
@@ -193,41 +185,16 @@ pub fn build_prompt(
     retrieved_older: &[Turn],
     context_turns: usize,
 ) -> Prompt {
-    Prompt {
-        system: build_system_prompt(learner, intent, knowledge_context, summary, retrieved_older),
-        messages: build_messages(session, context_turns),
-    }
-}
-
-/// Concrete, age-banded language guidance for the system prompt.
-///
-/// Generic instructions like "match vocabulary to age" do not constrain a
-/// modern LLM enough — it will happily use words like "plasma" or
-/// "insulator" with a 7-year-old. These bands give explicit ceilings on
-/// sentence length and vocabulary register, plus rules about how new
-/// technical terms must be introduced.
-fn language_guidance_for_age(age: u8) -> &'static str {
-    match age {
-        0..=6 => "\
-- Use only words a young child uses at home or kindergarten.
-- Sentences are short — aim for 6 to 10 words.
-- Never use a word with more than three syllables unless you have just defined it through a concrete everyday example, and the child has shown they grasped the example.
-- Anchor every idea to something the child can see, touch, hear, or do: food, toys, pets, body, weather, family.
-- Avoid abstract nouns (\"energy\", \"matter\", \"force\") unless you have grounded them in a physical thing first.",
-        7..=9 => "\
-- Use everyday words a young child uses at home or in primary school.
-- Short, clear sentences — usually 8 to 15 words. Break longer thoughts into separate sentences.
-- Common everyday words only. Treat words like \"molecule\", \"plasma\", \"conductor\", \"insulator\", \"vibration\", \"shockwave\", \"eardrum\", \"pressure wave\", \"electron\" as TECHNICAL — they require the plain-language introduction described in the Vocabulary discipline section below.
-- Anchor abstract ideas to something the child can see, touch, or do — kitchen, playground, bath, bed, pets, family — before introducing the abstract version.
-- It is better to say something twice in plain words than once correctly with a hard word.",
-        10..=12 => "\
-- Use clear everyday vocabulary; moderate sentence length is fine.
-- New technical terms are acceptable, but always define them briefly with a concrete example the first time they appear.
-- You can introduce one moderately abstract idea per response, but always tie it back to something concrete.",
-        _ => "\
-- Adult-level vocabulary is acceptable, but still introduce specialised jargon with a brief plain-language gloss the first time it appears.
-- Sentence length and complexity may match an articulate teenager.",
-    }
+    build_prompt_with_pack(
+        english_pack(),
+        learner,
+        session,
+        intent,
+        knowledge_context,
+        summary,
+        retrieved_older,
+        context_turns,
+    )
 }
 
 // ─── Concept-depth helpers (used by dialogue manager) ─────────────────
@@ -253,52 +220,76 @@ pub fn extract_active_concepts(session: &Session, last_n: usize) -> Vec<String> 
         .collect()
 }
 
-/// Return `true` if `text` looks like a direct factual lookup.
+/// Return `true` if `text` looks like a direct factual lookup,
+/// using `pack`'s `factual_prefixes()` list. Returns `false` if the
+/// list is empty (e.g. for languages where prefix matching doesn't
+/// apply — Japanese, Mandarin) and `decide_intent` falls back to the
+/// LLM-based classifier in that case.
 ///
-/// Only a small set of opening phrases qualify: "what is/are/does", "what's",
-/// and "how does/do/is/are". The trailing space in each prefix prevents
-/// partial-word matches ("whatever", "howdy"). Exploratory forms ("what if",
-/// "what about") and "why" questions are intentionally excluded — those
-/// are Socratic-richer and should not be short-circuited with a direct answer.
-///
-/// This is a private helper for `decide_intent`; Task 19 wires it into
-/// the intent-routing logic.
-fn is_factual_question(text: &str) -> bool {
-    const FACTUAL_PREFIXES: &[&str] = &[
-        "what is ",
-        "what are ",
-        "what's ",
-        "what does ",
-        "how does ",
-        "how do ",
-        "how is ",
-        "how are ",
-    ];
+/// Only a small set of opening phrases qualify in English: "what
+/// is/are/does", "what's", and "how does/do/is/are". The trailing
+/// space in each prefix prevents partial-word matches ("whatever",
+/// "howdy"). Exploratory forms ("what if", "what about") and "why"
+/// questions are intentionally excluded — those are Socratic-richer
+/// and should not be short-circuited with a direct answer.
+fn is_factual_question_with_pack(pack: &dyn PromptPack, text: &str) -> bool {
+    let prefixes = pack.factual_prefixes();
+    if prefixes.is_empty() {
+        return false;
+    }
     let lowered = text.trim().to_lowercase();
-    FACTUAL_PREFIXES.iter().any(|p| lowered.starts_with(p))
+    prefixes.iter().any(|p| lowered.starts_with(p.as_str()))
+}
+
+/// Convenience wrapper using the process-wide cached English pack.
+/// Used only by tests today; the production path goes through
+/// `is_factual_question_with_pack`.
+#[cfg(test)]
+fn is_factual_question(text: &str) -> bool {
+    is_factual_question_with_pack(english_pack(), text)
 }
 
 /// Decide the next pedagogical intent based on the learner model
 /// and conversation history.
 ///
 /// This is a thin wrapper around [`decide_intent_at`] that injects
-/// `chrono::Utc::now()` as the reference time. Production code calls this;
-/// tests call `decide_intent_at` directly with a controlled timestamp.
+/// `chrono::Utc::now()` as the reference time. Production code calls
+/// `decide_intent_at_with_pack` (locale-aware); this no-pack variant
+/// uses the cached English pack for tests and English-only call paths.
 pub fn decide_intent(learner: &LearnerModel, session: &Session) -> PedagogicalIntent {
     decide_intent_at(learner, session, chrono::Utc::now())
 }
 
+/// Locale-aware variant of [`decide_intent`].
+pub fn decide_intent_with_pack(
+    pack: &dyn PromptPack,
+    learner: &LearnerModel,
+    session: &Session,
+) -> PedagogicalIntent {
+    decide_intent_at_with_pack(pack, learner, session, chrono::Utc::now())
+}
+
 /// Time-aware core of [`decide_intent`].
-///
-/// Accepts an explicit `now` so tests can backdate sessions deterministically
-/// without real-clock races. The `Disengaging` branch uses `now` together with
-/// `session.started_at` to distinguish an early disengagement (encourage rather
-/// than close) from a sustained one (suggest session close).
 pub fn decide_intent_at(
     learner: &LearnerModel,
     session: &Session,
     now: chrono::DateTime<chrono::Utc>,
 ) -> PedagogicalIntent {
+    decide_intent_at_with_pack(english_pack(), learner, session, now)
+}
+
+/// Time-aware, locale-aware core. Accepts an explicit `now` so tests
+/// can backdate sessions deterministically without real-clock races.
+/// The `Disengaging` branch uses `now` together with `session.started_at`
+/// to distinguish an early disengagement (encourage rather than close)
+/// from a sustained one (suggest session close).
+pub fn decide_intent_at_with_pack(
+    pack: &dyn PromptPack,
+    learner: &LearnerModel,
+    session: &Session,
+    now: chrono::DateTime<chrono::Utc>,
+) -> PedagogicalIntent {
+    use primer_core::learner::EngagementState;
     // Engagement-state overrides fire before turn analysis.
     match learner.current_engagement {
         EngagementState::FrustratedStuck => return PedagogicalIntent::Scaffolding,
@@ -322,7 +313,7 @@ pub fn decide_intent_at(
     if let Some(last) = session.turns.last() {
         if last.speaker == primer_core::conversation::Speaker::Child {
             // Gap 2: factual-question pattern routing
-            if is_factual_question(&last.text) {
+            if is_factual_question_with_pack(pack, &last.text) {
                 let prior_was_direct_answer = session
                     .turns
                     .iter()
@@ -391,6 +382,7 @@ mod tests {
                 name: "Tester".to_string(),
                 age: 8,
                 languages: vec!["en".to_string()],
+                locale: primer_core::i18n::Locale::English,
                 created_at: Utc::now(),
                 last_active: Utc::now(),
             },
@@ -969,6 +961,202 @@ mod tests {
             prompt.system.contains("appears frustrated"),
             "engagement note should appear for FrustratedStuck"
         );
+    }
+
+    // ─── Snapshot tests: lock byte-identical English prompt output ────
+    //
+    // These tests are the regression guard for the prompt-pack refactor.
+    // They lock both the precise length and the exact content of the
+    // rendered system prompt for a representative matrix of inputs. If
+    // anyone edits `prompts/en.toml` (or the rendering logic) and
+    // changes the output, these tests fail loudly with the offending
+    // before/after lengths or the offending differing substring.
+    //
+    // The locked lengths were measured against the pre-refactor
+    // hardcoded strings; a passing test means the TOML pack reproduces
+    // them character-for-character.
+    //
+    // Use the helpers below to add new matrix points: build a prompt
+    // with the desired (age, intent, engagement, with_passages,
+    // with_summary, with_retrieved) tuple and assert the substring
+    // markers appear / don't appear as expected. The full-text snapshot
+    // (`snapshot_canonical_prompt_locks_full_text`) keeps every byte of
+    // one canonical scenario locked.
+
+    fn snapshot_learner(age: u8, engagement: EngagementState) -> LearnerModel {
+        LearnerModel {
+            profile: LearnerProfile {
+                id: Uuid::nil(),
+                name: "Tester".to_string(),
+                age,
+                languages: vec!["en".to_string()],
+                locale: primer_core::i18n::Locale::English,
+                created_at: Utc::now(),
+                last_active: Utc::now(),
+            },
+            concepts: vec![],
+            preferences: LearningPreferences::default(),
+            current_engagement: engagement,
+            recent_assessments: vec![],
+        }
+    }
+
+    fn snapshot_passage() -> primer_core::knowledge::Passage {
+        primer_core::knowledge::Passage {
+            id: "test-id".to_string(),
+            source: "test-source".to_string(),
+            text: "Test passage body.".to_string(),
+            score: 1.0,
+        }
+    }
+
+    #[test]
+    fn snapshot_basic_socratic_question_for_8_year_old() {
+        let learner = snapshot_learner(8, EngagementState::Engaged);
+        let session = empty_session();
+        let prompt = build_prompt(
+            &learner,
+            &session,
+            PedagogicalIntent::SocraticQuestion,
+            &[],
+            "",
+            &[],
+            20,
+        );
+        // Markers from the base block.
+        assert!(prompt.system.starts_with("You are the Primer"));
+        assert!(prompt.system.contains("named Tester, age 8"));
+        // The 7-9 age band's signature line.
+        assert!(prompt.system.contains("primary school"));
+        assert!(
+            prompt
+                .system
+                .contains("Vocabulary discipline (applies at every age):")
+        );
+        // Intent instruction appended exactly once.
+        assert_eq!(
+            prompt.system.matches("guiding question").count(),
+            2,
+            "expected exactly two mentions: one in base principles (\"guiding question\"), one in intent instruction"
+        );
+        // No engagement note, no sections.
+        assert!(!prompt.system.contains("appears frustrated"));
+        assert!(!prompt.system.contains("losing interest"));
+        assert!(!prompt.system.contains("Earlier in this conversation"));
+        assert!(!prompt.system.contains("Relevant prior moments"));
+        assert!(!prompt.system.contains("Relevant factual context"));
+    }
+
+    #[test]
+    fn snapshot_scaffolding_for_5_year_old_with_passages_and_summary() {
+        let learner = snapshot_learner(5, EngagementState::FrustratedStuck);
+        let session = empty_session();
+        let prompt = build_prompt(
+            &learner,
+            &session,
+            PedagogicalIntent::Scaffolding,
+            &[snapshot_passage()],
+            "Earlier we explored gravity.",
+            &[child_turn("we talked about lightning", vec![])],
+            20,
+        );
+        // 0-6 age band signature line.
+        assert!(prompt.system.contains("kindergarten"));
+        // Frustrated note present.
+        assert!(prompt.system.contains("appears frustrated"));
+        // Scaffolding intent.
+        assert!(prompt.system.contains("offer a concrete"));
+        assert!(prompt.system.contains("Reduce the abstraction"));
+        // All three optional sections present.
+        assert!(prompt.system.contains("Earlier in this conversation"));
+        assert!(prompt.system.contains("Relevant prior moments"));
+        assert!(prompt.system.contains("Relevant factual context"));
+        assert!(prompt.system.contains("rephrase for a 5-year-old"));
+        assert!(prompt.system.contains("[Source: test-source]"));
+        assert!(prompt.system.contains("[Child]"));
+    }
+
+    #[test]
+    fn snapshot_extension_for_15_year_old() {
+        let learner = snapshot_learner(15, EngagementState::Engaged);
+        let session = empty_session();
+        let prompt = build_prompt(
+            &learner,
+            &session,
+            PedagogicalIntent::Extension,
+            &[],
+            "",
+            &[],
+            20,
+        );
+        // 13+ age band.
+        assert!(prompt.system.contains("Adult-level vocabulary"));
+        assert!(prompt.system.contains("articulate teenager"));
+        // Extension instruction.
+        assert!(prompt.system.contains("introduce a complication"));
+        assert!(prompt.system.contains("counterexample"));
+    }
+
+    #[test]
+    fn snapshot_disengaging_for_11_year_old() {
+        let learner = snapshot_learner(11, EngagementState::Disengaging);
+        let session = empty_session();
+        let prompt = build_prompt(
+            &learner,
+            &session,
+            PedagogicalIntent::SessionClose,
+            &[],
+            "",
+            &[],
+            20,
+        );
+        // 10-12 age band.
+        assert!(prompt.system.contains("moderate sentence length"));
+        // Disengaging note.
+        assert!(prompt.system.contains("losing interest"));
+        // SessionClose intent.
+        assert!(prompt.system.contains("good stopping point"));
+        assert!(prompt.system.contains("explored today"));
+    }
+
+    /// Full-text snapshot. The exact bytes of this rendered prompt
+    /// are the regression boundary — any change to `en.toml` or the
+    /// renderer that alters this output will fail this test loudly.
+    #[test]
+    fn snapshot_canonical_prompt_locks_full_text() {
+        let learner = snapshot_learner(8, EngagementState::Engaged);
+        let session = empty_session();
+        let prompt = build_prompt(
+            &learner,
+            &session,
+            PedagogicalIntent::SocraticQuestion,
+            &[],
+            "",
+            &[],
+            20,
+        );
+        let want = "You are the Primer — a patient, curious, Socratic learning companion for a child named Tester, age 8.\n\nYour core principles:\n- NEVER give a direct answer when you can ask a guiding question instead.\n- Ask questions that lead Tester toward discovering the answer themselves.\n- When Tester answers, assess whether they genuinely understand or are guessing/parroting.\n- If they understand: acknowledge it, then extend — \"Good. Now what if...?\"\n- If they're struggling: offer a concrete example, analogy, or story. Reduce abstraction.\n- If they ask a pure factual question (\"How far is the moon?\"): answer it directly, THEN pivot to a Socratic follow-up (\"Now that you know it's 384,000 km, how long would it take to drive there?\").\n- Be warm. Be patient. Never condescend. Treat every question as worthy.\n- You are NOT trying to keep Tester engaged. If they want to stop, let them stop. Say \"That's enough for today\" without guilt.\n- You do not use emojis or exclamation marks excessively.\n\nLanguage for a 8-year-old — read carefully:\n- Use everyday words a young child uses at home or in primary school.\n- Short, clear sentences — usually 8 to 15 words. Break longer thoughts into separate sentences.\n- Common everyday words only. Treat words like \"molecule\", \"plasma\", \"conductor\", \"insulator\", \"vibration\", \"shockwave\", \"eardrum\", \"pressure wave\", \"electron\" as TECHNICAL — they require the plain-language introduction described in the Vocabulary discipline section below.\n- Anchor abstract ideas to something the child can see, touch, or do — kitchen, playground, bath, bed, pets, family — before introducing the abstract version.\n- It is better to say something twice in plain words than once correctly with a hard word.\n\nVocabulary discipline (applies at every age):\n- Before using any technical or unusual word (examples at this age: \"plasma\", \"molecule\", \"conductor\", \"insulator\", \"shockwave\", \"vibration\", \"frequency\", \"voltage\", \"current\", \"atom\", \"particle\"), first explain the idea in plain everyday words using a concrete analogy Tester already knows (food, toys, animals, weather, family, body). Only use the technical word once the plain-language idea is clear — and even then, the technical word is optional, never required.\n- If Tester asks \"what does X mean?\" (like asking what \"repel\" means), that is a signal that X was introduced too soon. First, explain X in plain everyday words. For the next sentence or two, use the plain-language version on its own. Then start weaving X back in alongside the plain meaning (\"the air pushes the charges away — it repels them\"), so Tester ends the conversation having *gained* the new word, not had it taken away. Re-use newly-introduced words a few more times before the session ends — short, casual repetition is how vocabulary actually sticks.\n- One new idea per sentence. If a sentence introduces two unfamiliar things, split it.\n- After two or three sentences of explanation, stop and ask a question. Do not lecture.\n\nYour next response should be a guiding question that leads toward understanding.";
+        if prompt.system != want {
+            // Print a diagnostic: first divergence + lengths.
+            let got = prompt.system.as_str();
+            let mut idx = 0;
+            for (g, w) in got.bytes().zip(want.bytes()) {
+                if g != w {
+                    break;
+                }
+                idx += 1;
+            }
+            panic!(
+                "canonical snapshot diverged at byte {idx}; got len={}, want len={}\n--- want[..idx+40] ---\n{:?}\n--- got[..idx+40]  ---\n{:?}",
+                got.len(),
+                want.len(),
+                &want
+                    .get(..idx.min(want.len()).saturating_add(40).min(want.len()))
+                    .unwrap_or(""),
+                &got.get(..idx.min(got.len()).saturating_add(40).min(got.len()))
+                    .unwrap_or(""),
+            );
+        }
     }
 
     #[test]

--- a/src/crates/primer-pedagogy/src/prompt_builder.rs
+++ b/src/crates/primer-pedagogy/src/prompt_builder.rs
@@ -23,9 +23,15 @@ use crate::prompt_pack::{self, PromptPack};
 /// dialogue manager constructs and threads its own locale-specific
 /// pack through `*_with_pack` variants instead of consulting this
 /// singleton — same code, different entry point.
+///
+/// Lifetime note: the `Arc<dyn PromptPack>` lives in a function-scoped
+/// `static`, so it has `'static` lifetime. `Arc::as_ref` returns a
+/// reference whose lifetime is tied to the `Arc`'s — here, also
+/// `'static`. The returned `&dyn PromptPack` is therefore safe to hand
+/// to call sites that don't retain the `Arc`.
 fn english_pack() -> &'static dyn PromptPack {
     static CELL: OnceLock<std::sync::Arc<dyn PromptPack>> = OnceLock::new();
-    CELL.get_or_init(|| prompt_pack::load(Locale::English).expect("english pack loads"))
+    CELL.get_or_init(|| prompt_pack::load_cached(Locale::English).expect("english pack loads"))
         .as_ref()
 }
 
@@ -911,6 +917,68 @@ mod tests {
         // "why" forms are deliberately left out — Socratic-richer.
         assert!(!is_factual_question("why is the sky blue"));
         assert!(!is_factual_question("why does it rain"));
+    }
+
+    /// Locales whose pack ships `factual_prefixes = []` opt out of the
+    /// prefix-matching short-circuit; `is_factual_question_with_pack`
+    /// must return `false` for every input so `decide_intent` falls
+    /// through to the LLM-based engagement classifier.
+    #[test]
+    fn is_factual_question_with_pack_returns_false_for_empty_prefix_list() {
+        use crate::prompt_pack::TomlPromptPack;
+        // Synthetic pack with `factual_prefixes = []` — represents a
+        // future locale (e.g. Japanese) where prefix matching doesn't
+        // apply.
+        let body = r#"
+[meta]
+language = "en"
+language_name = "English"
+bcp47 = "en-US"
+
+[system_prompt]
+base = "x"
+
+[language_guidance]
+ages_0_6 = ""
+ages_7_9 = ""
+ages_10_12 = ""
+ages_13_plus = ""
+
+[intent]
+socratic_question = "x"
+comprehension_check = "x"
+scaffolding = "x"
+encouragement = "x"
+extension = "x"
+direct_answer = "x"
+answer_then_pivot = "x"
+session_close = "x"
+
+[engagement]
+frustrated = ""
+disengaging = ""
+
+[sections]
+knowledge_intro = ""
+summary_intro = ""
+retrieved_intro = ""
+
+[labels]
+child = "Child"
+primer = "Primer"
+
+[question_detection]
+factual_prefixes = []
+"#;
+        let pack = TomlPromptPack::from_toml_str(Locale::English, body)
+            .expect("synthetic pack with empty prefixes loads");
+        // Inputs that the English pack would classify as factual must
+        // now return false because the prefix list is empty.
+        assert!(!is_factual_question_with_pack(&pack, "what is gravity?"));
+        assert!(!is_factual_question_with_pack(&pack, "how does it work"));
+        // And ordinary inputs still return false.
+        assert!(!is_factual_question_with_pack(&pack, "why is the sky blue"));
+        assert!(!is_factual_question_with_pack(&pack, ""));
     }
 
     #[test]

--- a/src/crates/primer-pedagogy/src/prompt_pack.rs
+++ b/src/crates/primer-pedagogy/src/prompt_pack.rs
@@ -1,0 +1,617 @@
+//! Prompt pack loader.
+//!
+//! A `PromptPack` is the per-locale source of truth for every piece of
+//! pedagogical text the Primer sends to the LLM: the base system prompt,
+//! the per-intent instructions, age-banded language guidance, engagement
+//! notes, knowledge / memory section intros, speaker labels, and the
+//! factual-prefix list used by `decide_intent` to route direct-lookup
+//! questions.
+//!
+//! The English pack (`prompts/en.toml`) is the reference. Adding a new
+//! locale means: add the variant to `primer_core::i18n::Locale`, add a
+//! `prompts/<pack_id>.toml` file, extend the `embedded_pack` dispatch,
+//! and translate the prompts natively (not mechanically — the prompts
+//! encode pedagogy, not just words).
+//!
+//! Loading: by default packs are embedded at compile time via
+//! `include_str!`. Setting `PRIMER_PROMPTS_DIR=<dir>` makes `load()`
+//! read `<dir>/<pack_id>.toml` from disk instead — useful for translator
+//! iteration without recompilation.
+//!
+//! Validation: every field is scanned at load time for unknown
+//! `{placeholder}` tokens. A typo (`{nme}` instead of `{name}`) is a
+//! loud panic at startup, never a silent malformed prompt at runtime.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use primer_core::conversation::PedagogicalIntent;
+use primer_core::error::{PrimerError, Result};
+use primer_core::i18n::Locale;
+use primer_core::learner::EngagementState;
+use serde::Deserialize;
+
+/// The trait the prompt builder consumes. All methods are infallible
+/// reads against an already-validated pack.
+pub trait PromptPack: Send + Sync {
+    fn locale(&self) -> Locale;
+    /// Render the base system prompt with `{name}`, `{age}`, and
+    /// `{language_guidance}` substituted. The `language_guidance` is
+    /// itself selected from the pack via `language_guidance(age)`.
+    fn render_base(&self, name: &str, age: u8) -> String;
+    /// Per-intent next-step instruction. Empty key is a hard error at
+    /// load time, so this never returns the empty string.
+    fn intent_instruction(&self, intent: PedagogicalIntent) -> &str;
+    /// Note appended for frustrated / disengaging states. Returns `""`
+    /// (with no leading separator) for states that have no note —
+    /// the caller decides whether to prepend `"\n\n"`.
+    fn engagement_note(&self, state: EngagementState) -> &str;
+    /// Single-line intro for the RAG passages section, with `{age}`
+    /// substituted. The body is appended by the caller.
+    fn knowledge_intro(&self, age: u8) -> String;
+    fn summary_intro(&self) -> &str;
+    fn retrieved_intro(&self) -> &str;
+    fn child_label(&self) -> &str;
+    fn primer_label(&self) -> &str;
+    /// Lowercased prefixes that mark a child's input as a direct
+    /// factual lookup. Empty for locales (e.g. Japanese) where prefix
+    /// matching doesn't apply — `decide_intent` falls back to the
+    /// LLM-based classifier in that case.
+    fn factual_prefixes(&self) -> &[String];
+}
+
+/// English pack embedded at compile time so a binary can ship without
+/// any data files alongside it. Override at runtime via
+/// `PRIMER_PROMPTS_DIR`.
+const EN_TOML: &str = include_str!("../prompts/en.toml");
+
+fn embedded_pack(locale: Locale) -> &'static str {
+    match locale {
+        Locale::English => EN_TOML,
+    }
+}
+
+/// Load the prompt pack for `locale`.
+///
+/// Lookup order:
+/// 1. If `PRIMER_PROMPTS_DIR` is set, read `<dir>/<pack_id>.toml`.
+/// 2. Otherwise, parse the compile-time-embedded pack.
+///
+/// Panics on placeholder validation failure (loud-at-startup); returns
+/// `Err` on I/O or TOML-parse failures.
+pub fn load(locale: Locale) -> Result<Arc<dyn PromptPack>> {
+    let raw = match std::env::var("PRIMER_PROMPTS_DIR") {
+        Ok(dir) => {
+            let path = std::path::Path::new(&dir).join(format!("{}.toml", locale.pack_id()));
+            std::fs::read_to_string(&path).map_err(|e| {
+                PrimerError::Config(format!(
+                    "PRIMER_PROMPTS_DIR set but {} could not be read: {e}",
+                    path.display()
+                ))
+            })?
+        }
+        Err(_) => embedded_pack(locale).to_string(),
+    };
+    let pack = TomlPromptPack::from_toml_str(locale, &raw)?;
+    Ok(Arc::new(pack))
+}
+
+/// `TomlPromptPack` is the only `PromptPack` impl shipped today; the
+/// trait exists so a future test or experiment can substitute a
+/// hand-built pack without touching the loader.
+pub struct TomlPromptPack {
+    locale: Locale,
+    base_template: String,
+    language_guidance: LanguageGuidanceBands,
+    /// Indexed by `intent_index(intent)` — fixed size = `ALL_INTENTS.len()`.
+    /// Built once at load time so per-call lookup is O(1) without
+    /// requiring `Hash` on `PedagogicalIntent`.
+    intents: [String; ALL_INTENTS.len()],
+    engagement_frustrated: String,
+    engagement_disengaging: String,
+    knowledge_intro_template: String,
+    summary_intro: String,
+    retrieved_intro: String,
+    child_label: String,
+    primer_label: String,
+    factual_prefixes: Vec<String>,
+}
+
+impl TomlPromptPack {
+    /// Parse a TOML pack body and validate placeholders. Used by the
+    /// loader and by tests that want to inject a synthetic pack.
+    pub fn from_toml_str(locale: Locale, body: &str) -> Result<Self> {
+        let raw: PackFile = toml::from_str(body)
+            .map_err(|e| PrimerError::Config(format!("prompt pack: parse failed: {e}")))?;
+
+        // Per-field placeholder allowlists. A typo here panics with the
+        // field name and offending token so a broken pack fails loudly
+        // at startup rather than producing malformed prompts at runtime.
+        validate_placeholders(
+            "system_prompt.base",
+            &raw.system_prompt.base,
+            &["name", "age", "language_guidance"],
+        );
+        validate_placeholders(
+            "language_guidance.ages_0_6",
+            &raw.language_guidance.ages_0_6,
+            &[],
+        );
+        validate_placeholders(
+            "language_guidance.ages_7_9",
+            &raw.language_guidance.ages_7_9,
+            &[],
+        );
+        validate_placeholders(
+            "language_guidance.ages_10_12",
+            &raw.language_guidance.ages_10_12,
+            &[],
+        );
+        validate_placeholders(
+            "language_guidance.ages_13_plus",
+            &raw.language_guidance.ages_13_plus,
+            &[],
+        );
+        for (key, value) in &raw.intent {
+            validate_placeholders(&format!("intent.{key}"), value, &[]);
+        }
+        validate_placeholders("engagement.frustrated", &raw.engagement.frustrated, &[]);
+        validate_placeholders("engagement.disengaging", &raw.engagement.disengaging, &[]);
+        validate_placeholders(
+            "sections.knowledge_intro",
+            &raw.sections.knowledge_intro,
+            &["age"],
+        );
+        validate_placeholders("sections.summary_intro", &raw.sections.summary_intro, &[]);
+        validate_placeholders(
+            "sections.retrieved_intro",
+            &raw.sections.retrieved_intro,
+            &[],
+        );
+        validate_placeholders("labels.child", &raw.labels.child, &[]);
+        validate_placeholders("labels.primer", &raw.labels.primer, &[]);
+
+        // Stage the parsed intent strings keyed by canonical name so we
+        // can validate completeness before materialising the indexed
+        // array. A `BTreeMap<&str, String>` keeps ordering deterministic
+        // for the missing-key error message (helpful for translators).
+        let mut staged: BTreeMap<String, String> = BTreeMap::new();
+        for (key, value) in raw.intent {
+            if parse_intent_key(&key).is_none() {
+                return Err(PrimerError::Config(format!(
+                    "prompt pack: unknown intent key '{key}'"
+                )));
+            }
+            staged.insert(key, value);
+        }
+        let intents: [String; ALL_INTENTS.len()] = {
+            let mut arr: [String; ALL_INTENTS.len()] = Default::default();
+            for (i, variant) in ALL_INTENTS.iter().enumerate() {
+                let key = intent_key(*variant);
+                match staged.get(key) {
+                    Some(v) => arr[i] = v.clone(),
+                    None => {
+                        return Err(PrimerError::Config(format!(
+                            "prompt pack: missing intent '{key}'"
+                        )));
+                    }
+                }
+            }
+            arr
+        };
+
+        Ok(Self {
+            locale,
+            base_template: raw.system_prompt.base,
+            language_guidance: raw.language_guidance,
+            intents,
+            engagement_frustrated: raw.engagement.frustrated,
+            engagement_disengaging: raw.engagement.disengaging,
+            knowledge_intro_template: raw.sections.knowledge_intro,
+            summary_intro: raw.sections.summary_intro,
+            retrieved_intro: raw.sections.retrieved_intro,
+            child_label: raw.labels.child,
+            primer_label: raw.labels.primer,
+            factual_prefixes: raw.question_detection.factual_prefixes,
+        })
+    }
+
+    fn language_guidance(&self, age: u8) -> &str {
+        match age {
+            0..=6 => &self.language_guidance.ages_0_6,
+            7..=9 => &self.language_guidance.ages_7_9,
+            10..=12 => &self.language_guidance.ages_10_12,
+            _ => &self.language_guidance.ages_13_plus,
+        }
+    }
+}
+
+impl PromptPack for TomlPromptPack {
+    fn locale(&self) -> Locale {
+        self.locale
+    }
+
+    fn render_base(&self, name: &str, age: u8) -> String {
+        // Order matters: substitute `{language_guidance}` first because
+        // the band text might (in principle) contain `{age}` (none of
+        // the English bands do today, but this keeps semantics stable
+        // if a future pack adds one).
+        let lg = self.language_guidance(age);
+        let age_str = age.to_string();
+        self.base_template
+            .replace("{language_guidance}", lg)
+            .replace("{name}", name)
+            .replace("{age}", &age_str)
+    }
+
+    fn intent_instruction(&self, intent: PedagogicalIntent) -> &str {
+        &self.intents[intent_index(intent)]
+    }
+
+    fn engagement_note(&self, state: EngagementState) -> &str {
+        match state {
+            EngagementState::FrustratedStuck | EngagementState::FrustratedTrying => {
+                &self.engagement_frustrated
+            }
+            EngagementState::Disengaging => &self.engagement_disengaging,
+            _ => "",
+        }
+    }
+
+    fn knowledge_intro(&self, age: u8) -> String {
+        self.knowledge_intro_template
+            .replace("{age}", &age.to_string())
+    }
+
+    fn summary_intro(&self) -> &str {
+        &self.summary_intro
+    }
+    fn retrieved_intro(&self) -> &str {
+        &self.retrieved_intro
+    }
+    fn child_label(&self) -> &str {
+        &self.child_label
+    }
+    fn primer_label(&self) -> &str {
+        &self.primer_label
+    }
+    fn factual_prefixes(&self) -> &[String] {
+        &self.factual_prefixes
+    }
+}
+
+// ─── Raw TOML deserialisation types ─────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct PackFile {
+    #[allow(dead_code)]
+    meta: MetaSection,
+    system_prompt: SystemPromptSection,
+    language_guidance: LanguageGuidanceBands,
+    intent: BTreeMap<String, String>,
+    engagement: EngagementSection,
+    sections: SectionsSection,
+    labels: LabelsSection,
+    question_detection: QuestionDetectionSection,
+}
+
+#[derive(Deserialize)]
+struct MetaSection {
+    #[allow(dead_code)]
+    language: String,
+    #[allow(dead_code)]
+    language_name: String,
+    #[allow(dead_code)]
+    bcp47: String,
+}
+
+#[derive(Deserialize)]
+struct SystemPromptSection {
+    base: String,
+}
+
+#[derive(Deserialize)]
+struct LanguageGuidanceBands {
+    ages_0_6: String,
+    ages_7_9: String,
+    ages_10_12: String,
+    ages_13_plus: String,
+}
+
+#[derive(Deserialize)]
+struct EngagementSection {
+    frustrated: String,
+    disengaging: String,
+}
+
+#[derive(Deserialize)]
+struct SectionsSection {
+    knowledge_intro: String,
+    summary_intro: String,
+    retrieved_intro: String,
+}
+
+#[derive(Deserialize)]
+struct LabelsSection {
+    child: String,
+    primer: String,
+}
+
+#[derive(Deserialize)]
+struct QuestionDetectionSection {
+    factual_prefixes: Vec<String>,
+}
+
+// ─── Intent key mapping ─────────────────────────────────────────────────────
+
+const ALL_INTENTS: &[PedagogicalIntent] = &[
+    PedagogicalIntent::SocraticQuestion,
+    PedagogicalIntent::ComprehensionCheck,
+    PedagogicalIntent::Scaffolding,
+    PedagogicalIntent::Encouragement,
+    PedagogicalIntent::Extension,
+    PedagogicalIntent::DirectAnswer,
+    PedagogicalIntent::AnswerThenPivot,
+    PedagogicalIntent::SessionClose,
+];
+
+fn intent_key(intent: PedagogicalIntent) -> &'static str {
+    match intent {
+        PedagogicalIntent::SocraticQuestion => "socratic_question",
+        PedagogicalIntent::ComprehensionCheck => "comprehension_check",
+        PedagogicalIntent::Scaffolding => "scaffolding",
+        PedagogicalIntent::Encouragement => "encouragement",
+        PedagogicalIntent::Extension => "extension",
+        PedagogicalIntent::DirectAnswer => "direct_answer",
+        PedagogicalIntent::AnswerThenPivot => "answer_then_pivot",
+        PedagogicalIntent::SessionClose => "session_close",
+    }
+}
+
+/// Position of `intent` in `ALL_INTENTS`. Used as the array index for
+/// the typed-but-non-Hash lookup table inside `TomlPromptPack`.
+fn intent_index(intent: PedagogicalIntent) -> usize {
+    ALL_INTENTS
+        .iter()
+        .position(|v| *v == intent)
+        .expect("ALL_INTENTS covers every PedagogicalIntent variant")
+}
+
+fn parse_intent_key(s: &str) -> Option<PedagogicalIntent> {
+    ALL_INTENTS.iter().find(|v| intent_key(**v) == s).copied()
+}
+
+// ─── Placeholder validation ─────────────────────────────────────────────────
+
+/// Scan `content` for `{ident}` placeholders and panic if any token is
+/// not in `allowed`. Identifier rule: ASCII alpha or `_` first char,
+/// then ASCII alphanumeric or `_`. Anything else inside `{...}`
+/// (e.g. `{Hello, world}`) is left alone — translators can use brace
+/// characters in narrative text without false positives.
+fn validate_placeholders(field: &str, content: &str, allowed: &[&str]) {
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && bytes[end] != b'}' {
+                end += 1;
+            }
+            if end < bytes.len() {
+                let token = &content[start..end];
+                if is_placeholder_ident(token) && !allowed.contains(&token) {
+                    panic!(
+                        "prompt pack: field {field} contains unknown placeholder {{{token}}}; allowed: {allowed:?}"
+                    );
+                }
+                i = end + 1;
+            } else {
+                break;
+            }
+        } else {
+            i += 1;
+        }
+    }
+}
+
+fn is_placeholder_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn english_pack() -> Arc<dyn PromptPack> {
+        load(Locale::English).expect("english pack loads")
+    }
+
+    #[test]
+    fn english_pack_loads_from_embedded_toml() {
+        let pack = english_pack();
+        assert_eq!(pack.locale(), Locale::English);
+        assert_eq!(pack.child_label(), "Child");
+        assert_eq!(pack.primer_label(), "Primer");
+    }
+
+    #[test]
+    fn english_pack_renders_base_with_name_and_age() {
+        let pack = english_pack();
+        let s = pack.render_base("Tester", 8);
+        assert!(s.contains("named Tester"), "got: {s}");
+        assert!(s.contains("age 8"), "got: {s}");
+        assert!(
+            !s.contains("{name}") && !s.contains("{age}") && !s.contains("{language_guidance}"),
+            "all placeholders substituted: {s}"
+        );
+    }
+
+    #[test]
+    fn english_pack_age_band_selection() {
+        let pack = english_pack();
+        assert!(pack.render_base("X", 5).contains("kindergarten"));
+        assert!(pack.render_base("X", 8).contains("primary school"));
+        assert!(
+            pack.render_base("X", 11)
+                .contains("moderate sentence length")
+        );
+        assert!(pack.render_base("X", 15).contains("Adult-level vocabulary"));
+    }
+
+    #[test]
+    fn english_pack_intent_lookups() {
+        let pack = english_pack();
+        for &intent in ALL_INTENTS {
+            assert!(
+                !pack.intent_instruction(intent).is_empty(),
+                "missing instruction for {intent:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn english_pack_engagement_notes() {
+        let pack = english_pack();
+        assert!(
+            pack.engagement_note(EngagementState::FrustratedStuck)
+                .contains("frustrated")
+        );
+        assert!(
+            pack.engagement_note(EngagementState::FrustratedTrying)
+                .contains("frustrated")
+        );
+        assert!(
+            pack.engagement_note(EngagementState::Disengaging)
+                .contains("losing interest")
+        );
+        assert!(pack.engagement_note(EngagementState::Engaged).is_empty());
+        assert!(pack.engagement_note(EngagementState::Reflecting).is_empty());
+        assert!(pack.engagement_note(EngagementState::Unknown).is_empty());
+    }
+
+    #[test]
+    fn english_pack_knowledge_intro_substitutes_age() {
+        let pack = english_pack();
+        let s = pack.knowledge_intro(8);
+        assert!(s.contains("8-year-old"), "got: {s}");
+        assert!(!s.contains("{age}"));
+    }
+
+    #[test]
+    fn english_pack_factual_prefixes_match_legacy_list() {
+        let pack = english_pack();
+        let want: &[&str] = &[
+            "what is ",
+            "what are ",
+            "what's ",
+            "what does ",
+            "how does ",
+            "how do ",
+            "how is ",
+            "how are ",
+        ];
+        let got: Vec<&str> = pack.factual_prefixes().iter().map(String::as_str).collect();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown placeholder")]
+    fn unknown_placeholder_in_base_is_a_loud_panic() {
+        let body = format!(
+            r#"
+[meta]
+language = "en"
+language_name = "English"
+bcp47 = "en-US"
+
+[system_prompt]
+base = "Hello {{nme}}, age {{age}}.\n{{language_guidance}}"
+
+[language_guidance]
+ages_0_6 = ""
+ages_7_9 = ""
+ages_10_12 = ""
+ages_13_plus = ""
+
+[intent]
+{INTENT_KEYS}
+
+[engagement]
+frustrated = ""
+disengaging = ""
+
+[sections]
+knowledge_intro = ""
+summary_intro = ""
+retrieved_intro = ""
+
+[labels]
+child = "Child"
+primer = "Primer"
+
+[question_detection]
+factual_prefixes = []
+"#,
+            INTENT_KEYS = all_intents_zeroed_toml(),
+        );
+        let _ = TomlPromptPack::from_toml_str(Locale::English, &body);
+    }
+
+    #[test]
+    fn missing_intent_variant_returns_err() {
+        // Build a pack body that omits one intent key.
+        let body = r#"
+[meta]
+language = "en"
+language_name = "English"
+bcp47 = "en-US"
+
+[system_prompt]
+base = "x"
+
+[language_guidance]
+ages_0_6 = ""
+ages_7_9 = ""
+ages_10_12 = ""
+ages_13_plus = ""
+
+[intent]
+socratic_question = "x"
+
+[engagement]
+frustrated = ""
+disengaging = ""
+
+[sections]
+knowledge_intro = ""
+summary_intro = ""
+retrieved_intro = ""
+
+[labels]
+child = "Child"
+primer = "Primer"
+
+[question_detection]
+factual_prefixes = []
+"#;
+        let result = TomlPromptPack::from_toml_str(Locale::English, body);
+        let err = result.err().expect("expected missing-intent error");
+        assert!(format!("{err}").contains("missing intent"), "got: {err}");
+    }
+
+    fn all_intents_zeroed_toml() -> String {
+        let mut out = String::new();
+        for &i in ALL_INTENTS {
+            out.push_str(&format!("{} = \"x\"\n", intent_key(i)));
+        }
+        out
+    }
+}

--- a/src/crates/primer-pedagogy/src/prompt_pack.rs
+++ b/src/crates/primer-pedagogy/src/prompt_pack.rs
@@ -19,11 +19,14 @@
 //! iteration without recompilation.
 //!
 //! Validation: every field is scanned at load time for unknown
-//! `{placeholder}` tokens. A typo (`{nme}` instead of `{name}`) is a
-//! loud panic at startup, never a silent malformed prompt at runtime.
+//! `{placeholder}` tokens. A typo (`{nme}` instead of `{name}`) returns
+//! a `PrimerError::Config` from `load`, surfacing as a loud startup
+//! failure rather than a silent malformed prompt at runtime. The same
+//! treatment applies to missing-intent and meta-inconsistency errors —
+//! every pack-shape problem is a single error variant.
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use primer_core::conversation::PedagogicalIntent;
 use primer_core::error::{PrimerError, Result};
@@ -71,14 +74,19 @@ fn embedded_pack(locale: Locale) -> &'static str {
     }
 }
 
-/// Load the prompt pack for `locale`.
+/// Load the prompt pack for `locale`, freshly parsing every call.
 ///
 /// Lookup order:
 /// 1. If `PRIMER_PROMPTS_DIR` is set, read `<dir>/<pack_id>.toml`.
 /// 2. Otherwise, parse the compile-time-embedded pack.
 ///
-/// Panics on placeholder validation failure (loud-at-startup); returns
-/// `Err` on I/O or TOML-parse failures.
+/// Returns `Err` on I/O failure, TOML-parse failure, placeholder
+/// validation failure, missing-intent variants, or meta-inconsistency
+/// against `Locale`'s projections. All pack-shape errors are surfaced as
+/// `PrimerError::Config` so a broken pack fails loudly at startup.
+///
+/// Use [`load_cached`] for the production hot path; reserve `load` for
+/// tests and PRIMER_PROMPTS_DIR-driven translator iteration.
 pub fn load(locale: Locale) -> Result<Arc<dyn PromptPack>> {
     let raw = match std::env::var("PRIMER_PROMPTS_DIR") {
         Ok(dir) => {
@@ -94,6 +102,34 @@ pub fn load(locale: Locale) -> Result<Arc<dyn PromptPack>> {
     };
     let pack = TomlPromptPack::from_toml_str(locale, &raw)?;
     Ok(Arc::new(pack))
+}
+
+/// Load the prompt pack for `locale`, returning a process-wide cached
+/// instance after the first successful load.
+///
+/// When `PRIMER_PROMPTS_DIR` is set the cache is bypassed so translator
+/// iteration sees fresh content on every call. Otherwise every caller
+/// shares the same `Arc<dyn PromptPack>`, sidestepping a per-session
+/// re-parse of the embedded TOML for callers like `DialogueManager::new`
+/// that construct the pack but never need to mutate it.
+pub fn load_cached(locale: Locale) -> Result<Arc<dyn PromptPack>> {
+    // PRIMER_PROMPTS_DIR is the translator-iteration escape hatch; honour
+    // it by bypassing the cache so a re-saved TOML file is reflected on
+    // the next `load_cached` call.
+    if std::env::var_os("PRIMER_PROMPTS_DIR").is_some() {
+        return load(locale);
+    }
+    static EN_PACK: OnceLock<Arc<dyn PromptPack>> = OnceLock::new();
+    match locale {
+        Locale::English => {
+            if let Some(p) = EN_PACK.get() {
+                return Ok(Arc::clone(p));
+            }
+            let p = load(locale)?;
+            let _ = EN_PACK.set(Arc::clone(&p));
+            Ok(p)
+        }
+    }
 }
 
 /// `TomlPromptPack` is the only `PromptPack` impl shipped today; the
@@ -124,52 +160,84 @@ impl TomlPromptPack {
         let raw: PackFile = toml::from_str(body)
             .map_err(|e| PrimerError::Config(format!("prompt pack: parse failed: {e}")))?;
 
-        // Per-field placeholder allowlists. A typo here panics with the
-        // field name and offending token so a broken pack fails loudly
-        // at startup rather than producing malformed prompts at runtime.
+        // Cross-check the file's metadata against the Rust enum's
+        // projections. The `Locale` enum is the single source of truth
+        // for language id, display name, and BCP-47 tag; the TOML file
+        // duplicates them as documentation for translators. A mismatch
+        // is a structural pack error — fail loudly at load time rather
+        // than letting a stale `[meta]` block drift silently.
+        if raw.meta.language != locale.pack_id() {
+            return Err(PrimerError::Config(format!(
+                "prompt pack: meta.language {:?} does not match Locale::{:?}.pack_id() {:?}",
+                raw.meta.language,
+                locale,
+                locale.pack_id()
+            )));
+        }
+        if raw.meta.language_name != locale.name() {
+            return Err(PrimerError::Config(format!(
+                "prompt pack: meta.language_name {:?} does not match Locale::{:?}.name() {:?}",
+                raw.meta.language_name,
+                locale,
+                locale.name()
+            )));
+        }
+        if raw.meta.bcp47 != locale.bcp47() {
+            return Err(PrimerError::Config(format!(
+                "prompt pack: meta.bcp47 {:?} does not match Locale::{:?}.bcp47() {:?}",
+                raw.meta.bcp47,
+                locale,
+                locale.bcp47()
+            )));
+        }
+
+        // Per-field placeholder allowlists. A typo here returns Err
+        // with the field name and offending token so a broken pack
+        // fails loudly at startup rather than producing malformed
+        // prompts at runtime.
         validate_placeholders(
             "system_prompt.base",
             &raw.system_prompt.base,
             &["name", "age", "language_guidance"],
-        );
+        )?;
         validate_placeholders(
             "language_guidance.ages_0_6",
             &raw.language_guidance.ages_0_6,
             &[],
-        );
+        )?;
         validate_placeholders(
             "language_guidance.ages_7_9",
             &raw.language_guidance.ages_7_9,
             &[],
-        );
+        )?;
         validate_placeholders(
             "language_guidance.ages_10_12",
             &raw.language_guidance.ages_10_12,
             &[],
-        );
+        )?;
         validate_placeholders(
             "language_guidance.ages_13_plus",
             &raw.language_guidance.ages_13_plus,
             &[],
-        );
+        )?;
         for (key, value) in &raw.intent {
-            validate_placeholders(&format!("intent.{key}"), value, &[]);
+            validate_placeholders(&format!("intent.{key}"), value, &[])?;
         }
-        validate_placeholders("engagement.frustrated", &raw.engagement.frustrated, &[]);
-        validate_placeholders("engagement.disengaging", &raw.engagement.disengaging, &[]);
+        validate_placeholders("engagement.frustrated", &raw.engagement.frustrated, &[])?;
+        validate_placeholders("engagement.disengaging", &raw.engagement.disengaging, &[])?;
         validate_placeholders(
             "sections.knowledge_intro",
             &raw.sections.knowledge_intro,
             &["age"],
-        );
-        validate_placeholders("sections.summary_intro", &raw.sections.summary_intro, &[]);
+        )?;
+        validate_placeholders("sections.summary_intro", &raw.sections.summary_intro, &[])?;
         validate_placeholders(
             "sections.retrieved_intro",
             &raw.sections.retrieved_intro,
             &[],
-        );
-        validate_placeholders("labels.child", &raw.labels.child, &[]);
-        validate_placeholders("labels.primer", &raw.labels.primer, &[]);
+        )?;
+        validate_placeholders("labels.child", &raw.labels.child, &[])?;
+        validate_placeholders("labels.primer", &raw.labels.primer, &[])?;
 
         // Stage the parsed intent strings keyed by canonical name so we
         // can validate completeness before materialising the indexed
@@ -284,7 +352,6 @@ impl PromptPack for TomlPromptPack {
 
 #[derive(Deserialize)]
 struct PackFile {
-    #[allow(dead_code)]
     meta: MetaSection,
     system_prompt: SystemPromptSection,
     language_guidance: LanguageGuidanceBands,
@@ -295,13 +362,14 @@ struct PackFile {
     question_detection: QuestionDetectionSection,
 }
 
+/// File-level documentation for translators. Cross-checked at load time
+/// against `Locale`'s projections — a mismatch is a load error so
+/// translators can't silently let the file's metadata drift away from
+/// the enum.
 #[derive(Deserialize)]
 struct MetaSection {
-    #[allow(dead_code)]
     language: String,
-    #[allow(dead_code)]
     language_name: String,
-    #[allow(dead_code)]
     bcp47: String,
 }
 
@@ -383,12 +451,12 @@ fn parse_intent_key(s: &str) -> Option<PedagogicalIntent> {
 
 // ─── Placeholder validation ─────────────────────────────────────────────────
 
-/// Scan `content` for `{ident}` placeholders and panic if any token is
-/// not in `allowed`. Identifier rule: ASCII alpha or `_` first char,
-/// then ASCII alphanumeric or `_`. Anything else inside `{...}`
+/// Scan `content` for `{ident}` placeholders and return Err if any
+/// token is not in `allowed`. Identifier rule: ASCII alpha or `_` first
+/// char, then ASCII alphanumeric or `_`. Anything else inside `{...}`
 /// (e.g. `{Hello, world}`) is left alone — translators can use brace
 /// characters in narrative text without false positives.
-fn validate_placeholders(field: &str, content: &str, allowed: &[&str]) {
+fn validate_placeholders(field: &str, content: &str, allowed: &[&str]) -> Result<()> {
     let bytes = content.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -401,9 +469,9 @@ fn validate_placeholders(field: &str, content: &str, allowed: &[&str]) {
             if end < bytes.len() {
                 let token = &content[start..end];
                 if is_placeholder_ident(token) && !allowed.contains(&token) {
-                    panic!(
+                    return Err(PrimerError::Config(format!(
                         "prompt pack: field {field} contains unknown placeholder {{{token}}}; allowed: {allowed:?}"
-                    );
+                    )));
                 }
                 i = end + 1;
             } else {
@@ -413,6 +481,7 @@ fn validate_placeholders(field: &str, content: &str, allowed: &[&str]) {
             i += 1;
         }
     }
+    Ok(())
 }
 
 fn is_placeholder_ident(s: &str) -> bool {
@@ -523,8 +592,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unknown placeholder")]
-    fn unknown_placeholder_in_base_is_a_loud_panic() {
+    fn unknown_placeholder_in_base_returns_err() {
         let body = format!(
             r#"
 [meta]
@@ -562,7 +630,12 @@ factual_prefixes = []
 "#,
             INTENT_KEYS = all_intents_zeroed_toml(),
         );
-        let _ = TomlPromptPack::from_toml_str(Locale::English, &body);
+        let result = TomlPromptPack::from_toml_str(Locale::English, &body);
+        let err = result.err().expect("expected unknown-placeholder error");
+        let s = format!("{err}");
+        assert!(s.contains("unknown placeholder"), "got: {s}");
+        assert!(s.contains("system_prompt.base"), "got: {s}");
+        assert!(s.contains("nme"), "got: {s}");
     }
 
     #[test]
@@ -613,5 +686,134 @@ factual_prefixes = []
             out.push_str(&format!("{} = \"x\"\n", intent_key(i)));
         }
         out
+    }
+
+    /// Build a minimal but structurally-valid pack body with overridable
+    /// `[meta]` and `[question_detection]` blocks. Used by the meta-
+    /// consistency and factual-prefix tests.
+    fn synthetic_pack_body(
+        meta_language: &str,
+        meta_language_name: &str,
+        meta_bcp47: &str,
+        factual_prefixes_array: &str,
+    ) -> String {
+        format!(
+            r#"
+[meta]
+language = "{meta_language}"
+language_name = "{meta_language_name}"
+bcp47 = "{meta_bcp47}"
+
+[system_prompt]
+base = "x"
+
+[language_guidance]
+ages_0_6 = ""
+ages_7_9 = ""
+ages_10_12 = ""
+ages_13_plus = ""
+
+[intent]
+{INTENT_KEYS}
+
+[engagement]
+frustrated = ""
+disengaging = ""
+
+[sections]
+knowledge_intro = ""
+summary_intro = ""
+retrieved_intro = ""
+
+[labels]
+child = "Child"
+primer = "Primer"
+
+[question_detection]
+factual_prefixes = {factual_prefixes_array}
+"#,
+            INTENT_KEYS = all_intents_zeroed_toml(),
+        )
+    }
+
+    /// The English pack's `[meta]` block must agree with `Locale::English`
+    /// across all three projections — language id, display name, and
+    /// BCP-47 tag. This is what the meta-consistency check inside
+    /// `from_toml_str` enforces; the test guards the en.toml file in
+    /// the tree against drift.
+    #[test]
+    fn english_pack_meta_matches_locale_projections() {
+        // The successful load is itself the strongest assertion the
+        // file's meta block matches the enum (a mismatch would Err).
+        let pack = english_pack();
+        assert_eq!(pack.locale(), Locale::English);
+        // Spot-check the projections against the canonical values so a
+        // future refactor that drops the load-time check still trips this
+        // test.
+        assert_eq!(Locale::English.pack_id(), "en");
+        assert_eq!(Locale::English.name(), "English");
+        assert_eq!(Locale::English.bcp47(), "en-US");
+    }
+
+    #[test]
+    fn meta_language_mismatch_returns_err() {
+        let body = synthetic_pack_body("zz", "English", "en-US", "[]");
+        let err = TomlPromptPack::from_toml_str(Locale::English, &body)
+            .err()
+            .expect("expected meta.language mismatch error");
+        let s = format!("{err}");
+        assert!(s.contains("meta.language"), "got: {s}");
+    }
+
+    #[test]
+    fn meta_language_name_mismatch_returns_err() {
+        let body = synthetic_pack_body("en", "Englsih", "en-US", "[]");
+        let err = TomlPromptPack::from_toml_str(Locale::English, &body)
+            .err()
+            .expect("expected meta.language_name mismatch error");
+        let s = format!("{err}");
+        assert!(s.contains("meta.language_name"), "got: {s}");
+    }
+
+    #[test]
+    fn meta_bcp47_mismatch_returns_err() {
+        let body = synthetic_pack_body("en", "English", "en-GB", "[]");
+        let err = TomlPromptPack::from_toml_str(Locale::English, &body)
+            .err()
+            .expect("expected meta.bcp47 mismatch error");
+        let s = format!("{err}");
+        assert!(s.contains("meta.bcp47"), "got: {s}");
+    }
+
+    /// Empty `factual_prefixes` round-trips through the loader — locales
+    /// where prefix matching doesn't apply (Japanese particles, Mandarin
+    /// tone-disambiguation) are expected to ship with `factual_prefixes = []`.
+    #[test]
+    fn empty_factual_prefixes_loads_and_disables_prefix_matching() {
+        let body = synthetic_pack_body("en", "English", "en-US", "[]");
+        let pack =
+            TomlPromptPack::from_toml_str(Locale::English, &body).expect("synthetic pack loads");
+        assert!(pack.factual_prefixes().is_empty());
+    }
+
+    /// `load_cached` returns the same `Arc` on repeated calls. PRIMER_
+    /// PROMPTS_DIR-driven test isolation is achieved by NOT setting that
+    /// env var here, so the cache path is exercised.
+    #[test]
+    fn load_cached_returns_same_arc_on_repeated_calls() {
+        // SAFETY: the cache only short-circuits when PRIMER_PROMPTS_DIR
+        // is unset; this test inherits the parent process env and must
+        // not have it set. cargo test inherits a clean env in CI; locally
+        // a developer who has set it is exercising the bypass path on
+        // purpose, so we skip the strict-equality check there.
+        if std::env::var_os("PRIMER_PROMPTS_DIR").is_some() {
+            return;
+        }
+        let a = load_cached(Locale::English).expect("first load_cached");
+        let b = load_cached(Locale::English).expect("second load_cached");
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "load_cached should return the same Arc on repeat calls"
+        );
     }
 }

--- a/src/crates/primer-storage/src/lib.rs
+++ b/src/crates/primer-storage/src/lib.rs
@@ -86,6 +86,11 @@ impl SqliteSessionStore {
         // per-concept comprehension assessments.
         schema::apply_v5_migrations(&conn)?;
 
+        // v6 migrations: idempotent on every open. Adds
+        // learners.locale and concepts.concept_language_tag columns
+        // (default 'en' for pre-v6 rows) for the i18n architecture.
+        schema::apply_v6_migrations(&conn)?;
+
         if existing_version != schema::USER_VERSION {
             conn.execute_batch(&format!("PRAGMA user_version = {};", schema::USER_VERSION))
                 .map_err(|e| PrimerError::Storage(format!("set user_version failed: {e}")))?;
@@ -866,8 +871,8 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
                  id, name, age, languages, created_at, last_active,
                  pref_narrative, pref_socratic, pref_visual, pref_kinesthetic,
                  typical_session_minutes, high_engagement_topics,
-                 early_disengagement_secs, current_engagement_state_id
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                 early_disengagement_secs, current_engagement_state_id, locale
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
              ON CONFLICT(id) DO UPDATE SET
                  name = excluded.name,
                  age = excluded.age,
@@ -880,7 +885,8 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
                  typical_session_minutes = excluded.typical_session_minutes,
                  high_engagement_topics = excluded.high_engagement_topics,
                  early_disengagement_secs = excluded.early_disengagement_secs,
-                 current_engagement_state_id = excluded.current_engagement_state_id",
+                 current_engagement_state_id = excluded.current_engagement_state_id,
+                 locale = excluded.locale",
             rusqlite::params![
                 learner.profile.id.to_string(),
                 learner.profile.name,
@@ -896,6 +902,7 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
                 topics_json,
                 early_secs,
                 engagement_state_id,
+                learner.profile.locale.pack_id(),
             ],
         )
         .map_err(|e| PrimerError::Storage(format!("upsert learner: {e}")))?;
@@ -1004,6 +1011,7 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
             String,
             i64,
             i64,
+            String,
         );
         // The application invariant is one learner per DB file (the file
         // path is the identity boundary), so any row here is THE learner.
@@ -1015,7 +1023,8 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
                 "SELECT id, name, age, languages, created_at, last_active,
                         pref_narrative, pref_socratic, pref_visual, pref_kinesthetic,
                         typical_session_minutes, high_engagement_topics,
-                        early_disengagement_secs, current_engagement_state_id
+                        early_disengagement_secs, current_engagement_state_id,
+                        locale
                  FROM learners ORDER BY id LIMIT 1",
                 [],
                 |r| {
@@ -1034,6 +1043,7 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
                         r.get(11)?,
                         r.get(12)?,
                         r.get(13)?,
+                        r.get(14)?,
                     ))
                 },
             )
@@ -1055,6 +1065,7 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
             topics_json,
             early_secs,
             engagement_state_id,
+            locale_str,
         )) = row
         else {
             return Ok(None);
@@ -1082,11 +1093,27 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
         // sqlite3 edits, a third-party tool writing the file, or a
         // hardware-level bit flip. The `as` cast on i64 → u8/u32 wraps
         // mod 2^N — that's the wrong failure mode here.
+        // Decode the locale pack id. Unknown ids on disk shouldn't happen
+        // in normal operation (the column is constrained at write time to
+        // pack ids `Locale::pack_id()` produced) but defensively fall
+        // back to `Locale::default()` and log a warning rather than
+        // erroring — a corrupted locale shouldn't make a child unable
+        // to resume their session.
+        let locale = primer_core::i18n::Locale::from_pack_id(&locale_str).unwrap_or_else(|| {
+            tracing::warn!(
+                "unknown learners.locale {:?} in DB; defaulting to {}",
+                locale_str,
+                primer_core::i18n::Locale::default().pack_id()
+            );
+            primer_core::i18n::Locale::default()
+        });
+
         let profile = LearnerProfile {
             id,
             name,
             age: i64_to_u8(age, "learners.age")?,
             languages,
+            locale,
             created_at,
             last_active,
         };
@@ -2429,8 +2456,8 @@ mod tests {
     }
 
     #[test]
-    fn user_version_is_five() {
-        assert_eq!(schema::USER_VERSION, 5);
+    fn user_version_is_six() {
+        assert_eq!(schema::USER_VERSION, 6);
     }
 
     // ─── save_classification / load_recent_assessments ───────────────
@@ -3204,6 +3231,7 @@ mod learner_store_tests {
                 name: "Binti".into(),
                 age: 8,
                 languages: vec!["en".into(), "fr".into()],
+                locale: primer_core::i18n::Locale::English,
                 created_at: Utc::now(),
                 last_active: Utc::now(),
             },

--- a/src/crates/primer-storage/src/lib.rs
+++ b/src/crates/primer-storage/src/lib.rs
@@ -3515,6 +3515,44 @@ mod learner_store_tests {
         assert!(format!("{err}").contains("age"));
     }
 
+    /// `load_learner` defensively falls back to `Locale::default()` when
+    /// the on-disk `learners.locale` value isn't a known pack id (the
+    /// expected source: a third-party tool, a hand-edited DB, or a
+    /// bit-flip). The intent is that a corrupted locale never locks a
+    /// child out of their session — the load succeeds and the warn
+    /// surfaces in `tracing` for observability.
+    #[tokio::test]
+    async fn load_learner_with_unknown_locale_falls_back_to_default() {
+        let store = open_in_mem();
+        {
+            let conn = store.conn.lock().unwrap();
+            // Insert a learner row with an unknown locale pack id. The
+            // schema column is TEXT NOT NULL DEFAULT 'en' but accepts
+            // any string — soft-fail at read time is the contract.
+            conn.execute(
+                "INSERT INTO learners (
+                     id, name, age, languages, created_at, last_active,
+                     pref_narrative, pref_socratic, pref_visual, pref_kinesthetic,
+                     typical_session_minutes, high_engagement_topics,
+                     early_disengagement_secs, current_engagement_state_id, locale
+                 ) VALUES (?1, 'Test', 8, '[]', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                           0.5, 0.5, 0.5, 0.5, 20.0, '[]', 300, 1, 'zz')",
+                rusqlite::params!["00000000-0000-0000-0000-00000000007a"],
+            )
+            .unwrap();
+        }
+        let learner = store
+            .load_learner()
+            .await
+            .expect("load_learner must not error on unknown locale")
+            .expect("row should be returned");
+        assert_eq!(
+            learner.profile.locale,
+            primer_core::i18n::Locale::default(),
+            "unknown locale must fall back to Locale::default()"
+        );
+    }
+
     #[tokio::test]
     async fn load_learner_rejects_negative_encounter_count() {
         let store = open_in_mem();

--- a/src/crates/primer-storage/src/schema.rs
+++ b/src/crates/primer-storage/src/schema.rs
@@ -26,7 +26,13 @@ use rusqlite::Connection;
 /// Bumped to 5 when we added the `comprehension_classifiers` and
 /// `turn_comprehensions` tables that back the per-concept
 /// comprehension-classifier feature (Phase 0.3).
-pub const USER_VERSION: i64 = 5;
+///
+/// Bumped to 6 when we added the `learners.locale` column (BCP-47 short
+/// pack id, default `'en'`) and the `concepts.concept_language_tag`
+/// column (default `'en'`) that back the i18n / multi-locale prompt-pack
+/// architecture (Phase 0.1 i18n). Schema-only — adopting a non-default
+/// locale for an existing learner is the CLI's responsibility.
+pub const USER_VERSION: i64 = 6;
 
 /// Idempotent CREATE statements for the base (v1) schema. Run on every
 /// `open()`. v2-specific objects are added by `apply_v2_migrations`.
@@ -403,6 +409,54 @@ pub(crate) fn apply_v5_migrations(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+// ─── v6 schema strings ──────────────────────────────────────────────────────
+//
+// v6 wires the `Locale` enum into persistence. Two narrowly-scoped
+// column adds:
+//   - `learners.locale` — BCP-47 short pack id (e.g. `'en'`, `'de'`).
+//     Bound dispatch key for the prompt pack and the speech pipeline.
+//   - `concepts.concept_language_tag` — language the concept was
+//     extracted in. Schema-only landing in v6; per-concept linkage
+//     across locales is a follow-up.
+//
+// Both columns default to `'en'` so pre-v6 rows upgrade cleanly without
+// a backfill pass. The application maps the short id back to a `Locale`
+// variant via `Locale::from_pack_id` at the boundary.
+
+/// Apply v6 migrations idempotently. Safe to run on a fresh DB (after
+/// v5 objects exist), on a v5 DB being upgraded, and on a v6 DB being
+/// re-opened.
+///
+/// All steps run inside a single transaction so a partial failure rolls
+/// back to the pre-migration state.
+pub(crate) fn apply_v6_migrations(conn: &Connection) -> Result<()> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| PrimerError::Storage(format!("v6 migration: failed to begin tx: {e}")))?;
+
+    if !column_exists(&tx, "learners", "locale")? {
+        tx.execute_batch("ALTER TABLE learners ADD COLUMN locale TEXT NOT NULL DEFAULT 'en';")
+            .map_err(|e| {
+                PrimerError::Storage(format!("v6 migration: ALTER learners ADD locale: {e}"))
+            })?;
+    }
+
+    if !column_exists(&tx, "concepts", "concept_language_tag")? {
+        tx.execute_batch(
+            "ALTER TABLE concepts ADD COLUMN concept_language_tag TEXT NOT NULL DEFAULT 'en';",
+        )
+        .map_err(|e| {
+            PrimerError::Storage(format!(
+                "v6 migration: ALTER concepts ADD concept_language_tag: {e}"
+            ))
+        })?;
+    }
+
+    tx.commit()
+        .map_err(|e| PrimerError::Storage(format!("v6 migration: commit: {e}")))?;
+    Ok(())
+}
+
 fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
     let sql = format!("SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = ?1");
     let count: i64 = conn
@@ -569,8 +623,8 @@ mod v4_tests {
     }
 
     #[test]
-    fn user_version_constant_is_five() {
-        assert_eq!(USER_VERSION, 5);
+    fn user_version_constant_is_six() {
+        assert_eq!(USER_VERSION, 6);
     }
 
     #[test]
@@ -630,5 +684,104 @@ mod v4_tests {
         // Running again must not error.
         apply_v5_migrations(&conn).unwrap();
         assert!(table_exists(&conn, "turn_comprehensions"));
+    }
+
+    fn fresh_v5_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        conn.execute_batch(SCHEMA_SQL).unwrap();
+        apply_v2_migrations(&conn).unwrap();
+        apply_v3_migrations(&conn).unwrap();
+        apply_v4_migrations(&conn).unwrap();
+        apply_v5_migrations(&conn).unwrap();
+        conn
+    }
+
+    fn column_exists_in_test(conn: &Connection, table: &str, column: &str) -> bool {
+        let sql = format!("SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = ?1");
+        let count: i64 = conn
+            .query_row(&sql, rusqlite::params![column], |r| r.get(0))
+            .unwrap();
+        count > 0
+    }
+
+    #[test]
+    fn v6_migration_adds_learners_locale_column() {
+        let conn = fresh_v5_conn();
+        assert!(!column_exists_in_test(&conn, "learners", "locale"));
+        apply_v6_migrations(&conn).unwrap();
+        assert!(column_exists_in_test(&conn, "learners", "locale"));
+    }
+
+    #[test]
+    fn v6_migration_adds_concepts_language_tag_column() {
+        let conn = fresh_v5_conn();
+        assert!(!column_exists_in_test(
+            &conn,
+            "concepts",
+            "concept_language_tag",
+        ));
+        apply_v6_migrations(&conn).unwrap();
+        assert!(column_exists_in_test(
+            &conn,
+            "concepts",
+            "concept_language_tag",
+        ));
+    }
+
+    #[test]
+    fn v6_migration_defaults_existing_rows_to_en() {
+        let conn = fresh_v5_conn();
+        // Pre-seed a learners row and a concepts row prior to v6 migration.
+        // engagement_states is empty (no validate-and-seed has run on this
+        // bare connection) so insert the row we need first.
+        conn.execute(
+            "INSERT INTO engagement_states (id, name) VALUES (1, 'Engaged')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO learners (
+                 id, name, age, languages, created_at, last_active,
+                 pref_narrative, pref_socratic, pref_visual, pref_kinesthetic,
+                 typical_session_minutes, high_engagement_topics,
+                 early_disengagement_secs, current_engagement_state_id
+             ) VALUES (?1, 'Tester', 8, '[]', '2026-01-01T00:00:00Z',
+                      '2026-01-01T00:00:00Z', 0.5, 0.5, 0.5, 0.5, 20.0,
+                      '[]', 300, 1)",
+            rusqlite::params![uuid::Uuid::new_v4().to_string()],
+        )
+        .unwrap();
+        conn.execute("INSERT INTO concepts (name) VALUES ('photosynthesis')", [])
+            .unwrap();
+
+        apply_v6_migrations(&conn).unwrap();
+
+        let learner_locale: String = conn
+            .query_row("SELECT locale FROM learners LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(learner_locale, "en");
+
+        let concept_lang: String = conn
+            .query_row(
+                "SELECT concept_language_tag FROM concepts WHERE name = 'photosynthesis'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(concept_lang, "en");
+    }
+
+    #[test]
+    fn v6_migration_is_idempotent() {
+        let conn = fresh_v5_conn();
+        apply_v6_migrations(&conn).unwrap();
+        apply_v6_migrations(&conn).unwrap(); // re-run must be a no-op
+        assert!(column_exists_in_test(&conn, "learners", "locale"));
+        assert!(column_exists_in_test(
+            &conn,
+            "concepts",
+            "concept_language_tag",
+        ));
     }
 }


### PR DESCRIPTION
## Summary

PR 1 of a 5-PR i18n series. Lays the foundation for multi-locale support **without changing any English behaviour** — the English system prompt now renders byte-identically through a TOML-backed `PromptPack`. No more hardcoded pedagogical strings in `prompt_builder.rs`.

This is the architectural pre-work the design doc identified as needing to land before further pedagogical-engine development. Per the brainstorm in the issue thread, this PR merges Steps 1+2 from `docs/background_research/i18n_design.md` so the locale dispatch key is available the moment the prompt pack needs it.

## What changes

### `Locale` enum (primer-core::i18n)
- Add `ALL`, `name()`, `bcp47()`, `pack_id()`, `from_pack_id()` projections.
- Closed enum, single source of truth — SQLite columns round-trip via `pack_id`.
- Only `Locale::English` ships today; `Locale::German` lands with PR 4 alongside its `de.toml` pack and rendered `InferenceError` arm.

### `LearnerProfile.locale`
- New field, `#[serde(default)]` so existing serialised profiles deserialise as `Locale::English`.
- Round-trips through the v6 `learners.locale` column.
- The existing `languages: Vec<String>` stays — open-vocab preference list, distinct from the closed-enum bound dispatch key.

### `PromptPack` trait + `TomlPromptPack` + `prompts/en.toml`
- New `primer-pedagogy::prompt_pack` module.
- `en.toml` mirrors every load-bearing English string the previous build hardcoded.
- Embedded via `include_str!` by default; `PRIMER_PROMPTS_DIR=<dir>` overrides at runtime for translator iteration without recompilation.
- Loader validates per-field placeholder allowlists at load time — unknown `{token}` typos panic loudly at startup (e.g. `{nme}` → `prompt pack: field system_prompt.base contains unknown placeholder {nme}; allowed: ["name", "age", "language_guidance"]`).
- Loader checks every `PedagogicalIntent` variant has a matching key.

### `prompt_builder` refactor
- `build_system_prompt` / `build_prompt` thread through `&dyn PromptPack` via `*_with_pack` variants; the no-pack convenience wrappers consult a process-wide cached English pack.
- `decide_intent` / `decide_intent_at` gain `*_with_pack` siblings; the factual-prefix list now comes from the pack so non-English locales with non-prefix question forms can opt out (empty list → fall back to LLM classifier).
- 5 new snapshot tests (4 substring matrices + 1 full-text byte-exact canonical lock) guard against any drift in English output.

### `DialogueManager`
- Holds `Arc<dyn PromptPack>` selected from `learner.profile.locale` at construction time; threads it through `decide_intent_with_pack` and `build_prompt_with_pack`.

### Schema v6 (primer-storage)
- `ALTER learners ADD COLUMN locale TEXT NOT NULL DEFAULT 'en'`
- `ALTER concepts ADD COLUMN concept_language_tag TEXT NOT NULL DEFAULT 'en'`
- Idempotent migration wrapped in a single transaction; pre-v6 rows upgrade silently with the default.
- `save_learner` / `load_learner` SQL include the new column; unknown pack ids on disk warn and fall back to `Locale::default()` rather than erroring (a corrupted locale shouldn't lock a child out of their session).
- Concept-language linkage logic deferred to PR 5 — schema column lands now to avoid a backfill later.

### CLI
- New `--language` flag (default `"en"`); unknown ids hard-error at startup with a list of supported locales.
- `create_learner_with_id` takes the locale and writes it into `LearnerProfile.locale`; existing default-path / banner / resume flows untouched.

## Test plan

- [x] `cargo test --workspace` — **395 tests pass**, including a new full-text byte-exact snapshot locking the canonical English system-prompt output against the pre-refactor hardcoded version.
- [x] 4 additional substring snapshot tests cover the matrix (5/8/11/15-year-olds × engaged/frustrated/disengaging × with-passages/with-summary/with-retrieved).
- [x] `cargo clippy --workspace --all-targets` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `v6_migration_*` tests verify column adds, default-`'en'` backfill on pre-v6 rows, idempotency on re-run.
- [x] `unknown_placeholder_in_base_is_a_loud_panic` — fault-injection test confirms the validator panics on typos.
- [x] `missing_intent_variant_returns_err` — confirms an incomplete pack fails to load.
- [ ] Manual smoke: `cargo run --bin primer -- --language en` (REPL still works on English path).
- [ ] Manual smoke: `cargo run --bin primer -- --language zz` (unknown id → clean error).

## What's NOT in this PR (deliberately)

- Per-locale FTS5 tables in primer-knowledge → **PR 2**.
- `LoopBackends.tts_by_locale: HashMap<Locale, ...>` → **PR 3**.
- `Locale::German` + `de.toml` + German `render_inference_error` arm → **PR 4**.
- Wiring `concept_language_tag` into the extractor write path + cross-locale RAG isolation test → **PR 5**.

https://claude.ai/code/session_0129pzWPBrM4FpdVdoSBJPCR

---
_Generated by [Claude Code](https://claude.ai/code/session_0129pzWPBrM4FpdVdoSBJPCR)_