### PR TITLE
i18n PRs 2-5 + review fixes rebased onto main

### DIFF
--- a/src/crates/primer-cli/src/main.rs
+++ b/src/crates/primer-cli/src/main.rs
@@ -1058,7 +1058,6 @@ async fn async_main() -> anyhow::Result<()> {
             voice_id: &cli.voice,
             mic_silence_ms: cli.mic_silence_ms,
             verbose: cli.verbose,
-            locale: cli_locale,
         };
         // run() builds backends from cfg, wires DialogueManager via a
         // Responder adapter, drives the state machine.

--- a/src/crates/primer-cli/src/main.rs
+++ b/src/crates/primer-cli/src/main.rs
@@ -877,7 +877,7 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     let session_store: Arc<primer_storage::SqliteSessionStore> = Arc::new(
-        match primer_storage::SqliteSessionStore::open(&session_path) {
+        match primer_storage::SqliteSessionStore::open_for_locale(&session_path, cli_locale) {
             Ok(s) => s,
             Err(e) => {
                 eprintln!(

--- a/src/crates/primer-cli/src/main.rs
+++ b/src/crates/primer-cli/src/main.rs
@@ -819,8 +819,10 @@ async fn async_main() -> anyhow::Result<()> {
     };
 
     // Knowledge base — in-memory by default (empty, but functional).
+    // Locale-scoped: passages are indexed in the locale's own FTS5 table
+    // so BM25 statistics stay locale-pure.
     let knowledge_path = cli.knowledge_db.unwrap_or_else(|| PathBuf::from(IN_MEMORY));
-    let knowledge = SqliteKnowledgeBase::open(&knowledge_path)?;
+    let knowledge = SqliteKnowledgeBase::open_for_locale(&knowledge_path, cli_locale)?;
 
     // Session store — defaults to a per-learner file under `~/.primer/`.
     // We look up HOME here (rather than inside `resolve_session_db_path`)

--- a/src/crates/primer-cli/src/main.rs
+++ b/src/crates/primer-cli/src/main.rs
@@ -1058,6 +1058,7 @@ async fn async_main() -> anyhow::Result<()> {
             voice_id: &cli.voice,
             mic_silence_ms: cli.mic_silence_ms,
             verbose: cli.verbose,
+            locale: cli_locale,
         };
         // run() builds backends from cfg, wires DialogueManager via a
         // Responder adapter, drives the state machine.

--- a/src/crates/primer-cli/src/speech_loop.rs
+++ b/src/crates/primer-cli/src/speech_loop.rs
@@ -140,10 +140,6 @@ pub struct SpeechLoopConfig<'a> {
     pub voice_id: &'a str,
     pub mic_silence_ms: u32,
     pub verbose: bool,
-    /// Active locale for TTS dispatch. Today's CLI binds this to the
-    /// resolved `--language` once and uses the same locale for the
-    /// whole session.
-    pub locale: primer_core::i18n::Locale,
 }
 
 use std::sync::Arc;
@@ -175,58 +171,14 @@ type TranscriptRx = Arc<std::sync::Mutex<std::sync::mpsc::Receiver<String>>>;
 /// whisper / piper instances; tests wire mocks. The VAD lives on the
 /// audio capture thread (production) or is stubbed out via direct VAD
 /// events on the channel (tests), so it's not part of this struct.
-///
-/// ## Per-locale TTS / voice
-///
-/// `tts_by_locale` and `voice_by_locale` are keyed maps: each entry is
-/// the TTS engine + voice profile to use when synthesising for that
-/// locale. `active_locale` is the dispatch key the SPEAK phase reads
-/// at each turn — bound for the lifetime of the loop in v1, but the
-/// shape leaves room for future code-switching scenarios (a locale
-/// switch mid-session for language-teaching) without further
-/// restructuring.
-///
-/// Today's CLI populates exactly one entry — the active locale —
-/// constructed via `LoopBackends::single_locale`. The state machine
-/// and dispatch logic are untouched by this refactor.
 pub struct LoopBackends {
     pub stt: Arc<dyn StreamingSpeechToText>,
-    pub tts_by_locale:
-        std::collections::HashMap<primer_core::i18n::Locale, Arc<dyn StreamingTextToSpeech>>,
-    /// Voice profile keyed by locale. Production wires the `model_id`
-    /// from `--voice` (e.g. `en_GB-alba-medium`); tests use
-    /// `VoiceProfile::default()`. Piper rejects model-id mismatches,
-    /// so each entry must align with the loaded voice ONNX file stem
-    /// for that locale.
-    pub voice_by_locale:
-        std::collections::HashMap<primer_core::i18n::Locale, primer_core::speech::VoiceProfile>,
-    /// Locale the SPEAK phase looks up in the maps above. v1 binds it
-    /// for the lifetime of the loop.
-    pub active_locale: primer_core::i18n::Locale,
-}
-
-impl LoopBackends {
-    /// Convenience constructor for the single-locale case (production
-    /// today, every existing test). Takes ownership of one TTS + voice
-    /// pair, wraps them in single-entry maps keyed by `locale`, and
-    /// sets `active_locale = locale`.
-    pub fn single_locale(
-        stt: Arc<dyn StreamingSpeechToText>,
-        tts: Arc<dyn StreamingTextToSpeech>,
-        voice: primer_core::speech::VoiceProfile,
-        locale: primer_core::i18n::Locale,
-    ) -> Self {
-        let mut tts_by_locale = std::collections::HashMap::new();
-        tts_by_locale.insert(locale, tts);
-        let mut voice_by_locale = std::collections::HashMap::new();
-        voice_by_locale.insert(locale, voice);
-        Self {
-            stt,
-            tts_by_locale,
-            voice_by_locale,
-            active_locale: locale,
-        }
-    }
+    pub tts: Arc<dyn StreamingTextToSpeech>,
+    /// Voice profile passed to `tts.open_session(...)`. Production wires
+    /// the model_id from `--voice` (e.g. `en_GB-alba-medium`); tests can
+    /// use `VoiceProfile::default()`. Piper rejects mismatches, so this
+    /// must align with the loaded voice ONNX file stem.
+    pub voice: primer_core::speech::VoiceProfile,
 }
 
 /// Awaitable hook that blocks until the speaker has finished playing
@@ -471,31 +423,8 @@ pub async fn run_loop<'r>(
             if let Some(flag) = is_speaking.as_ref() {
                 flag.store(true, std::sync::atomic::Ordering::SeqCst);
             }
-            // Dispatch on `active_locale`. v1 has a single entry so
-            // these lookups can't miss in practice; we treat a miss as
-            // a Speech error (rather than a panic) because LoopBackends
-            // is a public-ish struct that future code might construct
-            // without the convenience helper.
-            let active_tts = backends
-                .tts_by_locale
-                .get(&backends.active_locale)
-                .ok_or_else(|| {
-                    primer_core::error::PrimerError::Speech(format!(
-                        "no TTS configured for active locale {}",
-                        backends.active_locale.pack_id()
-                    ))
-                })?;
-            let active_voice = backends
-                .voice_by_locale
-                .get(&backends.active_locale)
-                .ok_or_else(|| {
-                    primer_core::error::PrimerError::Speech(format!(
-                        "no voice profile configured for active locale {}",
-                        backends.active_locale.pack_id()
-                    ))
-                })?;
-            let mut session = active_tts.open_session(active_voice)?;
-            let tts_rate = active_tts.sample_rate();
+            let mut session = backends.tts.open_session(&backends.voice)?;
+            let tts_rate = backends.tts.sample_rate();
             // ~200 ms of silence inserted between AudioChunks (each
             // chunk is one phrase). Gives the listener a perceptible
             // pause at sentence boundaries without adding much to
@@ -794,25 +723,20 @@ pub async fn run<'a>(
         .map_err(|e| primer_core::error::PrimerError::Speech(format!("spawn audio thread: {e}")))?;
 
     // ── Build LoopBackends with the channel STT wrapper ────────────
-    // Single-locale v1: the CLI's resolved locale is the active locale,
-    // and that's the only entry in the maps. PR 4 will populate
-    // additional locales when a second voice ships.
-    let voice = primer_core::speech::VoiceProfile {
-        model_id: cfg.voice_id.to_string(),
-        // Slow Piper slightly: length_scale = 1.0 / rate, so
-        // rate < 1.0 stretches each phoneme. 0.9 is barely
-        // perceptible but easier for younger children to follow.
-        rate: 0.9,
-        ..primer_core::speech::VoiceProfile::default()
-    };
-    let backends = LoopBackends::single_locale(
-        Arc::new(ChannelStt {
+    let backends = LoopBackends {
+        stt: Arc::new(ChannelStt {
             rx: Arc::new(std::sync::Mutex::new(transcript_rx)),
         }),
-        std::sync::Arc::clone(&tts),
-        voice,
-        cfg.locale,
-    );
+        tts: std::sync::Arc::clone(&tts),
+        voice: primer_core::speech::VoiceProfile {
+            model_id: cfg.voice_id.to_string(),
+            // Slow Piper slightly: length_scale = 1.0 / rate, so
+            // rate < 1.0 stretches each phoneme. 0.9 is barely
+            // perceptible but easier for younger children to follow.
+            rate: 0.9,
+            ..primer_core::speech::VoiceProfile::default()
+        },
+    };
 
     // ── on_audio callback: push synth chunks to the speaker ─────────
     // Uses a leftover buffer carried across calls so partial tails of
@@ -1283,12 +1207,11 @@ mod mocks {
 
         use primer_core::speech::VadEvent;
 
-        let backends = super::LoopBackends::single_locale(
-            Arc::new(MockStreamingStt::new("hello primer")),
-            Arc::new(MockStreamingTts::new(64)),
-            primer_core::speech::VoiceProfile::default(),
-            primer_core::i18n::Locale::English,
-        );
+        let backends = super::LoopBackends {
+            stt: Arc::new(MockStreamingStt::new("hello primer")),
+            tts: Arc::new(MockStreamingTts::new(64)),
+            voice: primer_core::speech::VoiceProfile::default(),
+        };
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();
@@ -1346,12 +1269,11 @@ mod mocks {
     async fn quit_phrase_short_circuits_speak() {
         use primer_core::speech::VadEvent;
 
-        let backends = super::LoopBackends::single_locale(
-            Arc::new(MockStreamingStt::new("goodbye")),
-            Arc::new(MockStreamingTts::new(64)),
-            primer_core::speech::VoiceProfile::default(),
-            primer_core::i18n::Locale::English,
-        );
+        let backends = super::LoopBackends {
+            stt: Arc::new(MockStreamingStt::new("goodbye")),
+            tts: Arc::new(MockStreamingTts::new(64)),
+            voice: primer_core::speech::VoiceProfile::default(),
+        };
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();
@@ -1415,12 +1337,11 @@ mod mocks {
         // look blue'", we need a smarter mock — but for the unit test
         // we accept that both attempts return the same canned text. The
         // assertion is about cancellation, not transcript stitching.
-        let backends = super::LoopBackends::single_locale(
-            Arc::new(MockStreamingStt::new("why does the sky look blue")),
-            Arc::new(MockStreamingTts::new(64)),
-            primer_core::speech::VoiceProfile::default(),
-            primer_core::i18n::Locale::English,
-        );
+        let backends = super::LoopBackends {
+            stt: Arc::new(MockStreamingStt::new("why does the sky look blue")),
+            tts: Arc::new(MockStreamingTts::new(64)),
+            voice: primer_core::speech::VoiceProfile::default(),
+        };
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         // First SpeechStart → SpeechEnd: triggers LATENT_THINK.
@@ -1547,12 +1468,11 @@ mod mocks {
     async fn commit_on_first_chunk_proceeds_to_speak() {
         use primer_core::speech::VadEvent;
 
-        let backends = super::LoopBackends::single_locale(
-            Arc::new(MockStreamingStt::new("hi primer")),
-            Arc::new(MockStreamingTts::new(64)),
-            primer_core::speech::VoiceProfile::default(),
-            primer_core::i18n::Locale::English,
-        );
+        let backends = super::LoopBackends {
+            stt: Arc::new(MockStreamingStt::new("hi primer")),
+            tts: Arc::new(MockStreamingTts::new(64)),
+            voice: primer_core::speech::VoiceProfile::default(),
+        };
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();
@@ -1613,12 +1533,11 @@ mod mocks {
 
         use primer_core::speech::VadEvent;
 
-        let backends = super::LoopBackends::single_locale(
-            Arc::new(MockStreamingStt::new("hi")),
-            Arc::new(MockStreamingTts::new(64)),
-            primer_core::speech::VoiceProfile::default(),
-            primer_core::i18n::Locale::English,
-        );
+        let backends = super::LoopBackends {
+            stt: Arc::new(MockStreamingStt::new("hi")),
+            tts: Arc::new(MockStreamingTts::new(64)),
+            voice: primer_core::speech::VoiceProfile::default(),
+        };
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();
@@ -1738,14 +1657,13 @@ mod mocks {
         }
 
         let captured = Arc::new(Mutex::new(Vec::<String>::new()));
-        let backends = super::LoopBackends::single_locale(
-            Arc::new(MockStreamingStt::new("hello primer")),
-            Arc::new(CapturingTts {
+        let backends = super::LoopBackends {
+            stt: Arc::new(MockStreamingStt::new("hello primer")),
+            tts: Arc::new(CapturingTts {
                 captured: Arc::clone(&captured),
             }),
-            VoiceProfile::default(),
-            primer_core::i18n::Locale::English,
-        );
+            voice: VoiceProfile::default(),
+        };
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();

--- a/src/crates/primer-cli/src/speech_loop.rs
+++ b/src/crates/primer-cli/src/speech_loop.rs
@@ -140,6 +140,10 @@ pub struct SpeechLoopConfig<'a> {
     pub voice_id: &'a str,
     pub mic_silence_ms: u32,
     pub verbose: bool,
+    /// Active locale for TTS dispatch. Today's CLI binds this to the
+    /// resolved `--language` once and uses the same locale for the
+    /// whole session.
+    pub locale: primer_core::i18n::Locale,
 }
 
 use std::sync::Arc;
@@ -171,14 +175,58 @@ type TranscriptRx = Arc<std::sync::Mutex<std::sync::mpsc::Receiver<String>>>;
 /// whisper / piper instances; tests wire mocks. The VAD lives on the
 /// audio capture thread (production) or is stubbed out via direct VAD
 /// events on the channel (tests), so it's not part of this struct.
+///
+/// ## Per-locale TTS / voice
+///
+/// `tts_by_locale` and `voice_by_locale` are keyed maps: each entry is
+/// the TTS engine + voice profile to use when synthesising for that
+/// locale. `active_locale` is the dispatch key the SPEAK phase reads
+/// at each turn — bound for the lifetime of the loop in v1, but the
+/// shape leaves room for future code-switching scenarios (a locale
+/// switch mid-session for language-teaching) without further
+/// restructuring.
+///
+/// Today's CLI populates exactly one entry — the active locale —
+/// constructed via `LoopBackends::single_locale`. The state machine
+/// and dispatch logic are untouched by this refactor.
 pub struct LoopBackends {
     pub stt: Arc<dyn StreamingSpeechToText>,
-    pub tts: Arc<dyn StreamingTextToSpeech>,
-    /// Voice profile passed to `tts.open_session(...)`. Production wires
-    /// the model_id from `--voice` (e.g. `en_GB-alba-medium`); tests can
-    /// use `VoiceProfile::default()`. Piper rejects mismatches, so this
-    /// must align with the loaded voice ONNX file stem.
-    pub voice: primer_core::speech::VoiceProfile,
+    pub tts_by_locale:
+        std::collections::HashMap<primer_core::i18n::Locale, Arc<dyn StreamingTextToSpeech>>,
+    /// Voice profile keyed by locale. Production wires the `model_id`
+    /// from `--voice` (e.g. `en_GB-alba-medium`); tests use
+    /// `VoiceProfile::default()`. Piper rejects model-id mismatches,
+    /// so each entry must align with the loaded voice ONNX file stem
+    /// for that locale.
+    pub voice_by_locale:
+        std::collections::HashMap<primer_core::i18n::Locale, primer_core::speech::VoiceProfile>,
+    /// Locale the SPEAK phase looks up in the maps above. v1 binds it
+    /// for the lifetime of the loop.
+    pub active_locale: primer_core::i18n::Locale,
+}
+
+impl LoopBackends {
+    /// Convenience constructor for the single-locale case (production
+    /// today, every existing test). Takes ownership of one TTS + voice
+    /// pair, wraps them in single-entry maps keyed by `locale`, and
+    /// sets `active_locale = locale`.
+    pub fn single_locale(
+        stt: Arc<dyn StreamingSpeechToText>,
+        tts: Arc<dyn StreamingTextToSpeech>,
+        voice: primer_core::speech::VoiceProfile,
+        locale: primer_core::i18n::Locale,
+    ) -> Self {
+        let mut tts_by_locale = std::collections::HashMap::new();
+        tts_by_locale.insert(locale, tts);
+        let mut voice_by_locale = std::collections::HashMap::new();
+        voice_by_locale.insert(locale, voice);
+        Self {
+            stt,
+            tts_by_locale,
+            voice_by_locale,
+            active_locale: locale,
+        }
+    }
 }
 
 /// Awaitable hook that blocks until the speaker has finished playing
@@ -423,8 +471,31 @@ pub async fn run_loop<'r>(
             if let Some(flag) = is_speaking.as_ref() {
                 flag.store(true, std::sync::atomic::Ordering::SeqCst);
             }
-            let mut session = backends.tts.open_session(&backends.voice)?;
-            let tts_rate = backends.tts.sample_rate();
+            // Dispatch on `active_locale`. v1 has a single entry so
+            // these lookups can't miss in practice; we treat a miss as
+            // a Speech error (rather than a panic) because LoopBackends
+            // is a public-ish struct that future code might construct
+            // without the convenience helper.
+            let active_tts = backends
+                .tts_by_locale
+                .get(&backends.active_locale)
+                .ok_or_else(|| {
+                    primer_core::error::PrimerError::Speech(format!(
+                        "no TTS configured for active locale {}",
+                        backends.active_locale.pack_id()
+                    ))
+                })?;
+            let active_voice = backends
+                .voice_by_locale
+                .get(&backends.active_locale)
+                .ok_or_else(|| {
+                    primer_core::error::PrimerError::Speech(format!(
+                        "no voice profile configured for active locale {}",
+                        backends.active_locale.pack_id()
+                    ))
+                })?;
+            let mut session = active_tts.open_session(active_voice)?;
+            let tts_rate = active_tts.sample_rate();
             // ~200 ms of silence inserted between AudioChunks (each
             // chunk is one phrase). Gives the listener a perceptible
             // pause at sentence boundaries without adding much to
@@ -723,20 +794,25 @@ pub async fn run<'a>(
         .map_err(|e| primer_core::error::PrimerError::Speech(format!("spawn audio thread: {e}")))?;
 
     // ── Build LoopBackends with the channel STT wrapper ────────────
-    let backends = LoopBackends {
-        stt: Arc::new(ChannelStt {
+    // Single-locale v1: the CLI's resolved locale is the active locale,
+    // and that's the only entry in the maps. PR 4 will populate
+    // additional locales when a second voice ships.
+    let voice = primer_core::speech::VoiceProfile {
+        model_id: cfg.voice_id.to_string(),
+        // Slow Piper slightly: length_scale = 1.0 / rate, so
+        // rate < 1.0 stretches each phoneme. 0.9 is barely
+        // perceptible but easier for younger children to follow.
+        rate: 0.9,
+        ..primer_core::speech::VoiceProfile::default()
+    };
+    let backends = LoopBackends::single_locale(
+        Arc::new(ChannelStt {
             rx: Arc::new(std::sync::Mutex::new(transcript_rx)),
         }),
-        tts: std::sync::Arc::clone(&tts),
-        voice: primer_core::speech::VoiceProfile {
-            model_id: cfg.voice_id.to_string(),
-            // Slow Piper slightly: length_scale = 1.0 / rate, so
-            // rate < 1.0 stretches each phoneme. 0.9 is barely
-            // perceptible but easier for younger children to follow.
-            rate: 0.9,
-            ..primer_core::speech::VoiceProfile::default()
-        },
-    };
+        std::sync::Arc::clone(&tts),
+        voice,
+        cfg.locale,
+    );
 
     // ── on_audio callback: push synth chunks to the speaker ─────────
     // Uses a leftover buffer carried across calls so partial tails of
@@ -1207,11 +1283,12 @@ mod mocks {
 
         use primer_core::speech::VadEvent;
 
-        let backends = super::LoopBackends {
-            stt: Arc::new(MockStreamingStt::new("hello primer")),
-            tts: Arc::new(MockStreamingTts::new(64)),
-            voice: primer_core::speech::VoiceProfile::default(),
-        };
+        let backends = super::LoopBackends::single_locale(
+            Arc::new(MockStreamingStt::new("hello primer")),
+            Arc::new(MockStreamingTts::new(64)),
+            primer_core::speech::VoiceProfile::default(),
+            primer_core::i18n::Locale::English,
+        );
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();
@@ -1269,11 +1346,12 @@ mod mocks {
     async fn quit_phrase_short_circuits_speak() {
         use primer_core::speech::VadEvent;
 
-        let backends = super::LoopBackends {
-            stt: Arc::new(MockStreamingStt::new("goodbye")),
-            tts: Arc::new(MockStreamingTts::new(64)),
-            voice: primer_core::speech::VoiceProfile::default(),
-        };
+        let backends = super::LoopBackends::single_locale(
+            Arc::new(MockStreamingStt::new("goodbye")),
+            Arc::new(MockStreamingTts::new(64)),
+            primer_core::speech::VoiceProfile::default(),
+            primer_core::i18n::Locale::English,
+        );
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();
@@ -1337,11 +1415,12 @@ mod mocks {
         // look blue'", we need a smarter mock — but for the unit test
         // we accept that both attempts return the same canned text. The
         // assertion is about cancellation, not transcript stitching.
-        let backends = super::LoopBackends {
-            stt: Arc::new(MockStreamingStt::new("why does the sky look blue")),
-            tts: Arc::new(MockStreamingTts::new(64)),
-            voice: primer_core::speech::VoiceProfile::default(),
-        };
+        let backends = super::LoopBackends::single_locale(
+            Arc::new(MockStreamingStt::new("why does the sky look blue")),
+            Arc::new(MockStreamingTts::new(64)),
+            primer_core::speech::VoiceProfile::default(),
+            primer_core::i18n::Locale::English,
+        );
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         // First SpeechStart → SpeechEnd: triggers LATENT_THINK.
@@ -1468,11 +1547,12 @@ mod mocks {
     async fn commit_on_first_chunk_proceeds_to_speak() {
         use primer_core::speech::VadEvent;
 
-        let backends = super::LoopBackends {
-            stt: Arc::new(MockStreamingStt::new("hi primer")),
-            tts: Arc::new(MockStreamingTts::new(64)),
-            voice: primer_core::speech::VoiceProfile::default(),
-        };
+        let backends = super::LoopBackends::single_locale(
+            Arc::new(MockStreamingStt::new("hi primer")),
+            Arc::new(MockStreamingTts::new(64)),
+            primer_core::speech::VoiceProfile::default(),
+            primer_core::i18n::Locale::English,
+        );
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();
@@ -1533,11 +1613,12 @@ mod mocks {
 
         use primer_core::speech::VadEvent;
 
-        let backends = super::LoopBackends {
-            stt: Arc::new(MockStreamingStt::new("hi")),
-            tts: Arc::new(MockStreamingTts::new(64)),
-            voice: primer_core::speech::VoiceProfile::default(),
-        };
+        let backends = super::LoopBackends::single_locale(
+            Arc::new(MockStreamingStt::new("hi")),
+            Arc::new(MockStreamingTts::new(64)),
+            primer_core::speech::VoiceProfile::default(),
+            primer_core::i18n::Locale::English,
+        );
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();
@@ -1657,13 +1738,14 @@ mod mocks {
         }
 
         let captured = Arc::new(Mutex::new(Vec::<String>::new()));
-        let backends = super::LoopBackends {
-            stt: Arc::new(MockStreamingStt::new("hello primer")),
-            tts: Arc::new(CapturingTts {
+        let backends = super::LoopBackends::single_locale(
+            Arc::new(MockStreamingStt::new("hello primer")),
+            Arc::new(CapturingTts {
                 captured: Arc::clone(&captured),
             }),
-            voice: VoiceProfile::default(),
-        };
+            VoiceProfile::default(),
+            primer_core::i18n::Locale::English,
+        );
 
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(64);
         event_tx.try_send(VadEvent::SpeechStart).unwrap();

--- a/src/crates/primer-core/src/i18n.rs
+++ b/src/crates/primer-core/src/i18n.rs
@@ -44,12 +44,13 @@ use serde::{Deserialize, Serialize};
 pub enum Locale {
     #[default]
     English,
+    German,
 }
 
 impl Locale {
     /// Every variant, in declaration order. Used by tests and by any
     /// startup path that needs to enumerate available locales.
-    pub const ALL: &'static [Self] = &[Self::English];
+    pub const ALL: &'static [Self] = &[Self::English, Self::German];
 
     /// Canonical machine-readable name. Stable identifier — do not
     /// rename. Mirrors the `name()` pattern on `EngagementState` and
@@ -57,6 +58,7 @@ impl Locale {
     pub fn name(self) -> &'static str {
         match self {
             Self::English => "English",
+            Self::German => "German",
         }
     }
 
@@ -66,6 +68,7 @@ impl Locale {
     pub fn bcp47(self) -> &'static str {
         match self {
             Self::English => "en-US",
+            Self::German => "de-DE",
         }
     }
 
@@ -76,6 +79,7 @@ impl Locale {
     pub fn pack_id(self) -> &'static str {
         match self {
             Self::English => "en",
+            Self::German => "de",
         }
     }
 
@@ -85,6 +89,7 @@ impl Locale {
     pub fn from_pack_id(s: &str) -> Option<Self> {
         match s {
             "en" => Some(Self::English),
+            "de" => Some(Self::German),
             _ => None,
         }
     }
@@ -95,6 +100,7 @@ impl Locale {
 pub fn render_inference_error(err: &InferenceError, locale: &Locale) -> String {
     match locale {
         Locale::English => render_english(err),
+        Locale::German => render_german(err),
     }
 }
 
@@ -133,6 +139,46 @@ fn render_english(err: &InferenceError) -> String {
     }
 }
 
+/// German rendering. Uses informal "du" — the Primer is a children's
+/// product and German children are universally addressed as "du" by
+/// adults outside formal institutional contexts. Singular/plural
+/// agreement is handled explicitly for the rate-limited case
+/// (1 Sekunde vs N Sekunden).
+fn render_german(err: &InferenceError) -> String {
+    use InferenceError::*;
+    match err {
+        Auth => {
+            "Authentifizierung fehlgeschlagen. Bitte überprüfe deinen ANTHROPIC_API_KEY in .env oder ~/.primer_env."
+                .into()
+        }
+        RateLimited {
+            retry_after: Some(d),
+        } => {
+            let secs = d.as_secs();
+            if secs == 1 {
+                "Der Dienst ist gerade beschäftigt. Bitte versuche es in 1 Sekunde wieder.".into()
+            } else {
+                format!(
+                    "Der Dienst ist gerade beschäftigt. Bitte versuche es in {secs} Sekunden wieder."
+                )
+            }
+        }
+        RateLimited { retry_after: None } => {
+            "Der Dienst ist gerade beschäftigt. Bitte versuche es gleich wieder.".into()
+        }
+        ServiceUnavailable => {
+            "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuche es gleich wieder.".into()
+        }
+        NetworkUnavailable => {
+            "Der Dienst ist nicht erreichbar. Bitte überprüfe deine Netzwerkverbindung.".into()
+        }
+        ModelNotFound { model } => {
+            format!("Modell '{model}' ist nicht verfügbar. Für Ollama führe `ollama pull {model}` aus.")
+        }
+        Other(_) => "Etwas Unerwartetes ist schiefgelaufen. Bitte versuche es erneut. (Details in den Logs.)".into(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,8 +192,74 @@ mod tests {
 
     #[test]
     fn locale_all_lists_every_variant() {
-        assert_eq!(Locale::ALL.len(), 1);
+        assert_eq!(Locale::ALL.len(), 2);
         assert!(Locale::ALL.contains(&Locale::English));
+        assert!(Locale::ALL.contains(&Locale::German));
+    }
+
+    #[test]
+    fn locale_german_pack_id_and_bcp47() {
+        assert_eq!(Locale::German.pack_id(), "de");
+        assert_eq!(Locale::German.bcp47(), "de-DE");
+        assert_eq!(Locale::German.name(), "German");
+        assert_eq!(Locale::from_pack_id("de"), Some(Locale::German));
+    }
+
+    #[test]
+    fn render_inference_error_dispatches_on_locale() {
+        let auth_en = render_inference_error(&InferenceError::Auth, &Locale::English);
+        let auth_de = render_inference_error(&InferenceError::Auth, &Locale::German);
+        assert_ne!(
+            auth_en, auth_de,
+            "different locales must produce different text"
+        );
+        assert!(auth_de.contains("ANTHROPIC_API_KEY"));
+        assert!(auth_de.contains("fehlgeschlagen"));
+    }
+
+    #[test]
+    fn german_rate_limited_singular_vs_plural() {
+        let one = render_inference_error(
+            &InferenceError::RateLimited {
+                retry_after: Some(Duration::from_secs(1)),
+            },
+            &Locale::German,
+        );
+        let many = render_inference_error(
+            &InferenceError::RateLimited {
+                retry_after: Some(Duration::from_secs(7)),
+            },
+            &Locale::German,
+        );
+        assert!(
+            one.contains("1 Sekunde") && !one.contains("1 Sekunden"),
+            "singular form expected for 1s: {one}"
+        );
+        assert!(many.contains("7 Sekunden"), "plural form expected: {many}");
+    }
+
+    #[test]
+    fn german_model_not_found_includes_model_name_and_pull_hint() {
+        let s = render_inference_error(
+            &InferenceError::ModelNotFound {
+                model: "llama3.2".into(),
+            },
+            &Locale::German,
+        );
+        assert!(s.contains("llama3.2"), "got: {s}");
+        assert!(s.to_lowercase().contains("pull"), "got: {s}");
+    }
+
+    #[test]
+    fn german_other_does_not_leak_inner_dev_string() {
+        let s = render_inference_error(
+            &InferenceError::Other("RAW_DEV_STRING_FOO".into()),
+            &Locale::German,
+        );
+        assert!(
+            !s.contains("RAW_DEV_STRING_FOO"),
+            "Other's inner string must not reach users; got: {s}"
+        );
     }
 
     #[test]

--- a/src/crates/primer-knowledge/src/lib.rs
+++ b/src/crates/primer-knowledge/src/lib.rs
@@ -5,59 +5,99 @@
 //! The knowledge base stores passages from Wikipedia, curated encyclopedias,
 //! and curriculum materials. It supports full-text search with BM25 ranking,
 //! and can be extended with embedding-based semantic search.
+//!
+//! ## Per-locale tables
+//!
+//! Each locale gets its own pair of tables: `passages_<pack_id>` (FTS5
+//! virtual table) and `passages_<pack_id>_content` (external-content
+//! storage). This isolation matters because BM25 statistics are
+//! computed per-FTS5-index — mixing English and (e.g.) German passages
+//! in a single index degrades retrieval quality for both. A future
+//! locale that benefits from a different FTS5 tokenizer
+//! (e.g. `porter` for English-only stemming) can configure it without
+//! affecting other locales.
+//!
+//! ## Migration from the legacy single-table layout
+//!
+//! Builds prior to PR 2 used a single `passages` / `passages_content`
+//! pair without locale qualification. On the first open under
+//! `open_for_locale`, if the legacy `passages` table exists and the
+//! locale-qualified table does not, this module migrates the legacy
+//! rows into the requested locale's tables in a single transaction
+//! and drops the legacy tables. The migration assumes the legacy
+//! corpus was in the locale being opened — which is the only sound
+//! assumption when the locale wasn't tracked at write time.
 
 use async_trait::async_trait;
 use primer_core::error::{PrimerError, Result};
+use primer_core::i18n::Locale;
 use primer_core::knowledge::*;
 use rusqlite::Connection;
 use std::path::Path;
 use std::sync::Mutex;
 
-/// SQLite FTS5-backed knowledge base.
+/// SQLite FTS5-backed knowledge base, scoped to one `Locale`.
 pub struct SqliteKnowledgeBase {
     conn: Mutex<Connection>,
+    locale: Locale,
 }
 
 impl SqliteKnowledgeBase {
-    /// Open an existing knowledge base, or create a new empty one.
+    /// Open the knowledge base for the default locale (English).
+    /// Back-compat shim for callers that pre-date the locale-aware API.
     pub fn open(path: &Path) -> Result<Self> {
+        Self::open_for_locale(path, Locale::default())
+    }
+
+    /// Open or create a knowledge base scoped to `locale`. The on-disk
+    /// schema uses per-locale tables (`passages_<pack_id>` and
+    /// `passages_<pack_id>_content`); a legacy single-table file is
+    /// migrated into `locale`'s tables on first open. New empty files
+    /// just create the locale-scoped tables.
+    pub fn open_for_locale(path: &Path, locale: Locale) -> Result<Self> {
         let conn = Connection::open(path)
             .map_err(|e| PrimerError::Knowledge(format!("Failed to open DB: {e}")))?;
 
-        // Create the FTS5 table if it doesn't exist.
-        conn.execute_batch(
-            "CREATE VIRTUAL TABLE IF NOT EXISTS passages USING fts5(
-                id,
-                source,
-                text,
-                content='passages_content',
-                content_rowid='rowid'
-            );
-            CREATE TABLE IF NOT EXISTS passages_content(
-                rowid INTEGER PRIMARY KEY,
-                id TEXT NOT NULL,
-                source TEXT NOT NULL,
-                text TEXT NOT NULL
-            );",
-        )
-        .map_err(|e| PrimerError::Knowledge(format!("Failed to create tables: {e}")))?;
+        migrate_or_create(&conn, locale.pack_id())?;
 
         Ok(Self {
             conn: Mutex::new(conn),
+            locale,
         })
+    }
+
+    /// Locale this knowledge base is scoped to. Useful for diagnostics
+    /// and for asserting that a `DialogueManager` and its knowledge base
+    /// agree on locale.
+    pub fn locale(&self) -> Locale {
+        self.locale
+    }
+
+    fn passages_table(&self) -> String {
+        format!("passages_{}", self.locale.pack_id())
+    }
+
+    fn content_table(&self) -> String {
+        format!("passages_{}_content", self.locale.pack_id())
     }
 
     /// Insert a passage into the knowledge base.
     pub fn insert_passage(&self, id: &str, source: &str, text: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
+        let content_table = self.content_table();
+        let passages_table = self.passages_table();
+
         conn.execute(
-            "INSERT INTO passages_content(id, source, text) VALUES (?1, ?2, ?3)",
+            &format!("INSERT INTO {content_table}(id, source, text) VALUES (?1, ?2, ?3)"),
             rusqlite::params![id, source, text],
         )
         .map_err(|e| PrimerError::Knowledge(format!("Insert failed: {e}")))?;
 
         conn.execute(
-            "INSERT INTO passages(rowid, id, source, text) VALUES (last_insert_rowid(), ?1, ?2, ?3)",
+            &format!(
+                "INSERT INTO {passages_table}(rowid, id, source, text) \
+                 VALUES (last_insert_rowid(), ?1, ?2, ?3)"
+            ),
             rusqlite::params![id, source, text],
         )
         .map_err(|e| PrimerError::Knowledge(format!("FTS insert failed: {e}")))?;
@@ -70,16 +110,21 @@ impl SqliteKnowledgeBase {
 impl KnowledgeBase for SqliteKnowledgeBase {
     async fn retrieve(&self, query: &str, params: &RetrievalParams) -> Result<Vec<Passage>> {
         let conn = self.conn.lock().unwrap();
+        let passages_table = self.passages_table();
 
-        // FTS5 match query with BM25 ranking.
+        // FTS5 match query with BM25 ranking. Table name is interpolated
+        // (NOT user input — comes from `Locale::pack_id()`, a closed
+        // enum projection), parameters are bound positionally — the
+        // user query and limit go through `?1` and `?2`.
+        let sql = format!(
+            "SELECT id, source, text, rank
+             FROM {passages_table}
+             WHERE {passages_table} MATCH ?1
+             ORDER BY rank
+             LIMIT ?2"
+        );
         let mut stmt = conn
-            .prepare(
-                "SELECT id, source, text, rank
-                 FROM passages
-                 WHERE passages MATCH ?1
-                 ORDER BY rank
-                 LIMIT ?2",
-            )
+            .prepare(&sql)
             .map_err(|e| PrimerError::Knowledge(format!("Query prepare failed: {e}")))?;
 
         let passages = stmt
@@ -103,5 +148,292 @@ impl KnowledgeBase for SqliteKnowledgeBase {
             .collect();
 
         Ok(passages)
+    }
+}
+
+// ─── Schema management ─────────────────────────────────────────────────────
+
+fn table_exists(conn: &Connection, name: &str) -> Result<bool> {
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type IN ('table','view') AND name=?1",
+            rusqlite::params![name],
+            |r| r.get(0),
+        )
+        .map_err(|e| PrimerError::Knowledge(format!("check table {name}: {e}")))?;
+    Ok(count > 0)
+}
+
+/// Create the per-locale tables idempotently. The FTS5 vtable uses
+/// SQLite's default tokenizer (`unicode61`) — fine for both English
+/// (case-folding, basic punctuation handling) and most other Latin /
+/// Cyrillic scripts. Locales with morphologically richer needs
+/// (heavy stemming, compound splitting) can override the tokenizer
+/// here per-pack-id when we add them; today every locale shares the
+/// same tokenizer.
+fn create_per_locale_tables(conn: &Connection, pack: &str) -> Result<()> {
+    let sql = format!(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS passages_{pack} USING fts5(
+            id,
+            source,
+            text,
+            content='passages_{pack}_content',
+            content_rowid='rowid'
+        );
+        CREATE TABLE IF NOT EXISTS passages_{pack}_content(
+            rowid INTEGER PRIMARY KEY,
+            id TEXT NOT NULL,
+            source TEXT NOT NULL,
+            text TEXT NOT NULL
+        );"
+    );
+    conn.execute_batch(&sql)
+        .map_err(|e| PrimerError::Knowledge(format!("Failed to create tables: {e}")))?;
+    Ok(())
+}
+
+/// Idempotent open-time setup. Three cases:
+///
+/// 1. **Legacy DB without locale tables**: copy rows from `passages_content`
+///    into `passages_<pack>_content`, rebuild the FTS index, drop the
+///    legacy tables. All in one transaction so a partial failure rolls
+///    back to the pre-migration state.
+/// 2. **Fresh or already-migrated DB**: create the locale tables if
+///    they don't already exist; otherwise no-op.
+///
+/// Migration is locale-specific: we adopt the legacy corpus into the
+/// locale being opened. That's the only sound assumption when the
+/// locale wasn't tracked at write time.
+fn migrate_or_create(conn: &Connection, pack: &str) -> Result<()> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| PrimerError::Knowledge(format!("begin migration tx: {e}")))?;
+
+    let legacy_exists = table_exists(&tx, "passages")?;
+    let new_exists = table_exists(&tx, &format!("passages_{pack}"))?;
+
+    if legacy_exists && !new_exists {
+        tracing::info!(
+            target = "primer-knowledge",
+            "migrating legacy `passages` table into `passages_{pack}`"
+        );
+        create_per_locale_tables(&tx, pack)?;
+        // Copy content first, then rebuild the FTS index from it.
+        tx.execute(
+            &format!(
+                "INSERT INTO passages_{pack}_content(rowid, id, source, text) \
+                 SELECT rowid, id, source, text FROM passages_content"
+            ),
+            [],
+        )
+        .map_err(|e| PrimerError::Knowledge(format!("copy legacy content: {e}")))?;
+        tx.execute(
+            &format!(
+                "INSERT INTO passages_{pack}(rowid, id, source, text) \
+                 SELECT rowid, id, source, text FROM passages_{pack}_content"
+            ),
+            [],
+        )
+        .map_err(|e| PrimerError::Knowledge(format!("rebuild FTS index: {e}")))?;
+        tx.execute_batch("DROP TABLE passages; DROP TABLE passages_content;")
+            .map_err(|e| PrimerError::Knowledge(format!("drop legacy tables: {e}")))?;
+    } else {
+        create_per_locale_tables(&tx, pack)?;
+    }
+
+    tx.commit()
+        .map_err(|e| PrimerError::Knowledge(format!("commit migration: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tmp_db_path() -> PathBuf {
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        dir.join(format!("primer-knowledge-test-{pid}-{nanos}.sqlite"))
+    }
+
+    #[tokio::test]
+    async fn open_for_english_creates_per_locale_tables() {
+        let path = tmp_db_path();
+        let kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::English).unwrap();
+        assert_eq!(kb.locale(), Locale::English);
+        // Insert + retrieve round-trip.
+        kb.insert_passage("p1", "test:source", "the quick brown fox jumps")
+            .unwrap();
+        let got = kb
+            .retrieve(
+                "fox",
+                &RetrievalParams {
+                    top_k: 5,
+                    min_score: f64::NEG_INFINITY,
+                    source_filter: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].id, "p1");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn open_back_compat_shim_uses_default_locale() {
+        let path = tmp_db_path();
+        let kb = SqliteKnowledgeBase::open(&path).unwrap();
+        assert_eq!(kb.locale(), Locale::default());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn reopen_existing_db_is_a_no_op() {
+        let path = tmp_db_path();
+        {
+            let kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::English).unwrap();
+            kb.insert_passage("p1", "src", "hello world").unwrap();
+        }
+        let kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::English).unwrap();
+        let got = kb
+            .retrieve(
+                "hello",
+                &RetrievalParams {
+                    top_k: 5,
+                    min_score: f64::NEG_INFINITY,
+                    source_filter: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(got.len(), 1);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn legacy_db_migrates_into_per_locale_tables_with_data_preserved() {
+        let path = tmp_db_path();
+        // Hand-roll a legacy schema (the pre-PR-2 layout) and pre-seed
+        // a row, then open under the new API and verify migration.
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE VIRTUAL TABLE passages USING fts5(
+                    id, source, text,
+                    content='passages_content', content_rowid='rowid'
+                );
+                CREATE TABLE passages_content(
+                    rowid INTEGER PRIMARY KEY,
+                    id TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    text TEXT NOT NULL
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO passages_content(rowid, id, source, text)
+                 VALUES (1, 'legacy-1', 'legacy:source', 'photosynthesis is amazing')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO passages(rowid, id, source, text)
+                 VALUES (1, 'legacy-1', 'legacy:source', 'photosynthesis is amazing')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::English).unwrap();
+        let got = kb
+            .retrieve(
+                "photosynthesis",
+                &RetrievalParams {
+                    top_k: 5,
+                    min_score: f64::NEG_INFINITY,
+                    source_filter: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(got.len(), 1, "legacy row should migrate into passages_en");
+        assert_eq!(got[0].id, "legacy-1");
+
+        // Legacy tables should be gone, locale-suffixed tables present.
+        {
+            let conn = kb.conn.lock().unwrap();
+            assert!(!table_exists(&conn, "passages").unwrap());
+            assert!(!table_exists(&conn, "passages_content").unwrap());
+            assert!(table_exists(&conn, "passages_en").unwrap());
+            assert!(table_exists(&conn, "passages_en_content").unwrap());
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn legacy_migration_rolls_back_on_partial_failure() {
+        // If a `passages_en` row pre-exists (manual user intervention,
+        // partial prior migration crash, etc.) such that the migration
+        // INSERT would conflict, the transaction rolls back and the
+        // legacy tables stay intact rather than leaving a mangled DB.
+        let path = tmp_db_path();
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE VIRTUAL TABLE passages USING fts5(
+                    id, source, text,
+                    content='passages_content', content_rowid='rowid'
+                );
+                CREATE TABLE passages_content(
+                    rowid INTEGER PRIMARY KEY,
+                    id TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    text TEXT NOT NULL
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO passages_content(rowid, id, source, text)
+                 VALUES (1, 'a', 's', 't')",
+                [],
+            )
+            .unwrap();
+            // Pre-seed a passages_en_content row that will collide on
+            // INSERT (rowid 1). This forces the migration's INSERT-SELECT
+            // to fail, exercising the rollback path.
+            conn.execute_batch(
+                "CREATE VIRTUAL TABLE passages_en USING fts5(
+                    id, source, text,
+                    content='passages_en_content', content_rowid='rowid'
+                );
+                CREATE TABLE passages_en_content(
+                    rowid INTEGER PRIMARY KEY,
+                    id TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    text TEXT NOT NULL
+                );
+                INSERT INTO passages_en_content(rowid, id, source, text)
+                    VALUES (1, 'pre-existing', 's', 't');",
+            )
+            .unwrap();
+        }
+        // `passages_en` already exists → migrate_or_create skips the
+        // legacy migration branch entirely (no conflict, no rollback).
+        // This test instead documents that case is benign: nothing
+        // moves when both tables already exist.
+        let _kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::English).unwrap();
+        let conn = Connection::open(&path).unwrap();
+        // Both tables still present.
+        assert!(table_exists(&conn, "passages").unwrap());
+        assert!(table_exists(&conn, "passages_en").unwrap());
+
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/crates/primer-knowledge/src/lib.rs
+++ b/src/crates/primer-knowledge/src/lib.rs
@@ -40,6 +40,13 @@ use std::sync::Mutex;
 pub struct SqliteKnowledgeBase {
     conn: Mutex<Connection>,
     locale: Locale,
+    /// `passages_<pack_id>` — the FTS5 virtual table name. Cached at
+    /// `open_for_locale` so the per-call `format!` allocation in the
+    /// insert/retrieve hot paths is gone.
+    passages_table: String,
+    /// `passages_<pack_id>_content` — the external-content storage
+    /// table name. Same caching rationale as `passages_table`.
+    content_table: String,
 }
 
 impl SqliteKnowledgeBase {
@@ -58,11 +65,14 @@ impl SqliteKnowledgeBase {
         let conn = Connection::open(path)
             .map_err(|e| PrimerError::Knowledge(format!("Failed to open DB: {e}")))?;
 
-        migrate_or_create(&conn, locale.pack_id())?;
+        let pack = locale.pack_id();
+        migrate_or_create(&conn, pack)?;
 
         Ok(Self {
             conn: Mutex::new(conn),
             locale,
+            passages_table: format!("passages_{pack}"),
+            content_table: format!("passages_{pack}_content"),
         })
     }
 
@@ -73,19 +83,11 @@ impl SqliteKnowledgeBase {
         self.locale
     }
 
-    fn passages_table(&self) -> String {
-        format!("passages_{}", self.locale.pack_id())
-    }
-
-    fn content_table(&self) -> String {
-        format!("passages_{}_content", self.locale.pack_id())
-    }
-
     /// Insert a passage into the knowledge base.
     pub fn insert_passage(&self, id: &str, source: &str, text: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        let content_table = self.content_table();
-        let passages_table = self.passages_table();
+        let content_table = &self.content_table;
+        let passages_table = &self.passages_table;
 
         conn.execute(
             &format!("INSERT INTO {content_table}(id, source, text) VALUES (?1, ?2, ?3)"),
@@ -110,7 +112,7 @@ impl SqliteKnowledgeBase {
 impl KnowledgeBase for SqliteKnowledgeBase {
     async fn retrieve(&self, query: &str, params: &RetrievalParams) -> Result<Vec<Passage>> {
         let conn = self.conn.lock().unwrap();
-        let passages_table = self.passages_table();
+        let passages_table = &self.passages_table;
 
         // FTS5 match query with BM25 ranking. Table name is interpolated
         // (NOT user input — comes from `Locale::pack_id()`, a closed
@@ -454,11 +456,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_migration_rolls_back_on_partial_failure() {
-        // If a `passages_en` row pre-exists (manual user intervention,
-        // partial prior migration crash, etc.) such that the migration
-        // INSERT would conflict, the transaction rolls back and the
-        // legacy tables stay intact rather than leaving a mangled DB.
+    async fn legacy_migration_skipped_when_target_already_exists() {
+        // If both `passages` and `passages_<pack>` exist, the
+        // `legacy_exists && !new_exists` guard in `migrate_or_create`
+        // skips the migration branch entirely. Documented behaviour:
+        // no-op, no data movement, both table sets stay intact. This
+        // covers DBs that were previously (partially or fully) opened
+        // under the new locale-aware API and still carry the legacy
+        // tables from a pre-PR-2 build.
         let path = tmp_db_path();
         {
             let conn = Connection::open(&path).unwrap();
@@ -472,20 +477,8 @@ mod tests {
                     id TEXT NOT NULL,
                     source TEXT NOT NULL,
                     text TEXT NOT NULL
-                );",
-            )
-            .unwrap();
-            conn.execute(
-                "INSERT INTO passages_content(rowid, id, source, text)
-                 VALUES (1, 'a', 's', 't')",
-                [],
-            )
-            .unwrap();
-            // Pre-seed a passages_en_content row that will collide on
-            // INSERT (rowid 1). This forces the migration's INSERT-SELECT
-            // to fail, exercising the rollback path.
-            conn.execute_batch(
-                "CREATE VIRTUAL TABLE passages_en USING fts5(
+                );
+                CREATE VIRTUAL TABLE passages_en USING fts5(
                     id, source, text,
                     content='passages_en_content', content_rowid='rowid'
                 );
@@ -494,21 +487,76 @@ mod tests {
                     id TEXT NOT NULL,
                     source TEXT NOT NULL,
                     text TEXT NOT NULL
-                );
-                INSERT INTO passages_en_content(rowid, id, source, text)
-                    VALUES (1, 'pre-existing', 's', 't');",
+                );",
             )
             .unwrap();
         }
-        // `passages_en` already exists → migrate_or_create skips the
-        // legacy migration branch entirely (no conflict, no rollback).
-        // This test instead documents that case is benign: nothing
-        // moves when both tables already exist.
+
         let _kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::English).unwrap();
         let conn = Connection::open(&path).unwrap();
-        // Both tables still present.
+        // Both legacy and locale-suffixed tables still present.
         assert!(table_exists(&conn, "passages").unwrap());
+        assert!(table_exists(&conn, "passages_content").unwrap());
         assert!(table_exists(&conn, "passages_en").unwrap());
+        assert!(table_exists(&conn, "passages_en_content").unwrap());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn legacy_migration_rolls_back_on_partial_failure() {
+        // Real rollback test: hand-roll a malformed legacy schema
+        // missing the `text` column. The migration's INSERT-SELECT
+        // (which references `text`) fails at SQL-prepare time, and
+        // since `migrate_or_create` runs the whole sequence inside a
+        // single `unchecked_transaction()`, the locale-suffixed tables
+        // it created earlier in the same transaction must also roll
+        // back — leaving the legacy tables intact and `passages_en`
+        // absent.
+        let path = tmp_db_path();
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE VIRTUAL TABLE passages USING fts5(
+                    id, source,
+                    content='passages_content', content_rowid='rowid'
+                );
+                CREATE TABLE passages_content(
+                    rowid INTEGER PRIMARY KEY,
+                    id TEXT NOT NULL,
+                    source TEXT NOT NULL
+                    -- no `text` column: forces migration INSERT-SELECT
+                    -- to fail with `no such column: text`.
+                );
+                INSERT INTO passages_content(rowid, id, source)
+                    VALUES (1, 'a', 's');",
+            )
+            .unwrap();
+        }
+
+        let result = SqliteKnowledgeBase::open_for_locale(&path, Locale::English);
+        let err = match result {
+            Ok(_) => panic!("malformed legacy schema must surface as an error"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, PrimerError::Knowledge(_)),
+            "expected Knowledge error, got: {err:?}"
+        );
+
+        let conn = Connection::open(&path).unwrap();
+        // Legacy tables intact.
+        assert!(table_exists(&conn, "passages").unwrap());
+        assert!(table_exists(&conn, "passages_content").unwrap());
+        // Locale-suffixed tables rolled back.
+        assert!(
+            !table_exists(&conn, "passages_en").unwrap(),
+            "passages_en must roll back when migration fails"
+        );
+        assert!(
+            !table_exists(&conn, "passages_en_content").unwrap(),
+            "passages_en_content must roll back when migration fails"
+        );
 
         let _ = std::fs::remove_file(&path);
     }

--- a/src/crates/primer-knowledge/src/lib.rs
+++ b/src/crates/primer-knowledge/src/lib.rs
@@ -252,13 +252,23 @@ mod tests {
     use std::path::PathBuf;
 
     fn tmp_db_path() -> PathBuf {
+        // Two parallel `tokio::test`s can call this helper inside the
+        // same nanosecond on fast machines and collide on filename, which
+        // surfaces as `SQLITE_READONLY_DBMOVED` mid-test. The atomic
+        // counter guarantees per-process uniqueness regardless of clock
+        // resolution.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
         let dir = std::env::temp_dir();
         let pid = std::process::id();
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        dir.join(format!("primer-knowledge-test-{pid}-{nanos}.sqlite"))
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        dir.join(format!(
+            "primer-knowledge-test-{pid}-{nanos}-{seq}.sqlite"
+        ))
     }
 
     #[tokio::test]

--- a/src/crates/primer-knowledge/src/lib.rs
+++ b/src/crates/primer-knowledge/src/lib.rs
@@ -378,6 +378,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cross_locale_isolation_passages_inserted_in_de_do_not_appear_in_en() {
+        // Open the same DB file under two different locales and verify
+        // their FTS5 indices stay isolated. This is the structural
+        // guarantee that BM25 stays locale-pure: each locale only ever
+        // queries its own `passages_<pack_id>` table.
+        let path = tmp_db_path();
+        // Insert a German passage.
+        {
+            let kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::German).unwrap();
+            kb.insert_passage(
+                "de-1",
+                "wikipedia:de:Photosynthese",
+                "Photosynthese ist der Vorgang, bei dem Pflanzen Licht aufnehmen.",
+            )
+            .unwrap();
+        }
+        // Insert an English passage.
+        {
+            let kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::English).unwrap();
+            kb.insert_passage(
+                "en-1",
+                "wikipedia:en:Photosynthesis",
+                "Photosynthesis is the process plants use to capture light.",
+            )
+            .unwrap();
+        }
+        // Query under English — only English row should come back.
+        {
+            let kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::English).unwrap();
+            let got = kb
+                .retrieve(
+                    "photosynthesis",
+                    &RetrievalParams {
+                        top_k: 10,
+                        min_score: f64::NEG_INFINITY,
+                        source_filter: vec![],
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(got.len(), 1, "English KB must not return German rows");
+            assert_eq!(got[0].id, "en-1");
+        }
+        // Query under German — only German row should come back. Use
+        // the German term so the query is locale-appropriate; the
+        // index isolation is what's being verified here, not query
+        // tokenisation.
+        {
+            let kb = SqliteKnowledgeBase::open_for_locale(&path, Locale::German).unwrap();
+            let got = kb
+                .retrieve(
+                    "photosynthese",
+                    &RetrievalParams {
+                        top_k: 10,
+                        min_score: f64::NEG_INFINITY,
+                        source_filter: vec![],
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(got.len(), 1, "German KB must not return English rows");
+            assert_eq!(got[0].id, "de-1");
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
     async fn legacy_migration_rolls_back_on_partial_failure() {
         // If a `passages_en` row pre-exists (manual user intervention,
         // partial prior migration crash, etc.) such that the migration

--- a/src/crates/primer-knowledge/src/lib.rs
+++ b/src/crates/primer-knowledge/src/lib.rs
@@ -266,9 +266,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-        dir.join(format!(
-            "primer-knowledge-test-{pid}-{nanos}-{seq}.sqlite"
-        ))
+        dir.join(format!("primer-knowledge-test-{pid}-{nanos}-{seq}.sqlite"))
     }
 
     #[tokio::test]

--- a/src/crates/primer-pedagogy/prompts/de.toml
+++ b/src/crates/primer-pedagogy/prompts/de.toml
@@ -24,7 +24,11 @@
 
 [meta]
 language = "de"
-language_name = "Deutsch"
+# `language_name` is an internal identity check against
+# `Locale::name()` and must be the English name of the locale, not
+# the native one. The native form ("Deutsch") would break the meta
+# consistency validator that PR #17 added.
+language_name = "German"
 bcp47 = "de-DE"
 
 # --- BASIS-SYSTEMPROMPT ---

--- a/src/crates/primer-pedagogy/prompts/de.toml
+++ b/src/crates/primer-pedagogy/prompts/de.toml
@@ -1,0 +1,197 @@
+# Deutsches Prompt-Pack — Locale::German.
+#
+# Diese Datei enthält jeden pädagogisch tragenden Text, den der Primer
+# an das LLM sendet, wenn die Locale auf Deutsch eingestellt ist. Der
+# Rust-Prompt-Builder liest aus dieser Datei; er enthält keine
+# deutschen Strings.
+#
+# Ansprache: das Kind wird durchgängig mit „du" angesprochen, nicht mit
+# „Sie". Deutsche Kinder werden außerhalb formaler Institutionen
+# universell mit „du" angesprochen — das ist der einzig richtige
+# Register für ein Kinderprodukt.
+#
+# Diese Datei ist KEINE wörtliche Übersetzung von en.toml. Die
+# Pädagogik wurde übernommen; die Beispiele, die Vokabel-Beispiele
+# und insbesondere die Sprachführung pro Altersgruppe wurden für das
+# Deutsche neu geschrieben (deutsche Komposita folgen nicht den
+# Silbenregeln des Englischen, „Energie" ist im Deutschen weniger
+# abstrakt als im Englischen, etc.).
+#
+# Platzhalter-Syntax: `{name}`, `{age}`, `{language_guidance}` werden
+# zur Renderzeit ersetzt. Jedes Feld hat eine feste Liste erlaubter
+# Platzhalter — `TomlPromptPack::load` validiert beim Laden und löst
+# eine Panik bei unbekannten Tokens aus.
+
+[meta]
+language = "de"
+language_name = "Deutsch"
+bcp47 = "de-DE"
+
+# --- BASIS-SYSTEMPROMPT ---
+# Erlaubte Platzhalter: {name}, {age}, {language_guidance}
+[system_prompt]
+base = """\
+Du bist der Primer — ein geduldiger, neugieriger, sokratischer Lernbegleiter für ein Kind namens {name}, {age} Jahre alt.
+
+Deine Grundprinzipien:
+- Gib NIEMALS eine direkte Antwort, wenn du stattdessen eine leitende Frage stellen kannst.
+- Stelle Fragen, die {name} dabei helfen, die Antwort selbst zu entdecken.
+- Wenn {name} antwortet, prüfe, ob das Verständnis echt ist oder nur geraten/nachgeplappert.
+- Bei echtem Verständnis: erkenne es an und erweitere — „Gut. Was wäre, wenn...?"
+- Bei Schwierigkeiten: biete ein konkretes Beispiel, eine Analogie oder eine Geschichte an. Verringere die Abstraktion.
+- Wenn {name} eine reine Faktenfrage stellt („Wie weit ist der Mond entfernt?"): antworte direkt und klar, lenke DANN zu einer sokratischen Folgefrage über („Jetzt, wo du weißt, dass es 384.000 km sind, wie lange würde es dauern, dorthin zu fahren?").
+- Sei warmherzig. Sei geduldig. Sei niemals herablassend. Behandle jede Frage als wertvoll.
+- Du versuchst NICHT, {name} um jeden Preis bei der Stange zu halten. Wenn das Kind aufhören möchte, lass es aufhören. Sage „Das war's für heute" ohne schlechtes Gewissen.
+- Du verwendest weder Emojis noch übermäßig viele Ausrufezeichen.
+
+Sprache für ein {age}-jähriges Kind — lies das aufmerksam:
+{language_guidance}
+
+Wortwahl-Disziplin (gilt für jedes Alter):
+- Bevor du ein Fachwort oder ein ungewöhnliches Wort benutzt (Beispiele in diesem Alter: „Plasma", „Molekül", „Leiter", „Isolator", „Schockwelle", „Schwingung", „Frequenz", „Spannung", „Stromstärke", „Atom", „Teilchen"), erkläre die Idee zuerst in einfachen Alltagsworten anhand einer konkreten Analogie, die {name} bereits kennt (Essen, Spielzeug, Tiere, Wetter, Familie, Körper). Verwende das Fachwort erst, wenn die Alltagserklärung klar ist — und auch dann ist das Fachwort optional, niemals Pflicht.
+- Wenn {name} fragt „Was bedeutet X?" (zum Beispiel was „abstoßen" bedeutet), ist das ein Signal, dass X zu früh eingeführt wurde. Erkläre X zunächst in einfachen Alltagsworten. In den nächsten ein, zwei Sätzen verwende nur die einfache Variante. Dann webe X allmählich wieder ein, gleichbedeutend mit der einfachen Bedeutung („die Luft drückt die Ladungen weg — sie stößt sie ab"), damit {name} das Gespräch mit einem *gewonnenen* neuen Wort beendet, nicht mit einem weggenommenen. Wiederhole neu eingeführte Wörter noch ein paar Mal vor Sitzungsende — kurze, beiläufige Wiederholung lässt Vokabular tatsächlich haften.
+- Eine neue Idee pro Satz. Wenn ein Satz zwei unbekannte Dinge einführt, teile ihn auf.
+- Stoppe nach zwei oder drei Erklärungssätzen und stelle eine Frage. Halte keinen Vortrag.\
+"""
+
+# --- ALTERSGRUPPEN-SPRACHFÜHRUNG ---
+# Diese Abschnitte sind die sprachabhängigsten. Sie wurden NICHT aus
+# dem Englischen übersetzt — die Drei-Silben-Regel des Englischen ist
+# für das Deutsche bedeutungslos (Komposita sind im Deutschen schon
+# für junge Kinder Alltag). Die Regeln hier sind aus deutscher
+# Perspektive neu formuliert: Komposita-Tiefe statt Silbenanzahl,
+# lateinische/griechische Wurzeln als Marker für Fachsprache, etc.
+[language_guidance]
+ages_0_6 = """\
+- Verwende nur Wörter, die ein junges Kind zu Hause oder im Kindergarten kennt.
+- Sätze sind kurz — etwa 6 bis 10 Wörter.
+- Komposita aus zwei vertrauten Alltagsteilen sind in Ordnung („Kühlschrank", „Spielplatz"). Vermeide Komposita aus drei oder mehr Teilen sowie Wörter mit lateinischen oder griechischen Wurzeln, es sei denn, du hast sie gerade durch ein konkretes Alltagsbeispiel eingeführt und das Kind hat das Beispiel verstanden.
+- Verankere jede Idee in etwas, das das Kind sehen, anfassen, hören oder tun kann: Essen, Spielzeug, Haustiere, Körper, Wetter, Familie.
+- Vermeide abstrakte Substantive („Energie", „Materie", „Kraft"), solange du sie nicht zuvor in einem konkreten Ding verankert hast.\
+"""
+
+ages_7_9 = """\
+- Verwende Alltagswörter, die ein junges Kind zu Hause oder in der Grundschule kennt.
+- Kurze, klare Sätze — meist 8 bis 15 Wörter. Teile längere Gedanken in einzelne Sätze auf.
+- Behandle Wörter mit lateinischen oder griechischen Wurzeln wie „Molekül", „Plasma", „Leiter", „Isolator", „Schwingung", „Schockwelle", „Trommelfell", „Druckwelle", „Elektron" als FACHWÖRTER — sie brauchen die in der Wortwahl-Disziplin beschriebene Alltagseinführung.
+- Lange technische Komposita (über drei Bestandteile) zählen ebenfalls als Fachwörter — führe sie ein, indem du die Bestandteile einzeln benennst.
+- Verankere abstrakte Ideen in etwas, das das Kind sehen, anfassen oder tun kann — Küche, Spielplatz, Bad, Bett, Haustiere, Familie — bevor du die abstrakte Variante einführst.
+- Lieber zweimal in einfachen Worten sagen als einmal richtig mit einem schwierigen Wort.\
+"""
+
+ages_10_12 = """\
+- Klare Alltagssprache; mittlere Satzlängen sind in Ordnung.
+- Neue Fachbegriffe sind erlaubt, aber definiere sie beim ersten Auftreten kurz mit einem konkreten Beispiel. Das gilt besonders für Wörter mit lateinischen/griechischen Wurzeln und für lange technische Komposita.
+- Eine mäßig abstrakte Idee pro Antwort ist in Ordnung, solange du sie an etwas Konkretes anbindest.\
+"""
+
+ages_13_plus = """\
+- Erwachsenenwortschatz ist zugelassen, aber führe spezialisierte Fachsprache beim ersten Auftreten weiterhin mit einer kurzen Alltagserklärung ein.
+- Satzlänge und Komplexität dürfen denen eines artikulierten Teenagers entsprechen.\
+"""
+
+# --- PÄDAGOGISCHE ABSICHT ---
+# Schlüssel müssen mit den Varianten von `PedagogicalIntent` in
+# snake_case übereinstimmen. Keine Platzhalter erlaubt.
+[intent]
+socratic_question = "Deine nächste Antwort soll eine leitende Frage sein, die zum Verständnis führt."
+
+comprehension_check = """\
+Deine nächste Antwort soll prüfen, ob das Kind wirklich versteht \
+oder nur Gehörtes wiederholt. Bitte das Kind, es anders zu erklären, \
+auf eine neue Situation anzuwenden oder einen Fehler in einer \
+absichtlich falschen Aussage zu finden.\
+"""
+
+scaffolding = """\
+Das Kind hat Schwierigkeiten. Deine nächste Antwort soll ein konkretes \
+Beispiel, eine Geschichte oder eine Analogie anbieten, die das Konzept \
+greifbar macht. Verringere die Abstraktion.\
+"""
+
+encouragement = """\
+Das Kind ist frustriert. Deine nächste Antwort soll ermutigen, \
+ohne herablassend zu sein. Erkenne die Schwierigkeit an. Normalisiere \
+Verwirrung. Schlage einen anderen Zugang vor.\
+"""
+
+extension = """\
+Das Kind hat Verständnis gezeigt. Deine nächste Antwort soll das \
+Konzept erweitern — führe eine Komplikation, ein Gegenbeispiel oder \
+eine Verbindung zu einem anderen Bereich ein.\
+"""
+
+direct_answer = """\
+Das ist eine Faktenfrage. Antworte direkt und klar, lenke dann mit \
+einer sokratischen Folgefrage über, die auf der Antwort aufbaut.\
+"""
+
+answer_then_pivot = """\
+Gib die Antwort knapp und lenke dann zu einer Frage, die das Kind \
+nachdenken lässt, *warum* die Tatsache wichtig ist oder was sich \
+ändern würde, wenn sie anders wäre.\
+"""
+
+session_close = """\
+Schlage vor, dass dies ein guter Schlusspunkt ist. Fasse zusammen, \
+was heute *erforscht* wurde (nicht was 'gelernt' wurde — was \
+*erforscht* wurde). Lass das Kind mit einer Frage zum Nachdenken bis \
+zum nächsten Mal.\
+"""
+
+# --- ENGAGEMENT-HINWEISE ---
+# Werden nur an den Systemprompt angefügt, wenn das Kind im
+# entsprechenden Zustand ist. Keine Platzhalter erlaubt.
+[engagement]
+frustrated = """\
+WICHTIG: Das Kind wirkt frustriert. Sei besonders sanft. Biete an, \
+das Thema anders anzugehen oder ganz zu wechseln.\
+"""
+
+disengaging = """\
+HINWEIS: Das Kind verliert vielleicht das Interesse. Erwäge eine \
+Pause vorzuschlagen oder zu einem Thema zu wechseln, das es \
+spannender findet.\
+"""
+
+# --- KONTEXT-/GEDÄCHTNIS-EINLEITUNGEN ---
+# Einzeilige Überschriften, die nur erscheinen, wenn der entsprechende
+# Abschnitt nicht leer ist. Der Inhalt (Passagen / Zusammenfassung /
+# abgerufene Wendungen) wird vom Renderer angefügt.
+[sections]
+# Erlaubte Platzhalter: {age}
+knowledge_intro = "Relevanter Sachkontext (zur Begründung deiner Antworten — nicht direkt zitieren, sondern für ein {age}-jähriges Kind umformulieren):"
+summary_intro = "Früher in diesem Gespräch (Langzeitgedächtnis über viele Wendungen hinweg):"
+retrieved_intro = "Relevante frühere Momente aus dieser Sitzung (nach Thema gefunden, nicht in Reihenfolge — als Hintergrund verstehen, nicht als aktuelles Gespräch):"
+
+# --- SPRECHER-LABELS ---
+# Werden in „[Kind] ..." / „[Primer] ..." in den abgerufenen früheren
+# Momenten verwendet. Keine Platzhalter erlaubt.
+[labels]
+child = "Kind"
+primer = "Primer"
+
+# --- FAKTENFRAGEN-ERKENNUNG ---
+# Kleingeschriebene Präfixe, die die Eingabe des Kindes als direkte
+# Faktensuche markieren; werden zu DirectAnswer geroutet (oder zu
+# AnswerThenPivot, falls die vorherige Primer-Wendung bereits ein
+# DirectAnswer war). Das nachfolgende Leerzeichen verhindert
+# Teilwort-Treffer.
+#
+# Erkundende Formen („was wäre, wenn..."), „warum"-Fragen und
+# „was bedeutet" sind absichtlich ausgeschlossen — diese sind
+# sokratisch reichhaltiger und sollen nicht mit einer direkten
+# Antwort kurzgeschlossen werden. Insbesondere wird „was bedeutet X?"
+# vom Systemprompt selbst behandelt (Wortwahl-Disziplin: Signal,
+# dass X zu früh eingeführt wurde).
+[question_detection]
+factual_prefixes = [
+    "was ist ",
+    "was sind ",
+    "wie funktioniert ",
+    "wie funktionieren ",
+    "wie ist ",
+    "wie sind ",
+    "wo ist ",
+    "wer ist ",
+]

--- a/src/crates/primer-pedagogy/src/prompt_builder.rs
+++ b/src/crates/primer-pedagogy/src/prompt_builder.rs
@@ -1227,6 +1227,53 @@ factual_prefixes = []
         }
     }
 
+    // ─── German locale: prompt rendering smoke + locale-dispatch ──────
+
+    #[test]
+    fn snapshot_german_pack_renders_native_german_prompt() {
+        // Build a system prompt under Locale::German and assert the
+        // markers that pin native-German rendering. Not a byte-exact
+        // snapshot — translators may iterate on the wording — but it
+        // catches: (a) accidental English fragments from a pack-dispatch
+        // bug, (b) placeholder substitution failures, (c) section-intro
+        // dispatch errors.
+        use crate::prompt_pack;
+        let pack = prompt_pack::load(primer_core::i18n::Locale::German).expect("german pack loads");
+        let learner = snapshot_learner(8, EngagementState::FrustratedStuck);
+        let prompt = super::build_system_prompt_with_pack(
+            &*pack,
+            &learner,
+            PedagogicalIntent::Scaffolding,
+            &[snapshot_passage()],
+            "Wir haben über die Schwerkraft gesprochen.",
+            &[child_turn("über Blitze geredet", vec![])],
+        );
+        // Base block markers.
+        assert!(prompt.starts_with("Du bist der Primer"));
+        assert!(prompt.contains("namens Tester"));
+        assert!(prompt.contains("8 Jahre alt"));
+        // Age-7-9 band marker.
+        assert!(prompt.contains("Grundschule"));
+        // Intent: Scaffolding instruction in German.
+        assert!(prompt.contains("Schwierigkeiten"));
+        assert!(prompt.contains("Verringere die Abstraktion"));
+        // Engagement note (FrustratedStuck → frustrated note).
+        assert!(prompt.contains("WICHTIG"));
+        assert!(prompt.contains("frustriert"));
+        // Knowledge intro (with {age} substituted).
+        assert!(prompt.contains("8-jähriges Kind umformulieren"));
+        // Summary intro.
+        assert!(prompt.contains("Früher in diesem Gespräch"));
+        // Retrieved-moments intro.
+        assert!(prompt.contains("Relevante frühere Momente"));
+        assert!(prompt.contains("[Kind]"));
+        // No accidental English fragments.
+        assert!(!prompt.contains("You are the Primer"));
+        assert!(!prompt.contains("Your next response"));
+        assert!(!prompt.contains("Earlier in this conversation"));
+        assert!(!prompt.contains("Relevant prior moments"));
+    }
+
     #[test]
     fn build_prompt_includes_engagement_note_for_frustrated_trying() {
         let learner = learner_with(EngagementState::FrustratedTrying, vec![]);

--- a/src/crates/primer-pedagogy/src/prompt_pack.rs
+++ b/src/crates/primer-pedagogy/src/prompt_pack.rs
@@ -122,6 +122,7 @@ pub fn load_cached(locale: Locale) -> Result<Arc<dyn PromptPack>> {
         return load(locale);
     }
     static EN_PACK: OnceLock<Arc<dyn PromptPack>> = OnceLock::new();
+    static DE_PACK: OnceLock<Arc<dyn PromptPack>> = OnceLock::new();
     match locale {
         Locale::English => {
             if let Some(p) = EN_PACK.get() {
@@ -129,6 +130,14 @@ pub fn load_cached(locale: Locale) -> Result<Arc<dyn PromptPack>> {
             }
             let p = load(locale)?;
             let _ = EN_PACK.set(Arc::clone(&p));
+            Ok(p)
+        }
+        Locale::German => {
+            if let Some(p) = DE_PACK.get() {
+                return Ok(Arc::clone(p));
+            }
+            let p = load(locale)?;
+            let _ = DE_PACK.set(Arc::clone(&p));
             Ok(p)
         }
     }

--- a/src/crates/primer-pedagogy/src/prompt_pack.rs
+++ b/src/crates/primer-pedagogy/src/prompt_pack.rs
@@ -616,8 +616,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unknown placeholder")]
-    fn corrupted_german_pack_with_unknown_placeholder_panics_at_load() {
+    fn corrupted_german_pack_with_unknown_placeholder_returns_err() {
         // Deliberately corrupt the language_guidance field of an
         // otherwise-valid German pack with a `{nme}` typo. Validates
         // that the per-field placeholder allowlist fires for German
@@ -628,7 +627,7 @@ mod tests {
             r#"
 [meta]
 language = "de"
-language_name = "Deutsch"
+language_name = "German"
 bcp47 = "de-DE"
 
 [system_prompt]
@@ -661,7 +660,11 @@ factual_prefixes = []
 "#,
             INTENT_KEYS = all_intents_zeroed_toml(),
         );
-        let _ = TomlPromptPack::from_toml_str(Locale::German, &body);
+        let result = TomlPromptPack::from_toml_str(Locale::German, &body);
+        let err = result.err().expect("expected unknown-placeholder error");
+        let s = format!("{err}");
+        assert!(s.contains("unknown placeholder"), "got: {s}");
+        assert!(s.contains("nme"), "got: {s}");
     }
 
     #[test]

--- a/src/crates/primer-pedagogy/src/prompt_pack.rs
+++ b/src/crates/primer-pedagogy/src/prompt_pack.rs
@@ -63,14 +63,16 @@ pub trait PromptPack: Send + Sync {
     fn factual_prefixes(&self) -> &[String];
 }
 
-/// English pack embedded at compile time so a binary can ship without
-/// any data files alongside it. Override at runtime via
+/// Per-locale packs embedded at compile time so a binary can ship
+/// without any data files alongside it. Override at runtime via
 /// `PRIMER_PROMPTS_DIR`.
 const EN_TOML: &str = include_str!("../prompts/en.toml");
+const DE_TOML: &str = include_str!("../prompts/de.toml");
 
 fn embedded_pack(locale: Locale) -> &'static str {
     match locale {
         Locale::English => EN_TOML,
+        Locale::German => DE_TOML,
     }
 }
 
@@ -501,6 +503,156 @@ mod tests {
 
     fn english_pack() -> Arc<dyn PromptPack> {
         load(Locale::English).expect("english pack loads")
+    }
+
+    fn german_pack() -> Arc<dyn PromptPack> {
+        load(Locale::German).expect("german pack loads")
+    }
+
+    #[test]
+    fn german_pack_loads_from_embedded_toml() {
+        let pack = german_pack();
+        assert_eq!(pack.locale(), Locale::German);
+        assert_eq!(pack.child_label(), "Kind");
+        assert_eq!(pack.primer_label(), "Primer");
+    }
+
+    #[test]
+    fn german_pack_renders_base_with_name_and_age() {
+        let pack = german_pack();
+        let s = pack.render_base("Lieschen", 8);
+        assert!(s.contains("namens Lieschen"), "got: {s}");
+        assert!(s.contains("8 Jahre alt"), "got: {s}");
+        assert!(
+            !s.contains("{name}") && !s.contains("{age}") && !s.contains("{language_guidance}"),
+            "all placeholders substituted: {s}"
+        );
+        // Sanity: a few key German phrases that should appear in the
+        // rendered base — guards against accidental English fragments.
+        assert!(s.contains("sokratischer"), "expected German ‘sokratischer’");
+        assert!(s.contains("geduldiger"), "expected German ‘geduldiger’");
+        assert!(!s.contains("Socratic learning"), "no English fragments");
+    }
+
+    #[test]
+    fn german_pack_age_band_selection() {
+        let pack = german_pack();
+        // Pick a unique German marker per band.
+        assert!(pack.render_base("X", 5).contains("Kindergarten"));
+        assert!(pack.render_base("X", 8).contains("Grundschule"));
+        assert!(
+            pack.render_base("X", 11)
+                .contains("Mittlere Satzlängen sind in Ordnung")
+                || pack.render_base("X", 11).contains("mittlere Satzlängen")
+        );
+        assert!(pack.render_base("X", 15).contains("Erwachsenenwortschatz"));
+    }
+
+    #[test]
+    fn german_pack_intent_lookups_all_populated() {
+        let pack = german_pack();
+        for &intent in ALL_INTENTS {
+            let s = pack.intent_instruction(intent);
+            assert!(!s.is_empty(), "missing instruction for {intent:?}");
+            // Every intent message should be in German — assert the
+            // absence of the English-pack signature phrase as a smoke
+            // test against accidental copy-paste from en.toml.
+            assert!(
+                !s.contains("Your next response"),
+                "english fragment leaked into intent {intent:?}: {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn german_pack_engagement_notes_in_german() {
+        let pack = german_pack();
+        let frustrated = pack.engagement_note(EngagementState::FrustratedStuck);
+        assert!(frustrated.contains("WICHTIG"), "got: {frustrated}");
+        assert!(frustrated.contains("frustriert"), "got: {frustrated}");
+        let disengaging = pack.engagement_note(EngagementState::Disengaging);
+        assert!(disengaging.contains("HINWEIS"), "got: {disengaging}");
+        assert!(disengaging.contains("Interesse"), "got: {disengaging}");
+    }
+
+    #[test]
+    fn german_pack_factual_prefixes_are_german() {
+        let pack = german_pack();
+        let prefixes: Vec<&str> = pack.factual_prefixes().iter().map(String::as_str).collect();
+        assert!(
+            !prefixes.is_empty(),
+            "german factual_prefixes must not be empty"
+        );
+        assert!(
+            prefixes.contains(&"was ist "),
+            "expected ‘was ist ’: {prefixes:?}"
+        );
+        assert!(
+            prefixes.contains(&"wie funktioniert "),
+            "expected ‘wie funktioniert ’: {prefixes:?}"
+        );
+        // Negative: no English prefixes should leak in.
+        assert!(
+            !prefixes.contains(&"what is "),
+            "english prefix leaked into german pack: {prefixes:?}"
+        );
+    }
+
+    #[test]
+    fn german_pack_knowledge_intro_substitutes_age() {
+        let pack = german_pack();
+        let s = pack.knowledge_intro(8);
+        assert!(s.contains("8-jähriges"), "got: {s}");
+        assert!(!s.contains("{age}"));
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown placeholder")]
+    fn corrupted_german_pack_with_unknown_placeholder_panics_at_load() {
+        // Deliberately corrupt the language_guidance field of an
+        // otherwise-valid German pack with a `{nme}` typo. Validates
+        // that the per-field placeholder allowlist fires for German
+        // exactly as it does for English (same code path; this is a
+        // sanity test that the locale-dispatch wiring doesn't somehow
+        // bypass validation).
+        let body = format!(
+            r#"
+[meta]
+language = "de"
+language_name = "Deutsch"
+bcp47 = "de-DE"
+
+[system_prompt]
+base = "Hallo {{name}}, {{age}} Jahre alt.\n{{language_guidance}}"
+
+[language_guidance]
+ages_0_6 = "Hallo {{nme}}"
+ages_7_9 = ""
+ages_10_12 = ""
+ages_13_plus = ""
+
+[intent]
+{INTENT_KEYS}
+
+[engagement]
+frustrated = ""
+disengaging = ""
+
+[sections]
+knowledge_intro = ""
+summary_intro = ""
+retrieved_intro = ""
+
+[labels]
+child = "Kind"
+primer = "Primer"
+
+[question_detection]
+factual_prefixes = []
+"#,
+            INTENT_KEYS = all_intents_zeroed_toml(),
+        );
+        let _ = TomlPromptPack::from_toml_str(Locale::German, &body);
     }
 
     #[test]

--- a/src/crates/primer-storage/src/lib.rs
+++ b/src/crates/primer-storage/src/lib.rs
@@ -30,22 +30,37 @@ use rusqlite::{Connection, OptionalExtension};
 use uuid::Uuid;
 
 /// SQLite-backed session store.
+///
+/// Each store is scoped to a single `Locale`. The application invariant
+/// is one learner per DB file, and one learner has one locale, so the
+/// store's locale matches the learner's. The locale is used as the
+/// `concept_language_tag` value when concepts are first inserted into
+/// the shared `concepts` table — `INSERT OR IGNORE` semantics mean the
+/// first locale to introduce a concept name owns the tag forever.
 #[derive(Debug)]
 pub struct SqliteSessionStore {
     conn: Mutex<Connection>,
+    locale: primer_core::i18n::Locale,
 }
 
 impl SqliteSessionStore {
-    /// Open (or create) a session store at `path`. Use `:memory:` for
-    /// an in-memory database.
+    /// Open (or create) a session store at `path`, defaulting to the
+    /// English locale. Back-compat shim for callers that pre-date the
+    /// locale-aware API.
+    pub fn open(path: &Path) -> Result<Self> {
+        Self::open_for_locale(path, primer_core::i18n::Locale::default())
+    }
+
+    /// Open (or create) a session store at `path` scoped to `locale`.
+    /// Use `:memory:` for an in-memory database.
     ///
     /// Creates the schema if missing, sets `PRAGMA foreign_keys = ON`,
-    /// asserts/sets `PRAGMA user_version`, and applies v2 through v5
+    /// asserts/sets `PRAGMA user_version`, and applies v2 through v6
     /// migrations to bring older DBs up to date. The migrations are
-    /// idempotent — safe to run on a fresh DB or any pre-v5 DB. A version
+    /// idempotent — safe to run on a fresh DB or any pre-v6 DB. A version
     /// newer than this build understands is a hard error rather than a
     /// silent downgrade.
-    pub fn open(path: &Path) -> Result<Self> {
+    pub fn open_for_locale(path: &Path, locale: primer_core::i18n::Locale) -> Result<Self> {
         let conn = Connection::open(path)
             .map_err(|e| PrimerError::Storage(format!("open failed: {e}")))?;
 
@@ -110,7 +125,14 @@ impl SqliteSessionStore {
 
         Ok(Self {
             conn: Mutex::new(conn),
+            locale,
         })
+    }
+
+    /// Locale this store is scoped to. Used as the
+    /// `concept_language_tag` value when concepts are first inserted.
+    pub fn locale(&self) -> primer_core::i18n::Locale {
+        self.locale
     }
 }
 
@@ -179,7 +201,9 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
                 )
                 .map_err(|e| PrimerError::Storage(format!("prepare insert turn: {e}")))?;
             let mut insert_concept = tx
-                .prepare("INSERT OR IGNORE INTO concepts (name) VALUES (?1)")
+                .prepare(
+                    "INSERT OR IGNORE INTO concepts (name, concept_language_tag) VALUES (?1, ?2)",
+                )
                 .map_err(|e| PrimerError::Storage(format!("prepare insert concept: {e}")))?;
             let mut select_concept = tx
                 .prepare("SELECT id FROM concepts WHERE name = ?1")
@@ -217,7 +241,7 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
                         Some(id) => id,
                         None => {
                             insert_concept
-                                .execute(rusqlite::params![name])
+                                .execute(rusqlite::params![name, self.locale.pack_id()])
                                 .map_err(|e| {
                                     PrimerError::Storage(format!("upsert concept {name}: {e}"))
                                 })?;
@@ -640,7 +664,7 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
             })?;
 
         let mut insert_concept = tx
-            .prepare("INSERT OR IGNORE INTO concepts (name) VALUES (?1)")
+            .prepare("INSERT OR IGNORE INTO concepts (name, concept_language_tag) VALUES (?1, ?2)")
             .map_err(|e| PrimerError::Storage(format!("prepare insert concept: {e}")))?;
         let mut select_concept = tx
             .prepare("SELECT id FROM concepts WHERE name = ?1")
@@ -651,7 +675,7 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
 
         for name in concepts {
             insert_concept
-                .execute(rusqlite::params![name])
+                .execute(rusqlite::params![name, self.locale.pack_id()])
                 .map_err(|e| PrimerError::Storage(format!("upsert concept {name}: {e}")))?;
             let cid: i64 = select_concept
                 .query_row(rusqlite::params![name], |r| r.get(0))
@@ -694,8 +718,11 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
             std::collections::HashMap::new();
 
         {
+            let locale_tag = self.locale.pack_id();
             let mut insert_concept = tx
-                .prepare("INSERT OR IGNORE INTO concepts (name) VALUES (?1)")
+                .prepare(
+                    "INSERT OR IGNORE INTO concepts (name, concept_language_tag) VALUES (?1, ?2)",
+                )
                 .map_err(|e| PrimerError::Storage(format!("prepare insert concept: {e}")))?;
             let mut select_concept = tx
                 .prepare("SELECT id FROM concepts WHERE name = ?1")
@@ -729,7 +756,7 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
                         Some(id) => id,
                         None => {
                             insert_concept
-                                .execute(rusqlite::params![name])
+                                .execute(rusqlite::params![name, locale_tag])
                                 .map_err(|e| {
                                     PrimerError::Storage(format!("upsert concept {name}: {e}"))
                                 })?;
@@ -803,8 +830,8 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
                 id
             } else {
                 tx.execute(
-                    "INSERT OR IGNORE INTO concepts (name) VALUES (?1)",
-                    rusqlite::params![a.concept],
+                    "INSERT OR IGNORE INTO concepts (name, concept_language_tag) VALUES (?1, ?2)",
+                    rusqlite::params![a.concept, self.locale.pack_id()],
                 )
                 .map_err(|e| {
                     PrimerError::Storage(format!("save_comprehensions: upsert concept: {e}"))
@@ -911,7 +938,9 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
         //    learner_concepts.
         if !learner.concepts.is_empty() {
             let mut insert_concept = tx
-                .prepare("INSERT OR IGNORE INTO concepts (name) VALUES (?1)")
+                .prepare(
+                    "INSERT OR IGNORE INTO concepts (name, concept_language_tag) VALUES (?1, ?2)",
+                )
                 .map_err(|e| PrimerError::Storage(format!("prepare insert concept: {e}")))?;
             let mut select_concept = tx
                 .prepare("SELECT id FROM concepts WHERE name = ?1")
@@ -940,7 +969,7 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
                     Some(id) => id,
                     None => {
                         insert_concept
-                            .execute(rusqlite::params![concept.concept_id])
+                            .execute(rusqlite::params![concept.concept_id, self.locale.pack_id()])
                             .map_err(|e| {
                                 PrimerError::Storage(format!(
                                     "upsert concept {}: {e}",
@@ -3277,6 +3306,78 @@ mod learner_store_tests {
             .query_row("SELECT COUNT(*) FROM learners", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    // ─── concept_language_tag (PR 5: i18n cross-locale tagging) ──────
+
+    #[tokio::test]
+    async fn save_learner_tags_concepts_with_store_locale() {
+        // German-locale store; first-time concept inserts should land
+        // with concept_language_tag = 'de'.
+        let store = SqliteSessionStore::open_for_locale(
+            std::path::Path::new(":memory:"),
+            primer_core::i18n::Locale::German,
+        )
+        .unwrap();
+        store.save_learner(&sample_learner()).await.unwrap();
+        let conn = store.conn.lock().unwrap();
+        let tags: Vec<String> = conn
+            .prepare("SELECT concept_language_tag FROM concepts ORDER BY id")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert!(!tags.is_empty(), "expected concepts inserted");
+        for t in &tags {
+            assert_eq!(t, "de", "every concept should be tagged 'de': {tags:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn first_locale_to_introduce_concept_owns_the_tag() {
+        // INSERT OR IGNORE semantics: once a concept name exists, the
+        // tag stays put even if a different-locale store later "inserts"
+        // the same name. This is the documented behaviour — first
+        // introduction wins. Cross-locale concept linkage is a follow-up
+        // PR; for now we just verify the documented behaviour.
+        let path = std::env::temp_dir().join(format!(
+            "primer-storage-locale-precedence-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        // Open once as English, save a learner whose concepts include
+        // "physics:gravity".
+        {
+            let en_store =
+                SqliteSessionStore::open_for_locale(&path, primer_core::i18n::Locale::English)
+                    .unwrap();
+            en_store.save_learner(&sample_learner()).await.unwrap();
+        }
+        // Reopen the same DB as German and save the SAME learner again
+        // (same concept names). The concept rows already exist; their
+        // tag should stay 'en' because of INSERT OR IGNORE.
+        {
+            let de_store =
+                SqliteSessionStore::open_for_locale(&path, primer_core::i18n::Locale::German)
+                    .unwrap();
+            de_store.save_learner(&sample_learner()).await.unwrap();
+            let conn = de_store.conn.lock().unwrap();
+            let tags: Vec<String> = conn
+                .prepare("SELECT concept_language_tag FROM concepts ORDER BY id")
+                .unwrap()
+                .query_map([], |r| r.get::<_, String>(0))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            for t in &tags {
+                assert_eq!(t, "en", "first-introducer wins: {tags:?}");
+            }
+        }
+        let _ = std::fs::remove_file(&path);
     }
 
     #[tokio::test]

--- a/src/crates/primer-storage/src/lib.rs
+++ b/src/crates/primer-storage/src/lib.rs
@@ -218,6 +218,7 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
             // doesn't hit the DB twice.
             let mut concept_name_cache: std::collections::HashMap<String, i64> =
                 std::collections::HashMap::new();
+            let locale_tag = self.locale.pack_id();
 
             for (idx, turn) in session.turns.iter().enumerate().skip(persisted_count) {
                 let speaker_id = catalog::speaker_id(turn.speaker);
@@ -241,7 +242,7 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
                         Some(id) => id,
                         None => {
                             insert_concept
-                                .execute(rusqlite::params![name, self.locale.pack_id()])
+                                .execute(rusqlite::params![name, locale_tag])
                                 .map_err(|e| {
                                     PrimerError::Storage(format!("upsert concept {name}: {e}"))
                                 })?;
@@ -672,10 +673,11 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
         let mut link_concept = tx
             .prepare("INSERT OR IGNORE INTO turn_concepts (turn_id, concept_id) VALUES (?1, ?2)")
             .map_err(|e| PrimerError::Storage(format!("prepare link concept: {e}")))?;
+        let locale_tag = self.locale.pack_id();
 
         for name in concepts {
             insert_concept
-                .execute(rusqlite::params![name, self.locale.pack_id()])
+                .execute(rusqlite::params![name, locale_tag])
                 .map_err(|e| PrimerError::Storage(format!("upsert concept {name}: {e}")))?;
             let cid: i64 = select_concept
                 .query_row(rusqlite::params![name], |r| r.get(0))
@@ -824,6 +826,7 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
         // update_exchange_concepts.
         let mut concept_id_cache: std::collections::HashMap<String, i64> =
             std::collections::HashMap::new();
+        let locale_tag = self.locale.pack_id();
 
         for a in assessments {
             let concept_id = if let Some(&id) = concept_id_cache.get(&a.concept) {
@@ -831,7 +834,7 @@ impl primer_core::storage::SessionStore for SqliteSessionStore {
             } else {
                 tx.execute(
                     "INSERT OR IGNORE INTO concepts (name, concept_language_tag) VALUES (?1, ?2)",
-                    rusqlite::params![a.concept, self.locale.pack_id()],
+                    rusqlite::params![a.concept, locale_tag],
                 )
                 .map_err(|e| {
                     PrimerError::Storage(format!("save_comprehensions: upsert concept: {e}"))
@@ -963,13 +966,14 @@ impl primer_core::storage::LearnerStore for SqliteSessionStore {
             // Per-call cache to skip re-querying concepts within one save.
             let mut concept_id_cache: std::collections::HashMap<String, i64> =
                 std::collections::HashMap::new();
+            let locale_tag = self.locale.pack_id();
 
             for concept in &learner.concepts {
                 let cid = match concept_id_cache.get(&concept.concept_id).copied() {
                     Some(id) => id,
                     None => {
                         insert_concept
-                            .execute(rusqlite::params![concept.concept_id, self.locale.pack_id()])
+                            .execute(rusqlite::params![concept.concept_id, locale_tag])
                             .map_err(|e| {
                                 PrimerError::Storage(format!(
                                     "upsert concept {}: {e}",
@@ -3234,6 +3238,138 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    // ─── i18n: concept_language_tag across INSERT sites (PR 5) ──────────
+    //
+    // Companion tests for the per-site coverage gap noted in the PR review.
+    // `save_learner` is already covered in `learner_store_tests`. The four
+    // tests below pin the same behaviour for the other INSERT paths so a
+    // regression introducing a sixth INSERT site without the tag would be
+    // caught locally rather than only via the cross-store precedence test.
+
+    fn open_memory_for_locale(locale: primer_core::i18n::Locale) -> SqliteSessionStore {
+        SqliteSessionStore::open_for_locale(std::path::Path::new(":memory:"), locale)
+            .expect("open :memory: for locale")
+    }
+
+    fn collect_concept_tags(store: &SqliteSessionStore) -> Vec<String> {
+        let conn = store.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare("SELECT concept_language_tag FROM concepts ORDER BY id")
+            .unwrap();
+        stmt.query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn save_session_tags_concepts_with_store_locale() {
+        use primer_core::conversation::Speaker;
+
+        let store = open_memory_for_locale(primer_core::i18n::Locale::German);
+        let mut session = Session::new(Uuid::new_v4());
+        session.add_turn(make_turn(
+            Speaker::Child,
+            "warum ist der Himmel blau",
+            None,
+            vec!["Himmel".into(), "Licht".into()],
+        ));
+        store.save_session(&session).await.unwrap();
+
+        let tags = collect_concept_tags(&store);
+        assert_eq!(tags.len(), 2, "expected two concept rows: {tags:?}");
+        for t in &tags {
+            assert_eq!(t, "de", "save_session must tag with store locale: {tags:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn update_turn_concepts_tags_concepts_with_store_locale() {
+        let store = open_memory_for_locale(primer_core::i18n::Locale::German);
+        let mut session = primer_core::conversation::Session::new(Uuid::new_v4());
+        session.add_turn(primer_core::conversation::Turn {
+            speaker: primer_core::conversation::Speaker::Child,
+            text: "was ist Photosynthese?".into(),
+            timestamp: Utc::now(),
+            intent: None,
+            concepts: vec![],
+        });
+        store.save_session(&session).await.unwrap();
+
+        store
+            .update_turn_concepts(session.id, 0, &["Photosynthese".into(), "Biologie".into()])
+            .await
+            .unwrap();
+
+        let tags = collect_concept_tags(&store);
+        assert_eq!(tags.len(), 2, "expected two concept rows: {tags:?}");
+        for t in &tags {
+            assert_eq!(
+                t, "de",
+                "update_turn_concepts must tag with store locale: {tags:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn update_exchange_concepts_tags_concepts_with_store_locale() {
+        let store = open_memory_for_locale(primer_core::i18n::Locale::German);
+        let session = make_two_turn_session();
+        store.save_session(&session).await.unwrap();
+
+        store
+            .update_exchange_concepts(session.id, 0, &["Schwerkraft".into()], 1, &["Masse".into()])
+            .await
+            .unwrap();
+
+        let tags = collect_concept_tags(&store);
+        assert_eq!(tags.len(), 2, "expected two concept rows: {tags:?}");
+        for t in &tags {
+            assert_eq!(
+                t, "de",
+                "update_exchange_concepts must tag with store locale: {tags:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn save_comprehensions_tags_concepts_with_store_locale() {
+        use primer_core::comprehension::ComprehensionAssessment;
+        use primer_core::learner::UnderstandingDepth;
+
+        let store = open_memory_for_locale(primer_core::i18n::Locale::German);
+        let session = make_two_turn_session();
+        store.save_session(&session).await.unwrap();
+
+        let assessments = vec![
+            ComprehensionAssessment {
+                concept: "Photosynthese".into(),
+                depth: UnderstandingDepth::Comprehension,
+                confidence: 0.85,
+                evidence: None,
+            },
+            ComprehensionAssessment {
+                concept: "Chlorophyll".into(),
+                depth: UnderstandingDepth::Aware,
+                confidence: 0.6,
+                evidence: None,
+            },
+        ];
+        store
+            .save_comprehensions(session.id, 1, &assessments, "llm:test:model")
+            .await
+            .unwrap();
+
+        let tags = collect_concept_tags(&store);
+        assert_eq!(tags.len(), 2, "expected two concept rows: {tags:?}");
+        for t in &tags {
+            assert_eq!(
+                t, "de",
+                "save_comprehensions must tag with store locale: {tags:?}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Why this exists

PRs #18, #19, #25, and #26 were marked MERGED on GitHub but only **into their stacked parents**, not into main. Only PR #17 (i18n PR 1) actually reached main, and it landed in a **substantially revised** form (~313 lines slimmer than the original branch commit, with `prompt_pack.rs`, `prompt_builder.rs`, `dialogue_manager.rs`, and `primer-storage` all reshaped).

This PR brings the work of i18n PRs 2-5 + the post-PR-26 review fixes onto main, cherry-picked off the `claude/i18n-pr5-concept-locale` stack and rebased against main's tightened PR 1 contract.

## Commits

| SHA | Origin | What |
|---|---|---|
| `5232782` | PR #18 | per-locale FTS5 tables in primer-knowledge |
| `3932deb` | PR #19 | locale-keyed TTS in LoopBackends |
| `fd9005d` | PR #25 | German locale: Locale::German + de.toml + render_german |
| `492ea26` | rebase fix | extend `load_cached` to `Locale::German` (function added during PR #17's revisions, didn't exist on the original branch) |
| `1d2451c` | PR #26 | tag concepts with `concept_language_tag` + cross-locale RAG isolation test |
| `4b752da` | PR #26 review | hoist `locale_tag`, cover 4 INSERT sites, fix `tmp_db_path` collision |
| `71e9f2a` | rebase fix | align German pack with main's tightened validators (`meta.language_name = "German"`, error-returning placeholder test) |
| `c610709` | rebase fix | `cargo fmt` follow-up on `tmp_db_path` |

The three "rebase fix" commits are the only delta vs. mechanically replaying the originals — they exist because main's PR 1 added `load_cached`, tightened `validate_meta_consistency`, and switched `from_toml_str` from panic to `Result`. Each rebase-fix commit message explains its rationale.

## What lands on main once this merges

- Locale-aware system prompts (English + German), hot-reloadable via `PRIMER_PROMPTS_DIR`
- Per-locale FTS5 indices for the knowledge base (cross-locale isolation tested)
- Per-locale-keyed TTS dispatch (single entry today; German voice drops in cleanly when wired)
- German `render_inference_error` arm
- All concepts tagged with their introducing locale (`concept_language_tag`)
- `--language de` end-to-end: German prompt + German factual-prefix routing + German error messages + concepts tagged `'de'`
- All 5 concept-INSERT sites consistently hoist `locale_tag` and write the language tag

## Test plan

- [x] `cargo test --workspace` — **422 tests pass** (was 405 on main pre-PR-2; +4 from PR 2 isolation, +1 from cross-locale knowledge test, +5 from PR 4 German tests, +3 from PR 5 tag tests, +4 from review-fix tag tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Out of scope (deferred follow-ups, both filed as issues)

- #29 — detect locale/learner mismatch on `--resume`
- #30 — migrate remaining `SqliteSessionStore::open()` callers to `open_for_locale`

🤖 Generated with [Claude Code](https://claude.com/claude-code)