### PR TITLE
docs(devel): contributor manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ cargo run --bin primer -- --resume <uuid>
 
 When the resumed session has more than `context_window_turns` (default 20) turns, the Primer maintains long-term memory in two complementary ways: a rolling LLM-generated summary (refreshed on resume only when the loaded one is stale, then every 20 further pre-window turns during active conversation) and FTS5-based retrieval of relevant older turns based on the current child input. Both are injected into the system prompt — the chat-message timeline the model sees stays equal to the last 20 turns, so context budget is bounded even across hours of conversation.
 
+## Contributing
+
+**Developer manual:** see [docs/devel/](docs/devel/) for the full contributor manual — getting started, architecture, subsystem deep-dives, and how-to recipes (add a new backend, schema migration, locale, …).
+
 ## License
 
 AGPL-3.0 — see [LICENSE](LICENSE).

--- a/docs/devel/01-getting-started.md
+++ b/docs/devel/01-getting-started.md
@@ -1,0 +1,119 @@
+# Getting started
+
+Welcome! This developer manual is for open-source contributors who have just cloned The Primer and want to get a working build, run their first conversation, and understand where things live before making changes. If you have used Rust before, the steps below should take ten to fifteen minutes; if anything trips you up, the **Gotcha** callouts in this chapter are the issues people hit most often.
+
+This chapter walks you through prerequisites, cloning, the first stub-mode run, then each optional backend (cloud, Ollama, embeddings, voice). It ends with a tour of testing, logging, and where the conversation data lives. Later chapters go deeper into the architecture and the contribution workflow.
+
+## Prerequisites
+
+You need:
+
+- **rustup** (NOT Homebrew rust). Install from <https://rustup.rs>. The repo's `rust-toolchain.toml` pins the toolchain version that the build expects.
+- **(optional) espeak-ng** — only needed if you plan to run `--speech` mode. macOS: `brew install espeak-ng`. Debian/Ubuntu: `sudo apt install espeak-ng-data`.
+- **(optional) An Anthropic API key** — only needed if you plan to run the cloud backend. Free Ollama and the no-network stub backend both work without one.
+
+> **Gotcha:** Homebrew rust shadows rustup on `$PATH` and ignores `rust-toolchain.toml`. The `silero` and `whisper` features need Rust 1.87+, which Homebrew may not yet ship. Always invoke as `~/.cargo/bin/cargo` for primer commands, or remove Homebrew rust from your `$PATH`. If a build fails with a confusing edition or feature-flag error, this is almost always why.
+
+## Cloning and the workspace layout
+
+> **Gotcha:** The workspace root is `src/Cargo.toml`, not the repo root. Every cargo command runs from `src/`. There is no `Cargo.toml` at the repo root, so `cargo build` from the top-level directory will fail with "could not find `Cargo.toml`".
+
+```bash
+git clone https://github.com/<org>/primer.git
+cd primer/src
+cargo build
+```
+
+The first build pulls dependencies and compiles twelve workspace crates, which takes a few minutes on a fresh checkout. SQLite is bundled and TLS uses rustls, so there are no system C libraries to install for the default build.
+
+## First run (stub backend, no API key)
+
+The stub backend returns canned Socratic responses with no model and no network. It is the fastest way to confirm your build works:
+
+```bash
+cargo run --bin primer
+```
+
+You will see a greeting and a prompt. Type a question, hit return, and a stub response comes back. Type `quit`, `exit`, or `bye` to leave.
+
+> **Note:** The binary is named `primer`, not `primer-cli`, because that is the `[[bin]]` name in the CLI crate's `Cargo.toml`. Use `cargo run --bin primer` even though the crate directory is `primer-cli/`.
+
+## Cloud backend (Anthropic)
+
+The cloud backend streams responses from the Anthropic Messages API. It needs an `ANTHROPIC_API_KEY` in your environment.
+
+The CLI auto-loads `.env` files at startup from two locations: a project-local `.env` (searched up from the current working directory) and a user-global `~/.primer_env`. Project-local wins over the home file, so a per-repo `.env` overrides anything you have set globally. Both `.env` and `~/.primer_env` are gitignored.
+
+```bash
+cp ../.env.example ../.env
+# edit ../.env to add ANTHROPIC_API_KEY=sk-ant-...
+cargo run --bin primer -- --backend cloud --name Binti --age 8
+```
+
+`--name` and `--age` are used to build the learner profile and to tune the system prompt for the child's age. The default cloud model is `claude-sonnet-4-6`; override with `--model claude-opus-4-7` (or any current Anthropic model id).
+
+## Ollama backend
+
+If you have [Ollama](https://ollama.com) running locally, you can point the Primer at it instead of the cloud:
+
+```bash
+cargo run --bin primer -- --backend ollama --model llama3.2
+```
+
+`--model` is required for Ollama and must match a tag you have already pulled (`ollama pull llama3.2`). The default endpoint is `http://localhost:11434`; override with `--ollama-url`.
+
+## Embeddings (hybrid retrieval)
+
+By default, the Primer's knowledge base uses BM25-only retrieval. To enable the hybrid (BM25 + dense-vector) retrieval pipeline, build with the `embedding` feature and pass `--embedder-backend fastembed`:
+
+```bash
+cargo run --bin primer --features primer-cli/embedding -- --embedder-backend fastembed
+```
+
+> **Note:** First run downloads BGE-M3 (~570 MB) into `~/.cache/primer/models/`. This is expected, not a hang — subsequent runs use the cached copy. The download uses the same `cdn.pyke.io` ONNX-runtime path as the speech feature.
+
+If the download fails, the Primer falls back to BM25-only and logs a warning rather than refusing to start.
+
+## Voice mode (speech)
+
+Voice mode swaps the text REPL for a full LISTEN -> THINK -> SPEAK -> LISTEN loop using Silero VAD, Whisper STT, and Piper TTS. It is gated by the `speech` Cargo feature so default builds stay light.
+
+> **Gotcha:** `--speech` requires system espeak-ng for Piper to phonemise text. The bundled `espeak-rs` ships an incomplete subset that fails on most voices. macOS: `brew install espeak-ng`. Debian/Ubuntu: `sudo apt install espeak-ng-data`.
+
+You will also need a whisper.cpp model file and a Piper voice (matching `.onnx` and `.onnx.json` sidecar). Piper voices live at <https://huggingface.co/rhasspy/piper-voices>; whisper.cpp models at <https://huggingface.co/ggerganov/whisper.cpp>.
+
+```bash
+cargo run --bin primer --features primer-cli/speech -- \
+  --speech \
+  --whisper-model <path>.bin \
+  --voice-onnx <path>.onnx \
+  --voice-config <path>.onnx.json \
+  --voice <model-id>
+```
+
+`--voice` is the `VoiceProfile.model_id` and must match the file stem of `--voice-onnx` — Piper rejects mismatches at session open.
+
+## Tests, logging, verbose output
+
+The workspace ships with parser, dialogue-manager, and integration tests across every crate.
+
+```bash
+cargo test                              # all tests
+cargo test -p primer-pedagogy           # one crate
+cargo test -p primer-pedagogy decide    # by substring
+RUST_LOG=debug cargo run --bin primer
+cargo run --bin primer -- --verbose     # pedagogy-flow tracing on stderr
+```
+
+`RUST_LOG=debug` enables verbose tracing across the whole codebase. `--verbose` is a lighter-weight option that prints just the pedagogical decisions (`[intent]`, `[classifier]`, `[extractor]`, `[comprehension]`) to stderr while keeping stdout clean for the conversation transcript.
+
+## Where session data lives
+
+By default, every conversation is persisted to `~/.primer/<slugified-name>.db` — one SQLite file per child, separate from the knowledge-base corpus on privacy grounds. The first time the directory is created, the CLI prints a one-line banner explaining where the data lives and how to opt out.
+
+If you want a one-off in-memory session that disappears when you exit, pass `--no-persist`. This is mutually exclusive with `--resume` and `--session-db`.
+
+## What to read next
+
+- [02-architecture-overview.md](02-architecture-overview.md) for the big picture — the twelve-crate layered graph, the trait boundaries, and the data-flow through a single turn.
+- [09-contributing.md](09-contributing.md) for the PR workflow, commit-message conventions, and how reviews work.

--- a/docs/devel/02-architecture-overview.md
+++ b/docs/devel/02-architecture-overview.md
@@ -1,0 +1,110 @@
+# Architecture overview
+
+## The central design principle
+
+Trait-based hardware abstraction. Backend selection is a runtime config choice, not a code change. This is what allows Phase 0 (cloud) to share code with Phase 1 (local NPU) and Phase 2 (voice).
+
+Concretely: the pedagogical engine — the part that decides what the Primer says next, when to ask a Socratic question, when to suggest a break — never imports `reqwest`, never knows whether inference is happening on a cloud GPU or a local NPU, never cares whether speech is synthesized through Piper or skipped entirely. It talks to traits defined in `primer-core`, and at startup the CLI wires concrete implementations into those slots. Swapping cloud Claude for a local llama.cpp build is a config flag, not a refactor. Adding a new speech engine means writing a new struct that implements `TextToSpeech` and registering it; nothing else changes.
+
+This is the load-bearing decision in the codebase. Most other architectural choices follow from it.
+
+## The crate graph
+
+The workspace is twelve crates organised in three layers: a binary at the top, a pedagogical engine in the middle, and a constellation of trait-implementing crates at the bottom that all depend on `primer-core` (which defines every public trait).
+
+Why does this matter to you? Because almost every contribution touches one of these crates, and the dependency arrows tell you what you can change in isolation and what ripples outward. A new inference backend is a self-contained PR inside `primer-inference`. A change to the `KnowledgeBase` trait signature, by contrast, ripples through every consumer. The diagram below is your map for the rest of this manual — subsequent chapters drill into individual crates, and each one assumes you know roughly where it sits.
+
+> **Legend:** blue = trait/interface (defined in `primer-core`); green = concrete implementation; amber = external boundary (HTTP, filesystem, vendor); grey = stub / test-only.
+
+```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'fontSize': '16px',
+    'fontFamily': 'system-ui, -apple-system, sans-serif',
+    'primaryColor': '#1e3a5f',
+    'primaryTextColor': '#ffffff',
+    'primaryBorderColor': '#4a90d9',
+    'lineColor': '#888888',
+    'secondaryColor': '#2d5016',
+    'tertiaryColor': '#5a3a1e'
+  }
+}}%%
+graph LR
+  classDef trait fill:#1e3a5f,stroke:#4a90d9,stroke-width:2px,color:#ffffff
+  classDef impl  fill:#2d5016,stroke:#5cb85c,stroke-width:2px,color:#ffffff
+
+  CLI[primer-cli]:::impl
+  PED[primer-pedagogy]:::impl
+  CORE[primer-core<br/>traits + types]:::trait
+  INF[primer-inference]:::impl
+  KB[primer-knowledge]:::impl
+  STO[primer-storage]:::impl
+  CLS[primer-classifier]:::impl
+  EXT[primer-extractor]:::impl
+  CMP[primer-comprehension]:::impl
+  EMB[primer-embedding]:::impl
+  KBL[primer-kb-load]:::impl
+  SP[primer-speech]:::impl
+
+  CLI --> PED
+  PED --> CORE
+  INF --> CORE
+  KB --> CORE
+  STO --> CORE
+  CLS --> CORE
+  EXT --> CORE
+  CMP --> CORE
+  EMB --> CORE
+  KBL --> CORE
+  SP --> CORE
+```
+
+ASCII fallback for environments where mermaid does not render:
+
+```
+primer-cli  →  primer-pedagogy  →  primer-core  ←  primer-inference, primer-speech, primer-knowledge, primer-storage, primer-classifier, primer-comprehension, primer-extractor, primer-embedding, primer-kb-load
+```
+
+The arrows point toward dependencies. `primer-core` is the hub: it defines `InferenceBackend`, `KnowledgeBase`, `SessionStore`, `LearnerStore`, `Embedder`, the speech traits, and the shared types they exchange (`Session`, `Turn`, `PedagogicalIntent`, `LearnerModel`, …). Every other crate either depends on `primer-core` to implement one of its traits, or depends on `primer-pedagogy` (and transitively `primer-core`) to consume the engine. There is no path from `primer-core` back out to a concrete implementation, which is what keeps the abstraction honest.
+
+## Crate-by-crate
+
+| Crate | Owns | Chapter |
+|---|---|---|
+| `primer-core` | every trait + shared types + consts + i18n + retry | §3-§7 |
+| `primer-inference` | `InferenceBackend` impls (stub, cloud, ollama) | [03](03-inference-and-pedagogy.md) |
+| `primer-pedagogy` | `DialogueManager`, `prompt_builder`, `decide_intent` | [03](03-inference-and-pedagogy.md) |
+| `primer-knowledge` | `SqliteKnowledgeBase`, FTS5 + hybrid retrieval | [04](04-knowledge-and-retrieval.md) |
+| `primer-embedding` | `Embedder` impls (stub, fastembed, ollama) | [04](04-knowledge-and-retrieval.md) |
+| `primer-kb-load` | JSONL ingestion, auto-seed, `--reembed` | [04](04-knowledge-and-retrieval.md) |
+| `primer-storage` | `SessionStore`, `LearnerStore`, schema migrations | [05](05-storage-and-sessions.md) |
+| `primer-classifier` | engagement classifier | [06](06-classifiers-and-learner-model.md) |
+| `primer-extractor` | concept extractor | [06](06-classifiers-and-learner-model.md) |
+| `primer-comprehension` | comprehension classifier | [06](06-classifiers-and-learner-model.md) |
+| `primer-speech` | VAD/STT/TTS impls + speech_loop helpers | [07](07-speech-and-voice-loop.md) |
+| `primer-cli` | the REPL binary `primer` | [03](03-inference-and-pedagogy.md), [08](08-testing-and-debugging.md) |
+
+A few orientation notes that the table can't carry on its own:
+
+- **The binary is named `primer`, not `primer-cli`** — that's the crate name, but `[[bin]]` in `primer-cli/Cargo.toml` renames the produced executable. So `cargo run --bin primer` is correct.
+- **`primer-pedagogy` is the only crate that depends on `primer-core` *and* nothing else internal.** It holds the engine but knows nothing about HTTP, SQLite, or audio. You can read the whole thing without touching a single I/O dep.
+- **The three "classifier" crates** (`primer-classifier`, `primer-extractor`, `primer-comprehension`) all share a structural pattern: a trait, an LLM-backed implementation that wraps `Arc<dyn InferenceBackend>`, and a stub for tests. They run *off* the main turn loop (spawned tasks, awaited at the start of the next turn), which is what keeps inference latency from compounding.
+- **`primer-storage` and `primer-knowledge` are deliberately separate.** Sessions (one DB per child, in `~/.primer/`) hold private learner data; the knowledge base holds the public RAG corpus. Privacy is the reason — see chapter 5.
+
+## The four pedagogical principles
+
+These are constraints on every change; if a change makes the Primer more answer-y or more engagement-maximising, it is wrong.
+
+1. The Primer asks more questions than it answers; pure factual questions get a direct answer, then a Socratic pivot.
+2. The Primer never tries to maximise engagement. It detects frustration/disengagement and offers breaks, scaffolding, or session close — never guilt.
+3. All learner data is local; cloud inference sends turns per-request only.
+4. Comprehension is verified through transfer questions, application, and contradiction probing — not assumed from a confident-sounding response.
+
+If a proposed change in code review feels off and you can't articulate why, check it against these four. They are not aspirational — they are encoded in the system prompt, in `decide_intent()`, in the retry budget, in the storage schema. Changes that quietly drift the product away from them are the most important ones to catch.
+
+## Status
+
+→ [README.md](../../README.md) for what works today.
+→ [ROADMAP.md](../../ROADMAP.md) for the phase plan.
+→ [primer_technical_spec.md](../../primer_technical_spec.md) for the long-form vision.

--- a/docs/devel/02-architecture-overview.md
+++ b/docs/devel/02-architecture-overview.md
@@ -14,7 +14,7 @@ The workspace is twelve crates organised in three layers: a binary at the top, a
 
 Why does this matter to you? Because almost every contribution touches one of these crates, and the dependency arrows tell you what you can change in isolation and what ripples outward. A new inference backend is a self-contained PR inside `primer-inference`. A change to the `KnowledgeBase` trait signature, by contrast, ripples through every consumer. The diagram below is your map for the rest of this manual — subsequent chapters drill into individual crates, and each one assumes you know roughly where it sits.
 
-> **Legend:** blue = trait/interface (defined in `primer-core`); green = concrete implementation; amber = external boundary (HTTP, filesystem, vendor); grey = stub / test-only.
+> **Legend:** blue = trait/interface (defined in `primer-core`); green = concrete implementation. Subsequent chapters introduce amber (external boundary) and grey (stub / test-only) for diagrams that need them.
 
 ```mermaid
 %%{init: {
@@ -66,13 +66,15 @@ ASCII fallback for environments where mermaid does not render:
 primer-cli  →  primer-pedagogy  →  primer-core  ←  primer-inference, primer-speech, primer-knowledge, primer-storage, primer-classifier, primer-comprehension, primer-extractor, primer-embedding, primer-kb-load
 ```
 
+`primer-cli` additionally depends on every concrete impl crate (`primer-inference`, `primer-knowledge`, `primer-embedding`, `primer-storage`, `primer-classifier`, `primer-extractor`, `primer-comprehension`, `primer-kb-load`, `primer-speech`) so it can construct the trait objects at startup — but it never imports their internals; it only uses them through the traits in `primer-core`.
+
 The arrows point toward dependencies. `primer-core` is the hub: it defines `InferenceBackend`, `KnowledgeBase`, `SessionStore`, `LearnerStore`, `Embedder`, the speech traits, and the shared types they exchange (`Session`, `Turn`, `PedagogicalIntent`, `LearnerModel`, …). Every other crate either depends on `primer-core` to implement one of its traits, or depends on `primer-pedagogy` (and transitively `primer-core`) to consume the engine. There is no path from `primer-core` back out to a concrete implementation, which is what keeps the abstraction honest.
 
 ## Crate-by-crate
 
 | Crate | Owns | Chapter |
 |---|---|---|
-| `primer-core` | every trait + shared types + consts + i18n + retry | §3-§7 |
+| `primer-core` | every trait + shared types + consts + i18n + retry | shared by all chapters |
 | `primer-inference` | `InferenceBackend` impls (stub, cloud, ollama) | [03](03-inference-and-pedagogy.md) |
 | `primer-pedagogy` | `DialogueManager`, `prompt_builder`, `decide_intent` | [03](03-inference-and-pedagogy.md) |
 | `primer-knowledge` | `SqliteKnowledgeBase`, FTS5 + hybrid retrieval | [04](04-knowledge-and-retrieval.md) |

--- a/docs/devel/03-inference-and-pedagogy.md
+++ b/docs/devel/03-inference-and-pedagogy.md
@@ -27,21 +27,21 @@ pub trait InferenceBackend: Send + Sync {
 }
 ```
 
-Full source at [inference.rs](src/crates/primer-core/src/inference.rs). The `Prompt` type carries a `system: String` plus a `Vec<Message>` of role-tagged history; `TokenStream` is `Pin<Box<dyn Stream<Item = Result<TokenChunk>> + Send>>`.
+Full source at [inference.rs](../../src/crates/primer-core/src/inference.rs). The `Prompt` type carries a `system: String` plus a `Vec<Message>` of role-tagged history; `TokenStream` is `Pin<Box<dyn Stream<Item = Result<TokenChunk>> + Send>>`.
 
 ## The three concrete backends
 
 ### StubBackend
 
-Canned Socratic responses, no model, no network. It implements the trait with a small lookup keyed on intent and emits one final `TokenChunk` to satisfy the streaming signature — a degenerate but valid stream that the rest of the pipeline handles correctly. This is the default for `cargo run --bin primer` (no API key required) and the only backend the workspace tests rely on, which is why most of the dialogue manager's behaviour can be exercised with no model at all. See [stub.rs](src/crates/primer-inference/src/stub.rs).
+Canned Socratic responses, no model, no network. It implements the trait with a small lookup keyed on intent and emits one final `TokenChunk` to satisfy the streaming signature — a degenerate but valid stream that the rest of the pipeline handles correctly. This is the default for `cargo run --bin primer` (no API key required) and the only backend the workspace tests rely on, which is why most of the dialogue manager's behaviour can be exercised with no model at all. See [stub.rs](../../src/crates/primer-inference/src/stub.rs).
 
 ### CloudBackend (Anthropic SSE)
 
-The Anthropic Messages API streams via Server-Sent Events: `event:` and `data:` lines separated by blank lines, with JSON payloads that carry `content_block_delta` events. `CloudBackend` parses this with a hand-rolled `SseBuffer` and a `parse_anthropic_event` function — no SSE crate dependency. The byte stream is consumed by a spawned tokio task that forwards parsed chunks through a `futures::channel::mpsc::unbounded` channel; the `TokenStream` returned to the caller wraps the receiver. One detail to know: the Anthropic API treats system instructions as a top-level field on the request body, not a message role, so `CloudBackend` maps `Role::System` entries from the `Prompt`'s message list to `"user"` when serialising. See [cloud.rs](src/crates/primer-inference/src/cloud.rs).
+The Anthropic Messages API streams via Server-Sent Events: `event:` and `data:` lines separated by blank lines, with JSON payloads that carry `content_block_delta` events. `CloudBackend` parses this with a hand-rolled `SseBuffer` and a `parse_anthropic_event` function — no SSE crate dependency. The byte stream is consumed by a spawned tokio task that forwards parsed chunks through a `futures::channel::mpsc::unbounded` channel; the `TokenStream` returned to the caller wraps the receiver. One detail to know: the Anthropic API treats system instructions as a top-level field on the request body, not a message role, so `CloudBackend` maps `Role::System` entries from the `Prompt`'s message list to `"user"` when serialising. See [cloud.rs](../../src/crates/primer-inference/src/cloud.rs).
 
 ### OllamaBackend (NDJSON)
 
-Ollama's `/api/chat` endpoint streams newline-delimited JSON: one complete object per `\n`-terminated line, each carrying a `message.content` fragment and a final `done: true` line. `OllamaBackend` parses this with `NdjsonBuffer` and `parse_ollama_line`, with the same spawned-task-plus-mpsc shape as the cloud backend. The divergence here is that Ollama's chat API has no separate system field, so the backend prepends a `system`-role message to the messages array rather than mapping it onto a `"user"` slot. See [ollama.rs](src/crates/primer-inference/src/ollama.rs).
+Ollama's `/api/chat` endpoint streams newline-delimited JSON: one complete object per `\n`-terminated line, each carrying a `message.content` fragment and a final `done: true` line. `OllamaBackend` parses this with `NdjsonBuffer` and `parse_ollama_line`, with the same spawned-task-plus-mpsc shape as the cloud backend. The divergence here is that Ollama's chat API has no separate system field, so the backend prepends a `system`-role message to the messages array rather than mapping it onto a `"user"` slot. See [ollama.rs](../../src/crates/primer-inference/src/ollama.rs).
 
 > **Gotcha:** The two backends differ in how they handle system messages — `CloudBackend` rewrites `Role::System` to `"user"` (because the real system field is sent at the top level), while `OllamaBackend` prepends a `system`-role message inline. Watch this divergence when reworking prompt assembly; it's an easy place to silently leak instruction text into the wrong slot.
 
@@ -51,11 +51,11 @@ Retries happen only at the request-send and status-check phase. The cloud and Ol
 
 The retry helper lives in `primer-core` and is HTTP-neutral — no `reqwest` dependency. Backends translate their own status codes via `classify_anthropic_status` / `classify_ollama_status` into `InferenceError` variants before invoking it; the helper inspects `is_retryable()` and the optional `retry_after` to decide what to do.
 
-Defaults are tuned for conversational latency. Three attempts × ~250 ms × 2 ≈ ~1.75 s worst case before the failure surfaces to the dialogue manager. `Retry-After` headers up to 5 s are honoured exactly; longer waits surface immediately rather than leaving a child staring at a 30-second silent gap. Each retry decision emits `tracing::info!(target: "primer::retry", attempt, kind, delay_ms)` so a future voice-mode change can subscribe and play a "give me a moment" bridging phrase. See [retry.rs](src/crates/primer-core/src/retry.rs) and the per-subsystem defaults in [consts.rs](src/crates/primer-core/src/consts.rs).
+Defaults are tuned for conversational latency. Three attempts × ~250 ms × 2 ≈ ~1.75 s worst case before the failure surfaces to the dialogue manager. `Retry-After` headers up to 5 s are honoured exactly; longer waits surface immediately rather than leaving a child staring at a 30-second silent gap. Each retry decision emits `tracing::info!(target: "primer::retry", attempt, kind, delay_ms)` so a future voice-mode change can subscribe and play a "give me a moment" bridging phrase. See [retry.rs](../../src/crates/primer-core/src/retry.rs) and the per-subsystem defaults in [consts.rs](../../src/crates/primer-core/src/consts.rs).
 
 ## The typed InferenceError
 
-Inference failures are categorised so the retry helper, the i18n layer, and the call site can each act on them coherently. `InferenceError` lives in [error.rs](src/crates/primer-core/src/error.rs) and has six variants:
+Inference failures are categorised so the retry helper, the i18n layer, and the call site can each act on them coherently. `InferenceError` lives in [error.rs](../../src/crates/primer-core/src/error.rs) and has six variants:
 
 - `Auth` — 401 / 403, or any auth-shape failure.
 - `RateLimited { retry_after: Option<Duration> }` — 429 with the optional header parsed.
@@ -70,7 +70,7 @@ Inference failures are categorised so the retry helper, the i18n layer, and the 
 
 `DialogueManager` is the orchestrator that turns a child's input into a Primer turn. It records the child's message, decides the pedagogical intent, retrieves passages from the knowledge base and relevant older turns from long-term memory, builds the system prompt, calls the inference backend, records the response, refreshes the rolling summary if due, and schedules the post-turn classifier / extractor / comprehension tasks. Held entirely as borrowed `&dyn` references to the backends and the knowledge base, plus `Arc<dyn ...>` for the classifier and stores it spawns work with — swapping backends is a CLI-layer wiring change, not a code change.
 
-It lives at [src/crates/primer-pedagogy/src/dialogue_manager/](src/crates/primer-pedagogy/src/dialogue_manager/) and is a directory module split by axis. The split is deliberate: each file is small enough to read in one sitting, and the boundaries match the things you are likely to change together. When adding a new method, place it in the file matching its responsibility and use `pub(super)` visibility for cross-module access.
+It lives at [src/crates/primer-pedagogy/src/dialogue_manager/](../../src/crates/primer-pedagogy/src/dialogue_manager/) and is a directory module split by axis. The split is deliberate: each file is small enough to read in one sitting, and the boundaries match the things you are likely to change together. When adding a new method, place it in the file matching its responsibility and use `pub(super)` visibility for cross-module access.
 
 - `mod.rs` — struct, type aliases, and module glue
 - `lifecycle.rs` — `new` / `open_session` / `resume_session` / `close_session` plus accessors
@@ -85,7 +85,7 @@ It lives at [src/crates/primer-pedagogy/src/dialogue_manager/](src/crates/primer
 
 ## decide_intent()
 
-`decide_intent` is the brain of the Socratic behaviour: a deterministic heuristic that reads the learner model and the recent session turns and returns a `PedagogicalIntent`. It is the single most important function to test rigorously when adding pedagogical features, because every turn passes through it and every changed branch shifts what the Primer says next. The function has three layers of fallback (`decide_intent` → `decide_intent_at` → `decide_intent_at_with_pack`) so callers without a clock or a locale pack still get sensible defaults. It lives in [prompt_builder.rs](src/crates/primer-pedagogy/src/prompt_builder.rs).
+`decide_intent` is the brain of the Socratic behaviour: a deterministic heuristic that reads the learner model and the recent session turns and returns a `PedagogicalIntent`. It is the single most important function to test rigorously when adding pedagogical features, because every turn passes through it and every changed branch shifts what the Primer says next. The function has three layers of fallback (`decide_intent` → `decide_intent_at` → `decide_intent_at_with_pack`) so callers without a clock or a locale pack still get sensible defaults. It lives in [prompt_builder.rs](../../src/crates/primer-pedagogy/src/prompt_builder.rs).
 
 Characterization tests in the inline `prompt_builder::tests` module pin the current behaviour — eighteen cases at the time of writing, covering factual-question routing, the `Encouragement` / `SessionClose` split for sustained disengagement, time-driven `SuggestBreak`, and the engagement-state overrides that always win over wallclock cadence. These tests are how the codebase keeps the Socratic principle from drifting under refactoring pressure.
 
@@ -99,11 +99,11 @@ Worked example: adding a hypothetical `OpenAIBackend`.
 
 1. **Implement the trait.** Create `primer-inference/src/openai.rs`. Implement `generate_stream` against the OpenAI chat-completions endpoint; let the default `generate` and `summarize` impls do their work unless you have a reason to override them.
 
-2. **Hand-roll the streaming.** OpenAI uses SSE like Anthropic; you can lift `SseBuffer` from [cloud.rs](src/crates/primer-inference/src/cloud.rs) or write a `parse_openai_event` analogue. Forward parsed chunks via `futures::channel::mpsc::unbounded` driven by a spawned tokio task — the same shape both existing backends use.
+2. **Hand-roll the streaming.** OpenAI uses SSE like Anthropic; you can lift `SseBuffer` from [cloud.rs](../../src/crates/primer-inference/src/cloud.rs) or write a `parse_openai_event` analogue. Forward parsed chunks via `futures::channel::mpsc::unbounded` driven by a spawned tokio task — the same shape both existing backends use.
 
 3. **Map errors to `InferenceError`.** Add a `classify_openai_status(status: StatusCode) -> Option<InferenceError>` helper. Map 401 → `Auth`, 429 → `RateLimited { retry_after }` (parse the `Retry-After` header), 404 → `ModelNotFound { model }`, 5xx → `ServiceUnavailable`, transport errors → `NetworkUnavailable`, anything else → `Other(...)`. Never embed user-facing English in the variant fields — keep them as locale-neutral data.
 
-4. **Wrap the pre-stream phase in `retry_with_backoff`.** Pattern lifted from [cloud.rs](src/crates/primer-inference/src/cloud.rs):
+4. **Wrap the pre-stream phase in `retry_with_backoff`.** Pattern lifted from [cloud.rs](../../src/crates/primer-inference/src/cloud.rs):
 
    ```rust
    // src/crates/primer-inference/src/openai.rs (excerpt)
@@ -118,19 +118,19 @@ Worked example: adding a hypothetical `OpenAIBackend`.
 
    The retry helper handles `is_retryable()` and `Retry-After` honouring for you; you only have to do the status-to-variant mapping correctly.
 
-5. **Wire into the CLI.** Backend selection lives in [main.rs](src/crates/primer-cli/src/main.rs). Find the dispatch site (search for `match cli.backend.as_str()`) and add an `"openai"` arm that constructs your new backend with the API key, model, and any other config. The CLI uses string-based dispatch, not a typed enum, so there's no separate `Backend` enum file.
+5. **Wire into the CLI.** Backend selection lives in [main.rs](../../src/crates/primer-cli/src/main.rs). Find the dispatch site (search for `match cli.backend.as_str()`) and add an `"openai"` arm that constructs your new backend with the API key, model, and any other config. The CLI uses string-based dispatch, not a typed enum, so there's no separate `Backend` enum file.
 
-6. **Add the `--backend openai` clap variant.** Plus `--openai-api-key` (or env-var fallback) following the existing `--api-key` / `ANTHROPIC_API_KEY` pattern in [primer-cli](src/crates/primer-cli/).
+6. **Add the `--backend openai` clap variant.** Plus `--openai-api-key` (or env-var fallback) following the existing `--api-key` / `ANTHROPIC_API_KEY` pattern in [primer-cli](../../src/crates/primer-cli/).
 
 7. **Write integration tests.** Stub the HTTP layer with `wiremock` or similar. At minimum cover: success → chunks arrive in order; 429 → retry honours `Retry-After`; mid-stream disconnect → error propagates and the dialogue-manager-layer test confirms the partial turn is not recorded.
 
-8. **Update [README.md](README.md)** to mention the new backend in the supported-backends list, and (if behaviour diverges) add a one-line gotcha to [CLAUDE.md](CLAUDE.md).
+8. **Update [README.md](../../README.md)** to mention the new backend in the supported-backends list, and (if behaviour diverges) add a one-line gotcha to [CLAUDE.md](../../CLAUDE.md).
 
 ### Recipe — Add a new `PedagogicalIntent`
 
 Worked example: adding `Celebrate` (acknowledge a breakthrough moment, then pivot back to inquiry).
 
-1. **Add the variant to the enum.** Edit the `PedagogicalIntent` definition in [conversation.rs](src/crates/primer-core/src/conversation.rs). The enum is unit-only (no explicit discriminants — IDs are assigned separately).
+1. **Add the variant to the enum.** Edit the `PedagogicalIntent` definition in [conversation.rs](../../src/crates/primer-core/src/conversation.rs). The enum is unit-only (no explicit discriminants — IDs are assigned separately).
 
    ```rust
    // src/crates/primer-core/src/conversation.rs
@@ -154,7 +154,7 @@ Worked example: adding `Celebrate` (acknowledge a breakthrough moment, then pivo
 
 3. **Bump the length assertion.** The test at `conversation.rs:146` pins the count. Change `assert_eq!(PedagogicalIntent::ALL.len(), 9);` to match your new total.
 
-4. **Assign the integer ID.** Edit [catalog.rs](src/crates/primer-storage/src/catalog.rs). Add a match arm to BOTH `intent_id()` and `intent_name()` (they have to stay in sync — there's a unit test for that). Pick the next unused id; never reuse a retired one — historical rows in the session DB carry the old id, and reusing the integer would silently rewrite history.
+4. **Assign the integer ID.** Edit [catalog.rs](../../src/crates/primer-storage/src/catalog.rs). Add a match arm to BOTH `intent_id()` and `intent_name()` (they have to stay in sync — there's a unit test for that). Pick the next unused id; never reuse a retired one — historical rows in the session DB carry the old id, and reusing the integer would silently rewrite history.
 
    ```rust
    // src/crates/primer-storage/src/catalog.rs
@@ -173,7 +173,7 @@ Worked example: adding `Celebrate` (acknowledge a breakthrough moment, then pivo
    }
    ```
 
-5. **Add a routing branch in `decide_intent`.** In [prompt_builder.rs](src/crates/primer-pedagogy/src/prompt_builder.rs), add the heuristic that routes to `Celebrate`. Keep it deterministic — engagement-state overrides should still win, and the time-driven `SuggestBreak` branch should still take precedence over a celebration when both apply.
+5. **Add a routing branch in `decide_intent`.** In [prompt_builder.rs](../../src/crates/primer-pedagogy/src/prompt_builder.rs), add the heuristic that routes to `Celebrate`. Keep it deterministic — engagement-state overrides should still win, and the time-driven `SuggestBreak` branch should still take precedence over a celebration when both apply.
 
 6. **Extend the prompt builder.** In `build_system_prompt_with_pack_and_vocab`, add a section for the `Celebrate` intent describing how the Primer should celebrate (briefly, then pivot back to inquiry — never break principle 2).
 

--- a/docs/devel/03-inference-and-pedagogy.md
+++ b/docs/devel/03-inference-and-pedagogy.md
@@ -1,0 +1,162 @@
+# Inference and pedagogy
+
+This chapter walks through the two halves of the Primer's "thinking" pipeline: the inference layer that produces text, and the pedagogical engine that decides what to ask for. If you want to add a new model backend, change how the Primer responds to a particular kind of child input, or just understand the lifecycle of a single conversational turn, start here.
+
+## The InferenceBackend trait
+
+Every LLM in the system — cloud-hosted Claude, a local Ollama daemon, a future llama.cpp build, the canned-response stub used in tests — sits behind a single trait. The pedagogical engine holds a `&dyn InferenceBackend` and never knows which one it is talking to. Three required methods make up the contract: `generate` returns a complete response, `generate_stream` returns an asynchronous stream of token chunks, and `summarize` condenses a slice of conversation turns into a paragraph of long-term memory. The trait provides default impls for `generate` (collects from `generate_stream`) and `summarize` (builds a one-shot prompt and dispatches to `generate`), so a real backend usually only has to implement `generate_stream`.
+
+Streaming is the primary interface. The non-streaming wrapper exists because some flows (the rolling-summary refresh, classifier/extractor/comprehension prompts) want a complete string and don't benefit from incremental delivery. Everywhere else — including the REPL — the dialogue manager consumes chunks as they arrive so the TTS pipeline (Phase 2) can begin speaking before generation is complete.
+
+```rust
+// src/crates/primer-core/src/inference.rs
+#[async_trait]
+pub trait InferenceBackend: Send + Sync {
+    fn name(&self) -> &str;
+    async fn is_available(&self) -> bool;
+
+    async fn generate(&self, prompt: &Prompt, params: &GenerationParams) -> Result<String> { /* default impl */ }
+
+    async fn generate_stream(
+        &self,
+        prompt: &Prompt,
+        params: &GenerationParams,
+    ) -> Result<TokenStream>;
+
+    async fn summarize(&self, turns: &[Turn], target_chars: usize) -> Result<String> { /* default impl */ }
+}
+```
+
+Full source at [inference.rs](src/crates/primer-core/src/inference.rs). The `Prompt` type carries a `system: String` plus a `Vec<Message>` of role-tagged history; `TokenStream` is `Pin<Box<dyn Stream<Item = Result<TokenChunk>> + Send>>`.
+
+## The three concrete backends
+
+### StubBackend
+
+Canned Socratic responses, no model, no network. It implements the trait with a small lookup keyed on intent and emits one final `TokenChunk` to satisfy the streaming signature — a degenerate but valid stream that the rest of the pipeline handles correctly. This is the default for `cargo run --bin primer` (no API key required) and the only backend the workspace tests rely on, which is why most of the dialogue manager's behaviour can be exercised with no model at all. See [stub.rs](src/crates/primer-inference/src/stub.rs).
+
+### CloudBackend (Anthropic SSE)
+
+The Anthropic Messages API streams via Server-Sent Events: `event:` and `data:` lines separated by blank lines, with JSON payloads that carry `content_block_delta` events. `CloudBackend` parses this with a hand-rolled `SseBuffer` and a `parse_anthropic_event` function — no SSE crate dependency. The byte stream is consumed by a spawned tokio task that forwards parsed chunks through a `futures::channel::mpsc::unbounded` channel; the `TokenStream` returned to the caller wraps the receiver. One detail to know: the Anthropic API treats system instructions as a top-level field on the request body, not a message role, so `CloudBackend` maps `Role::System` entries from the `Prompt`'s message list to `"user"` when serialising. See [cloud.rs](src/crates/primer-inference/src/cloud.rs).
+
+### OllamaBackend (NDJSON)
+
+Ollama's `/api/chat` endpoint streams newline-delimited JSON: one complete object per `\n`-terminated line, each carrying a `message.content` fragment and a final `done: true` line. `OllamaBackend` parses this with `NdjsonBuffer` and `parse_ollama_line`, with the same spawned-task-plus-mpsc shape as the cloud backend. The divergence here is that Ollama's chat API has no separate system field, so the backend prepends a `system`-role message to the messages array rather than mapping it onto a `"user"` slot. See [ollama.rs](src/crates/primer-inference/src/ollama.rs).
+
+> **Gotcha:** The two backends differ in how they handle system messages — `CloudBackend` rewrites `Role::System` to `"user"` (because the real system field is sent at the top level), while `OllamaBackend` prepends a `system`-role message inline. Watch this divergence when reworking prompt assembly; it's an easy place to silently leak instruction text into the wrong slot.
+
+## The retry layer
+
+Retries happen only at the request-send and status-check phase. The cloud and Ollama backends each wrap their pre-stream HTTP call in `primer_core::retry::retry_with_backoff` — once `generate_stream` has begun consuming bytes from a 2xx response, mid-stream errors propagate cleanly and the partial Primer turn is dropped at the dialogue-manager layer (the child turn stays; the half-formed response does not). This deliberately keeps the retry surface narrow: a retry that re-issued mid-stream would either replay tokens the child has already heard or silently re-prompt the model, both of which we want to avoid.
+
+The retry helper lives in `primer-core` and is HTTP-neutral — no `reqwest` dependency. Backends translate their own status codes via `classify_anthropic_status` / `classify_ollama_status` into `InferenceError` variants before invoking it; the helper inspects `is_retryable()` and the optional `retry_after` to decide what to do.
+
+Defaults are tuned for conversational latency. Three attempts × ~250 ms × 2 ≈ ~1.75 s worst case before the failure surfaces to the dialogue manager. `Retry-After` headers up to 5 s are honoured exactly; longer waits surface immediately rather than leaving a child staring at a 30-second silent gap. Each retry decision emits `tracing::info!(target: "primer::retry", attempt, kind, delay_ms)` so a future voice-mode change can subscribe and play a "give me a moment" bridging phrase. See [retry.rs](src/crates/primer-core/src/retry.rs) and the per-subsystem defaults in [consts.rs](src/crates/primer-core/src/consts.rs).
+
+## The typed InferenceError
+
+Inference failures are categorised so the retry helper, the i18n layer, and the call site can each act on them coherently. `InferenceError` lives in [error.rs](src/crates/primer-core/src/error.rs) and has six variants:
+
+- `Auth` — 401 / 403, or any auth-shape failure.
+- `RateLimited { retry_after: Option<Duration> }` — 429 with the optional header parsed.
+- `ServiceUnavailable` — 5xx, or daemon-down on Ollama.
+- `NetworkUnavailable` — connect / timeout / DNS / TLS failure at the transport layer.
+- `ModelNotFound { model: String }` — Ollama 404 on a configured model name.
+- `Other(String)` — catch-all for unmapped conditions, plus `From<&str>` and `From<String>` impls so producers can write `format!(...).into()`.
+
+> **Why:** `Other`'s inner string is dev-facing only — it never reaches users. The i18n layer in `primer_core::i18n::render_inference_error` substitutes a generic message for `Other` and the call site logs the full error via `tracing::warn!`. Never embed user-facing English in `InferenceError` variant fields (no `hint: String`); never render `Other`'s inner string to the child. This is the discipline that lets a future locale PR be purely additive.
+
+## DialogueManager
+
+`DialogueManager` is the orchestrator that turns a child's input into a Primer turn. It records the child's message, decides the pedagogical intent, retrieves passages from the knowledge base and relevant older turns from long-term memory, builds the system prompt, calls the inference backend, records the response, refreshes the rolling summary if due, and schedules the post-turn classifier / extractor / comprehension tasks. Held entirely as borrowed `&dyn` references to the backends and the knowledge base, plus `Arc<dyn ...>` for the classifier and stores it spawns work with — swapping backends is a CLI-layer wiring change, not a code change.
+
+It lives at [src/crates/primer-pedagogy/src/dialogue_manager/](src/crates/primer-pedagogy/src/dialogue_manager/) and is a directory module split by axis. The split is deliberate: each file is small enough to read in one sitting, and the boundaries match the things you are likely to change together. When adding a new method, place it in the file matching its responsibility and use `pub(super)` visibility for cross-module access.
+
+- `mod.rs` — struct, type aliases, and module glue
+- `lifecycle.rs` — `new` / `open_session` / `resume_session` / `close_session` plus accessors
+- `turn.rs` — the `respond_to_streaming` orchestrator and its seven private helpers
+- `background.rs` — await / drain / apply for the classifier, extractor, and comprehension tasks
+- `retrieval.rs` — knowledge-base and long-term-memory retrieval
+- `summary.rs` — the two summary-refresh cadences (active vs. resume)
+- `learner_update.rs` — the engagement-state heuristic (still a placeholder, word-count-based)
+- `apply.rs` — pure free functions plus their unit tests
+
+> **Note:** When adding a new method to `DialogueManager`, place it in the file matching its responsibility and use `pub(super)` visibility for cross-module access. Tests follow the same axis split — `tests/lifecycle_tests.rs`, `tests/turn_tests.rs`, `tests/background_tests.rs`, with shared mocks and builders in `tests/test_support.rs`.
+
+## decide_intent()
+
+`decide_intent` is the brain of the Socratic behaviour: a deterministic heuristic that reads the learner model and the recent session turns and returns a `PedagogicalIntent`. It is the single most important function to test rigorously when adding pedagogical features, because every turn passes through it and every changed branch shifts what the Primer says next. The function has three layers of fallback (`decide_intent` → `decide_intent_at` → `decide_intent_at_with_pack`) so callers without a clock or a locale pack still get sensible defaults. It lives in [prompt_builder.rs](src/crates/primer-pedagogy/src/prompt_builder.rs).
+
+Characterization tests in the inline `prompt_builder::tests` module pin the current behaviour — eighteen cases at the time of writing, covering factual-question routing, the `Encouragement` / `SessionClose` split for sustained disengagement, time-driven `SuggestBreak`, and the engagement-state overrides that always win over wallclock cadence. These tests are how the codebase keeps the Socratic principle from drifting under refactoring pressure.
+
+> **Note:** When you change intent routing, add a characterization test for the new branch BEFORE the implementation. The test pins the routing case so a future refactor can't quietly regress it; the order — test first — is what makes this work, because writing the test against an existing implementation tends to encode the bug rather than the intent.
+
+---
+
+### Recipe — Add a new `InferenceBackend`
+
+Worked example: adding a hypothetical `OpenAIBackend`.
+
+1. **Implement the trait.** Create `primer-inference/src/openai.rs`. Implement `generate_stream` against the OpenAI chat-completions endpoint; let the default `generate` and `summarize` impls do their work unless you have a reason to override them.
+
+2. **Hand-roll the streaming.** OpenAI uses SSE like Anthropic; you can lift `SseBuffer` from [cloud.rs](src/crates/primer-inference/src/cloud.rs) or write a `parse_openai_event` analogue. Forward parsed chunks via `futures::channel::mpsc::unbounded` driven by a spawned tokio task — the same shape both existing backends use.
+
+3. **Map errors to `InferenceError`.** Add a `classify_openai_status(status: StatusCode) -> Option<InferenceError>` helper. Map 401 → `Auth`, 429 → `RateLimited { retry_after }` (parse the `Retry-After` header), 404 → `ModelNotFound { model }`, 5xx → `ServiceUnavailable`, transport errors → `NetworkUnavailable`, anything else → `Other(...)`. Never embed user-facing English in the variant fields — keep them as locale-neutral data.
+
+4. **Wrap the pre-stream phase in `retry_with_backoff`.** Pattern lifted from [cloud.rs](src/crates/primer-inference/src/cloud.rs):
+
+   ```rust
+   // src/crates/primer-inference/src/openai.rs (excerpt)
+   let resp = retry_with_backoff(retry_settings, || async {
+       let r = client.post(&url).headers(headers.clone()).json(&body).send().await?;
+       classify_openai_status(r.status()).map(|err| Err(err))?;
+       Ok(r)
+   }).await?;
+   ```
+
+   The retry helper handles `is_retryable()` and `Retry-After` honouring for you; you only have to do the status-to-variant mapping correctly.
+
+5. **Register in `primer-cli`.** Add an `OpenAi` variant to the `Backend` enum in `primer-cli/src/backend.rs` and wire construction in the factory function that turns CLI flags into a `Box<dyn InferenceBackend>`.
+
+6. **Add the `--backend openai` clap variant.** Plus `--openai-api-key` (or env-var fallback) following the existing `--api-key` / `ANTHROPIC_API_KEY` pattern in [primer-cli](src/crates/primer-cli/).
+
+7. **Write integration tests.** Stub the HTTP layer with `wiremock` or similar. At minimum cover: success → chunks arrive in order; 429 → retry honours `Retry-After`; mid-stream disconnect → error propagates and the dialogue-manager-layer test confirms the partial turn is not recorded.
+
+8. **Update [README.md](README.md)** to mention the new backend in the supported-backends list, and (if behaviour diverges) add a one-line gotcha to [CLAUDE.md](CLAUDE.md).
+
+### Recipe — Add a new `PedagogicalIntent`
+
+Worked example: adding `Celebrate` (acknowledge a breakthrough moment, then pivot back to inquiry).
+
+1. **Add the variant to the enum.** Edit the `PedagogicalIntent` definition in [primer-core](src/crates/primer-core/):
+
+   ```rust
+   // src/crates/primer-core/src/intent.rs
+   pub enum PedagogicalIntent {
+       // ...existing variants...
+       Celebrate = 10,
+   }
+   ```
+
+   The integer value is the lookup-table id stored in the session DB. Pick the next unused id — never reuse a retired one. See chapter 05 (storage) for why; the short version is that historical rows in `turns` and `turn_classifications` carry old ids and re-using a number silently rewrites history.
+
+2. **Add a routing branch in `decide_intent`.** In [prompt_builder.rs](src/crates/primer-pedagogy/src/prompt_builder.rs), add the heuristic that routes to `Celebrate`. Keep it deterministic — engagement-state overrides should still win, and the time-driven `SuggestBreak` branch should still take precedence over a celebration when both apply.
+
+3. **Extend the prompt builder.** In `build_system_prompt_with_pack_and_vocab`, add a section for the `Celebrate` intent describing how the Primer should celebrate (briefly acknowledge the breakthrough, then pivot back to inquiry — never break principle 2 of the pedagogical principles, which forbids engagement-maximising behaviour).
+
+4. **Add a characterization test.** Inside the `prompt_builder::tests` module:
+
+   ```rust
+   // src/crates/primer-pedagogy/src/prompt_builder.rs (tests module)
+   #[test]
+   fn celebrate_when_child_makes_correct_synthesis() {
+       let intent = decide_intent(&fixture_for_synthesis_moment());
+       assert_eq!(intent, PedagogicalIntent::Celebrate);
+   }
+   ```
+
+   Add it before the routing branch in step 2 lands — that's the discipline that catches regressions in this file.
+
+5. **Open any test session DB.** The lookup-table seeder in `primer-storage` validates the in-DB rows against the Rust enum on every `open()`; a new variant gets seeded automatically the next time you open a session DB. No migration step is required for the enum addition itself.
+
+6. **Update the [CLAUDE.md](CLAUDE.md) gotcha list** if the new intent has cross-cutting behaviour — for example, if `Celebrate` interacts with the break-suggestion cadence or the vocabulary review hints.

--- a/docs/devel/03-inference-and-pedagogy.md
+++ b/docs/devel/03-inference-and-pedagogy.md
@@ -128,10 +128,10 @@ Worked example: adding a hypothetical `OpenAIBackend`.
 
 Worked example: adding `Celebrate` (acknowledge a breakthrough moment, then pivot back to inquiry).
 
-1. **Add the variant to the enum.** Edit the `PedagogicalIntent` definition in [primer-core](src/crates/primer-core/):
+1. **Add the variant to the enum.** Edit the `PedagogicalIntent` definition in [conversation.rs](src/crates/primer-core/src/conversation.rs):
 
    ```rust
-   // src/crates/primer-core/src/intent.rs
+   // src/crates/primer-core/src/conversation.rs
    pub enum PedagogicalIntent {
        // ...existing variants...
        Celebrate = 10,

--- a/docs/devel/03-inference-and-pedagogy.md
+++ b/docs/devel/03-inference-and-pedagogy.md
@@ -4,9 +4,9 @@ This chapter walks through the two halves of the Primer's "thinking" pipeline: t
 
 ## The InferenceBackend trait
 
-Every LLM in the system — cloud-hosted Claude, a local Ollama daemon, a future llama.cpp build, the canned-response stub used in tests — sits behind a single trait. The pedagogical engine holds a `&dyn InferenceBackend` and never knows which one it is talking to. Three required methods make up the contract: `generate` returns a complete response, `generate_stream` returns an asynchronous stream of token chunks, and `summarize` condenses a slice of conversation turns into a paragraph of long-term memory. The trait provides default impls for `generate` (collects from `generate_stream`) and `summarize` (builds a one-shot prompt and dispatches to `generate`), so a real backend usually only has to implement `generate_stream`.
+Every LLM in the system — cloud-hosted Claude, a local Ollama daemon, a future llama.cpp build, the canned-response stub used in tests — sits behind a single trait. The pedagogical engine holds a `&dyn InferenceBackend` and never knows which one it is talking to. The contract is five methods, of which three are required (no default impl): `name` (the human-readable backend identifier), `is_available` (a runtime readiness check), and `generate_stream` (an asynchronous stream of token chunks). The remaining two — `generate` (one-shot collected response) and `summarize` (condense a slice of turns into a paragraph of long-term memory) — ship with default impls that delegate down to `generate_stream`, so a real backend usually only has to override `generate_stream` plus the two `name` / `is_available` methods.
 
-Streaming is the primary interface. The non-streaming wrapper exists because some flows (the rolling-summary refresh, classifier/extractor/comprehension prompts) want a complete string and don't benefit from incremental delivery. Everywhere else — including the REPL — the dialogue manager consumes chunks as they arrive so the TTS pipeline (Phase 2) can begin speaking before generation is complete.
+`generate_stream` is the canonical surface because it's the one the conversation loop actually drives: streaming lets the TTS pipeline (Phase 2) begin speaking before generation is complete, and a chunk-at-a-time REPL feels less laggy than a wait-for-the-whole-paragraph one. The non-streaming `generate` exists only because some flows — the rolling-summary refresh, the structured-output classifier / extractor / comprehension prompts — want a complete string and don't benefit from incremental delivery, so the trait provides them a default that collects the stream once it lands.
 
 ```rust
 // src/crates/primer-core/src/inference.rs
@@ -74,14 +74,14 @@ It lives at [src/crates/primer-pedagogy/src/dialogue_manager/](src/crates/primer
 
 - `mod.rs` — struct, type aliases, and module glue
 - `lifecycle.rs` — `new` / `open_session` / `resume_session` / `close_session` plus accessors
-- `turn.rs` — the `respond_to_streaming` orchestrator and its seven private helpers
+- `turn.rs` — the `respond_to_streaming` orchestrator and its private helpers for child-turn recording, prompt assembly, inference streaming, primer-turn recording, persistence, and the spawn-task helpers (embedding, classification, post-response)
 - `background.rs` — await / drain / apply for the classifier, extractor, and comprehension tasks
 - `retrieval.rs` — knowledge-base and long-term-memory retrieval
 - `summary.rs` — the two summary-refresh cadences (active vs. resume)
 - `learner_update.rs` — the engagement-state heuristic (still a placeholder, word-count-based)
 - `apply.rs` — pure free functions plus their unit tests
 
-> **Note:** When adding a new method to `DialogueManager`, place it in the file matching its responsibility and use `pub(super)` visibility for cross-module access. Tests follow the same axis split — `tests/lifecycle_tests.rs`, `tests/turn_tests.rs`, `tests/background_tests.rs`, with shared mocks and builders in `tests/test_support.rs`.
+> **Note:** When adding a new method to `DialogueManager`, place it in the file matching its responsibility and use `pub(super)` visibility for cross-module access. Tests follow the same axis split — `tests/lifecycle_tests.rs`, `tests/turn_tests.rs`, `tests/background_tests.rs`, with shared mocks and builders in `dialogue_manager/test_support.rs` (sibling of `mod.rs`, not under the `tests/` subdir).
 
 ## decide_intent()
 
@@ -109,14 +109,16 @@ Worked example: adding a hypothetical `OpenAIBackend`.
    // src/crates/primer-inference/src/openai.rs (excerpt)
    let resp = retry_with_backoff(retry_settings, || async {
        let r = client.post(&url).headers(headers.clone()).json(&body).send().await?;
-       classify_openai_status(r.status()).map(|err| Err(err))?;
+       if !r.status().is_success() {
+           return Err(classify_openai_status(r.status()));
+       }
        Ok(r)
    }).await?;
    ```
 
    The retry helper handles `is_retryable()` and `Retry-After` honouring for you; you only have to do the status-to-variant mapping correctly.
 
-5. **Register in `primer-cli`.** Add an `OpenAi` variant to the `Backend` enum in `primer-cli/src/backend.rs` and wire construction in the factory function that turns CLI flags into a `Box<dyn InferenceBackend>`.
+5. **Wire into the CLI.** Backend selection lives in [main.rs](src/crates/primer-cli/src/main.rs). Find the dispatch site (search for `match cli.backend.as_str()`) and add an `"openai"` arm that constructs your new backend with the API key, model, and any other config. The CLI uses string-based dispatch, not a typed enum, so there's no separate `Backend` enum file.
 
 6. **Add the `--backend openai` clap variant.** Plus `--openai-api-key` (or env-var fallback) following the existing `--api-key` / `ANTHROPIC_API_KEY` pattern in [primer-cli](src/crates/primer-cli/).
 
@@ -128,23 +130,54 @@ Worked example: adding a hypothetical `OpenAIBackend`.
 
 Worked example: adding `Celebrate` (acknowledge a breakthrough moment, then pivot back to inquiry).
 
-1. **Add the variant to the enum.** Edit the `PedagogicalIntent` definition in [conversation.rs](src/crates/primer-core/src/conversation.rs):
+1. **Add the variant to the enum.** Edit the `PedagogicalIntent` definition in [conversation.rs](src/crates/primer-core/src/conversation.rs). The enum is unit-only (no explicit discriminants — IDs are assigned separately).
 
    ```rust
    // src/crates/primer-core/src/conversation.rs
    pub enum PedagogicalIntent {
        // ...existing variants...
-       Celebrate = 10,
+       Celebrate,
    }
    ```
 
-   The integer value is the lookup-table id stored in the session DB. Pick the next unused id — never reuse a retired one. See chapter 05 (storage) for why; the short version is that historical rows in `turns` and `turn_classifications` carry old ids and re-using a number silently rewrites history.
+2. **Add the variant to `PedagogicalIntent::ALL`.** Same file. The `ALL` array is the single source of truth that the storage layer's lookup-table seeder walks. A unit test (`assert_eq!(PedagogicalIntent::ALL.len(), N)`) will fail if you skip this — that's a feature.
 
-2. **Add a routing branch in `decide_intent`.** In [prompt_builder.rs](src/crates/primer-pedagogy/src/prompt_builder.rs), add the heuristic that routes to `Celebrate`. Keep it deterministic — engagement-state overrides should still win, and the time-driven `SuggestBreak` branch should still take precedence over a celebration when both apply.
+   ```rust
+   // src/crates/primer-core/src/conversation.rs
+   impl PedagogicalIntent {
+       pub const ALL: &'static [PedagogicalIntent] = &[
+           // ...existing variants...
+           PedagogicalIntent::Celebrate,
+       ];
+   }
+   ```
 
-3. **Extend the prompt builder.** In `build_system_prompt_with_pack_and_vocab`, add a section for the `Celebrate` intent describing how the Primer should celebrate (briefly acknowledge the breakthrough, then pivot back to inquiry — never break principle 2 of the pedagogical principles, which forbids engagement-maximising behaviour).
+3. **Bump the length assertion.** The test at `conversation.rs:146` pins the count. Change `assert_eq!(PedagogicalIntent::ALL.len(), 9);` to match your new total.
 
-4. **Add a characterization test.** Inside the `prompt_builder::tests` module:
+4. **Assign the integer ID.** Edit [catalog.rs](src/crates/primer-storage/src/catalog.rs). Add a match arm to BOTH `intent_id()` and `intent_name()` (they have to stay in sync — there's a unit test for that). Pick the next unused id; never reuse a retired one — historical rows in the session DB carry the old id, and reusing the integer would silently rewrite history.
+
+   ```rust
+   // src/crates/primer-storage/src/catalog.rs
+   pub fn intent_id(intent: PedagogicalIntent) -> i64 {
+       match intent {
+           // ...existing arms...
+           PedagogicalIntent::Celebrate => 10,
+       }
+   }
+
+   pub fn intent_name(intent: PedagogicalIntent) -> &'static str {
+       match intent {
+           // ...existing arms...
+           PedagogicalIntent::Celebrate => "celebrate",
+       }
+   }
+   ```
+
+5. **Add a routing branch in `decide_intent`.** In [prompt_builder.rs](src/crates/primer-pedagogy/src/prompt_builder.rs), add the heuristic that routes to `Celebrate`. Keep it deterministic — engagement-state overrides should still win, and the time-driven `SuggestBreak` branch should still take precedence over a celebration when both apply.
+
+6. **Extend the prompt builder.** In `build_system_prompt_with_pack_and_vocab`, add a section for the `Celebrate` intent describing how the Primer should celebrate (briefly, then pivot back to inquiry — never break principle 2).
+
+7. **Add a characterization test.** In `prompt_builder.rs`'s `tests` module:
 
    ```rust
    // src/crates/primer-pedagogy/src/prompt_builder.rs (tests module)
@@ -155,8 +188,4 @@ Worked example: adding `Celebrate` (acknowledge a breakthrough moment, then pivo
    }
    ```
 
-   Add it before the routing branch in step 2 lands — that's the discipline that catches regressions in this file.
-
-5. **Open any test session DB.** The lookup-table seeder in `primer-storage` validates the in-DB rows against the Rust enum on every `open()`; a new variant gets seeded automatically the next time you open a session DB. No migration step is required for the enum addition itself.
-
-6. **Update the [CLAUDE.md](CLAUDE.md) gotcha list** if the new intent has cross-cutting behaviour — for example, if `Celebrate` interacts with the break-suggestion cadence or the vocabulary review hints.
+8. **Open any test session DB.** The `validate_and_seed_lookup` helper in `primer-storage/src/catalog.rs` walks `PedagogicalIntent::ALL` on every `open()`; once steps 2-4 above are done, your new variant gets seeded automatically. No migration step required.

--- a/docs/devel/04-knowledge-and-retrieval.md
+++ b/docs/devel/04-knowledge-and-retrieval.md
@@ -1,0 +1,262 @@
+# Knowledge and retrieval
+
+This chapter is about how the Primer grounds its replies in real, attributed text. It covers the [KnowledgeBase](src/crates/primer-core/src/knowledge.rs) trait, the SQLite + FTS5 implementation, the lexical (BM25) and hybrid (BM25 + dense-vector RRF) retrieval paths, the [Embedder](src/crates/primer-core/src/embedder.rs) trait and its three concrete backends, the multi-layer auto-seeded corpus that ships in the repo, and the locale-aware schema that lets every language live side-by-side without contaminating each other's BM25 statistics. Two recipes at the end show how to extend the seed corpus and how to add a brand-new locale.
+
+If you already read chapter 3 on inference and pedagogy, the dialogue manager you saw there pulls retrieved passages into the system prompt before every turn — this chapter is the back half of that pipeline.
+
+## The KnowledgeBase trait
+
+Every retrieval surface the dialogue manager sees is one trait, defined in [knowledge.rs](src/crates/primer-core/src/knowledge.rs). The contract is small on purpose: backends decide how to store and rank passages, but the trait shape is fixed so the engine never knows whether it is talking to a SQLite FTS5 index, a future on-device vector store, or a stub.
+
+```rust
+// src/crates/primer-core/src/knowledge.rs
+#[async_trait]
+pub trait KnowledgeBase: Send + Sync {
+    async fn retrieve(&self, query: &str, params: &RetrievalParams) -> Result<Vec<Passage>>;
+
+    async fn retrieve_for_context(
+        &self,
+        conversation_summary: &str,
+        params: &RetrievalParams,
+    ) -> Result<Vec<Passage>> { /* default: delegates to retrieve */ }
+
+    async fn upsert_source(&self, _source: &SourceMeta) -> Result<()> { /* default no-op */ }
+    async fn list_sources(&self) -> Result<Vec<SourceMeta>> { /* default empty */ }
+
+    async fn retrieve_hybrid(
+        &self,
+        query: &str,
+        embedder: &dyn Embedder,
+        params: &HybridParams,
+    ) -> Result<Vec<Passage>> { /* default: BM25-only fallback */ }
+}
+```
+
+A few details worth pinning down before you read further. `Passage` is `{ id, source, text, score }`, where `score` is "higher = more relevant" regardless of the underlying ranker — backends must normalise their internal scoring into that direction before returning. `SourceMeta` is the per-source attribution + licence record (`id`, `license`, `attribution`, `source_url`, `retrieved_at`); a passage's `source` field is a logical foreign key into `SourceMeta::id`. `RetrievalParams` is BM25-shaped (`top_k`, `min_score`, `source_filter`); `HybridParams` adds the wider candidate pool (`bm25_top_k`, `vector_top_k`) plus the RRF constant (`rrf_k`). Both `Default` impls read from [consts::retrieval](src/crates/primer-core/src/consts.rs) so any tuning change happens in one place.
+
+> **Note:** When no `Embedder` is wired, `retrieve_hybrid`'s default trait impl falls back to BM25-only — every consumer can call it unconditionally. This is what keeps the dialogue manager free of `if cfg!(feature = "embedding")` branches.
+
+## SqliteKnowledgeBase schema
+
+The concrete backend is [SqliteKnowledgeBase](src/crates/primer-knowledge/src/lib.rs), which uses SQLite FTS5 as its lexical index and stores per-passage `f32` vectors as BLOBs for the dense leg. It is locale-scoped: every locale gets its own pair of tables plus its own embedding store, so a German corpus and an English corpus can coexist in one file without polluting each other's term statistics.
+
+For locale `<pack_id>` (e.g. `en`, `de`), the per-locale layout is:
+
+- `passages_<pack_id>` — the FTS5 virtual table, used for BM25 ranking.
+- `passages_<pack_id>_content` — the external-content storage table that backs the FTS5 index. The plan and some older comments call this `passages_<pack_id>_meta`; the actual table name in source is `_content`.
+- `embeddings_<pack_id>` — one row per passage with the `f32` vector stored as a BLOB column, plus a `model_id` foreign key.
+
+Two cross-locale tables travel alongside:
+
+- `sources` — licence + attribution metadata, keyed by source id. Phase 0.2 schema; populated lazily by `upsert_source`.
+- `embedding_models` — `(name, dim)` registry for every embedder ever seen on this DB. Mismatched dim under an existing name is a hard error rather than a silent fallback.
+
+The schema is at [USER_VERSION](src/crates/primer-knowledge/src/lib.rs) `3`. Migrations layer additively, each idempotent and transaction-wrapped: v2 added `sources`; v3 added `embedding_models` and the per-locale `embeddings_<pack>` tables. A pre-locale legacy `passages` table (from before the locale-aware refactor) is migrated into the requested locale's `passages_<pack>_content` pair on first open and the legacy table is dropped — the migration assumes the legacy corpus matches the locale being opened, which is the only sound assumption when locale wasn't tracked at write time.
+
+To open a knowledge base, prefer the locale-explicit constructor:
+
+```rust
+use primer_core::i18n::Locale;
+use primer_knowledge::SqliteKnowledgeBase;
+
+let kb = SqliteKnowledgeBase::open_for_locale(path, Locale::English)?;
+```
+
+The shorter `SqliteKnowledgeBase::open(path)` exists for back-compat but is `#[deprecated]` — it silently routes a non-English corpus through the English-default migration path, which is exactly the bug class the deprecation message warns about.
+
+## BM25 ranking
+
+SQLite FTS5 ranks results with BM25, which is the lexical-overlap baseline that has powered most search engines since the 1990s. One quirk worth knowing: FTS5 returns BM25 scores as **negative** numbers (more negative = more relevant), because internally the ranker is sorted ascending. The `KnowledgeBase` public API negates this when it builds a `Passage`, so callers always see "higher = more relevant" — the `score` field is monotonic in the natural sense. If you ever read raw `bm25(...)` values in a debugging session, remember the sign flip when comparing them to what the trait returns.
+
+Child input is sanitised before it touches FTS5. Tokens are stripped of non-alphanumeric characters, FTS5 reserved keywords (`AND`, `OR`, `NOT`, `NEAR`) are dropped, surviving tokens are quoted and OR-joined. An empty result short-circuits the query. This is what allows the long-term-memory layer in `primer-storage` to take raw child input safely; BM25 + `LIMIT k` keeps the OR-join from producing noise.
+
+## Hybrid retrieval
+
+Lexical search is great when the child uses the corpus's own vocabulary and shaky when they don't. Hybrid retrieval addresses the second case by running a second leg over dense vectors — semantic similarity in an embedding space — and fusing both ranked lists.
+
+`SqliteKnowledgeBase::retrieve_hybrid` does exactly that:
+
+1. Run BM25 with `top_k = bm25_top_k` (default 30 — wider than what's ultimately returned, so the fusion stage has a candidate pool to work with).
+2. Embed the query through the supplied [Embedder](src/crates/primer-core/src/embedder.rs) and run a cosine search over the per-passage vectors with `top_k = vector_top_k` (default 30).
+3. Fuse the two ranked lists via Reciprocal Rank Fusion (`primer_core::rrf::fuse(&[ranked_lists], k)`) with `rrf_k = 60` — the industry-standard default. Smaller values weight the very top of each list more heavily; larger values flatten the curve.
+4. Apply `min_score` and return the top `final_top_k` (default 5).
+
+`HybridParams::default()` reads from [consts::retrieval](src/crates/primer-core/src/consts.rs); a `default_mirrors_consts` test pins the alignment so a code reviewer doesn't have to chase two sources of truth.
+
+> **Note:** Bumping the candidate pool sizes (`KB_BM25_TOP_K`, `KB_VECTOR_TOP_K`) is cheap — it only affects in-memory work, not what ends up in the prompt. Bumping `KB_FINAL_TOP_K` is what costs prompt tokens, because every returned passage is injected into the system prompt every turn.
+
+The fallback story is important. When the dialogue manager has no `Embedder` wired (the BM25-only configuration that was the pre-Phase-0.2.5 default), the trait's default `retrieve_hybrid` impl quietly delegates to `retrieve` with `final_top_k` and `min_score`. That means every consumer can call `retrieve_hybrid` unconditionally; a future flag-flip to "hybrid by default" needs no change at the call site.
+
+## The Embedder trait
+
+The dense leg requires a way to turn text into a fixed-dimension `f32` vector. That contract lives in [embedder.rs](src/crates/primer-core/src/embedder.rs):
+
+```rust
+// src/crates/primer-core/src/embedder.rs
+#[async_trait]
+pub trait Embedder: Named + Send + Sync {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>>;
+    fn dim(&self) -> usize;
+    fn model_id(&self) -> &str;
+}
+```
+
+`Embedder` inherits from `Named`, which is the same single-source-of-truth `name()` trait that all the speech traits inherit from — backends never have to write `name()` twice. `model_id` is a stable identifier (e.g. `"bge-m3"`, `"stub-fxhash-v1"`) persisted alongside every stored vector so cross-model mixing is detectable at open time.
+
+Three concrete impls live in [primer-embedding](src/crates/primer-embedding/src/lib.rs):
+
+### StubEmbedder
+
+Always built, no feature flag. It hashes each input through FNV + xorshift to produce a deterministic, L2-normalised `f32` vector of configurable dimension (default 384). Model id is `"stub-fxhash-v1"`. This is the embedder every workspace test uses when it needs a non-trivial vector backend without a model download. See [stub.rs](src/crates/primer-embedding/src/stub.rs).
+
+> **Gotcha:** `--embedder-backend stub` is for testing the hybrid pipeline structurally only. In production it dilutes BM25 with semantic noise from a hash function — two synonyms produce orthogonal vectors — and should never be the default. If you see suspicious recall behaviour, the first thing to check is which embedder is actually wired.
+
+### FastEmbedBackend
+
+Behind the `fastembed` feature. Wraps [fastembed-rs](https://github.com/Anush008/fastembed-rs) `5.7.0` to load BGE-M3, a 1024-dimensional multilingual embedding model that covers EN/DE/JA/HI in one binary so the initial test cohort never hits a model swap. The int8-quantised weights weigh in at about 570 MB. See [fastembed_backend.rs](src/crates/primer-embedding/src/fastembed_backend.rs).
+
+> **Gotcha:** First-run BGE-M3 download is ~570 MB into `~/.cache/primer/models/` and uses the same `cdn.pyke.io` ONNX-runtime download as the speech feature. Construction failure falls back to BM25-only with a `tracing::warn!` — the conversation still works, which is strictly better than refusing to start.
+
+### OllamaEmbedder
+
+Behind the `ollama` feature. Calls the local Ollama daemon's `/api/embeddings` endpoint (default model `nomic-embed-text`, default URL `http://localhost:11434`). This is the developer-prototyping path — useful for trying out a different embedding model without rebuilding the binary, but not the recommended runtime backend because it adds a network hop in the hot path. See [ollama.rs](src/crates/primer-embedding/src/ollama.rs).
+
+> **Gotcha:** The `embedding` and `speech` cargo features both pin `ort = "=2.0.0-rc.10"`. Bumping fastembed past `5.7.0` will break the speech build until the vendored silero/whisper/piper crates get rc.11+ patches. The two feature stacks share an ort version by load-bearing constraint, not by accident.
+
+> **Why:** Mismatched embedding dim under an existing `model_id` is a hard error in both `primer-knowledge` (schema v3) and `primer-storage` (schema v8). Silent fallback would invisibly degrade retrieval; the loud failure is the single mechanism that prevents that bug class. To deliberately swap models on an existing knowledge-base file, run `primer-kb-load --reembed --force --knowledge-db <path> --locale <pack>`.
+
+## Auto-seed and multi-file discovery
+
+A fresh KB starts empty. Rather than ask every contributor to populate one by hand, the loader at [primer-kb-load](src/crates/primer-kb-load/src/lib.rs) auto-seeds on first open if the database is empty.
+
+`auto_seed_if_empty(kb, locale)` is the entry point — it is called unconditionally during CLI startup. The function checks `kb.passage_count()`; if non-zero it returns `Ok(None)` immediately. If zero, it discovers seed files for the locale and loads each in turn.
+
+Discovery is the interesting part. `discover_seed_files(locale)` walks a fixed precedence list of candidate directories:
+
+1. `$PRIMER_SEED_DIR` — environment override, useful for tests and packaged builds.
+2. `$XDG_DATA_HOME/primer/seed/` — the standard cross-distro user data path. Falls back to `~/.local/share/primer/seed/` when `XDG_DATA_HOME` is unset.
+3. `$CARGO_MANIFEST_DIR/.../data/seed/` — the in-repo path, walking up from the crate's manifest dir up to five levels. This is what makes `cargo run` from `src/` work without any environment setup.
+
+Whichever directory yields at least one matching file wins, and **all** matching `*.<pack_id>.jsonl` files in that directory are returned, sorted lexicographically and loaded in that order. "Matching" means a regular file whose name ends in `.<pack>.jsonl` — distractors like `wiki_passages.de.jsonl` (wrong locale) and `README.md` (wrong extension) are correctly ignored when the locale is English.
+
+This is what makes the multi-layer corpus work transparently. Today, for `Locale::English`, the in-repo seed dir holds two files:
+
+- `seed_passages.en.jsonl` — 55 hand-drafted passages, CC0-1.0, covering the five planned clusters (space, body, how-things-work, life, earth/weather).
+- `wiki_passages.en.jsonl` — 35 lead paragraphs from Simple English Wikipedia, CC-BY-SA-3.0, covering physics fundamentals, chemistry, biology, earth science, and health.
+
+Both load on a fresh English KB, giving 90 passages out of the box. A future `wiki_passages.de.jsonl` would auto-load on a German session without any code change. The older `discover_seed_jsonl(locale)` API still exists for back-compat (it returns just the canonical `seed_passages.<pack>.jsonl`); new code should prefer `discover_seed_files`.
+
+The loader half — `load_jsonl(kb, path)` — is idempotent. It treats `id` as the deduplication key: a row already in `passages_<pack>_content` with the same `id` is skipped, not overwritten, mirroring the append-only behaviour of `SessionStore::save_session`. Re-running on the same JSONL is a no-op; running it on a JSONL with new entries adds only the new ones. The `sources` table uses upsert semantics so attribution stays current.
+
+> **Note:** `auto_seed_if_empty` runs unconditionally on every CLI startup, but the empty-KB check makes the actual load conditional. After the first run the KB is non-empty and the function is a `passage_count` query plus an early return.
+
+## Wikipedia ingestion pipeline
+
+The Wikipedia layer is regenerated by a Python pipeline at [data/ingest/](data/ingest/), not at build time — the developer runs it once and commits the resulting JSONL. This keeps Rust builds hermetic (no network, no Python dep) and makes changes to the corpus reviewable as ordinary diffs.
+
+The design is: pure functions where possible; network is the test boundary, injected via an `http_client` parameter so the unit tests can run with a mocked transport. Source files live next to a `tests/` directory that exercises the pure halves directly.
+
+Two functions do the actual fetching, in [simple_wikipedia.py](data/ingest/simple_wikipedia.py):
+
+- `fetch_lead(title, *, http_client)` — fetch one article's lead paragraph. Raises loudly on missing pages, empty extracts, and disambiguation pages (matched by `_DISAMBIGUATION_PATTERNS` against the lead's first 300 characters; the cure is a more specific title like `Base (chemistry)` rather than `Base`).
+- `fetch_leads(titles, *, http_client)` — batched variant that fetches up to 20 titles per API call. Strictly better than calling `fetch_lead` in a loop because the MediaWiki extracts endpoint enforces a per-IP rate limit; one request for twenty leads costs a single rate-limit slot.
+
+The whitelist at [simple_wikipedia_whitelist.txt](data/ingest/simple_wikipedia_whitelist.txt) is hand-curated. To expand it, [build_whitelist.py](data/ingest/build_whitelist.py) pulls candidates from Wikipedia's Vital Articles Level 4 list — they still need manual review because the Vital list includes plenty of articles that aren't appropriate for an eight-year-old.
+
+To regenerate the wiki layer:
+
+```bash
+# from the repo root
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r data/ingest/requirements.txt
+cd data/ingest
+python3 simple_wikipedia.py
+```
+
+Re-runs are deterministic — output is sorted by `id`, JSON-serialised with `ensure_ascii=True`, so diffs only reflect real article-content changes upstream. Commit the regenerated `data/seed/wiki_passages.en.jsonl` alongside whatever change motivated the rerun.
+
+## Sweep tests
+
+Two sweep tests pin the retrieval defaults against the 90-passage corpus. Both live in [primer-kb-load/tests/](src/crates/primer-kb-load/tests/), not under `primer-knowledge/`, because they exercise the full ingestion + retrieval pipeline end-to-end.
+
+- [retrieval_sweep.rs](src/crates/primer-kb-load/tests/retrieval_sweep.rs) — BM25-only sweep. Always built; `#[ignore]`'d so it doesn't run in default CI. Run via `cargo test -p primer-kb-load --test retrieval_sweep -- --ignored sweep_retrieval_params --nocapture`. The 24-cell sweep is what produced today's defaults: `KB_FINAL_TOP_K = 5` and `KB_BM25_ONLY_MIN_SCORE = 0.5`.
+- [retrieval_sweep_hybrid.rs](src/crates/primer-kb-load/tests/retrieval_sweep_hybrid.rs) — hybrid (BM25 + dense-vector RRF) sweep. Gated on `--features fastembed` AND `#[ignore]`'d, so even `cargo test --features fastembed` skips it without `--ignored`. Run via `cargo test -p primer-kb-load --features fastembed --test retrieval_sweep_hybrid -- --ignored sweep_retrieval_params_hybrid --nocapture`. The 54-cell sweep produced today's hybrid defaults: `KB_BM25_TOP_K = 30`, `KB_VECTOR_TOP_K = 30`, `KB_FINAL_TOP_K = 5`, `RRF_K = 60`. Hybrid achieves 100% loose / 100% strict recall on the 87-query benchmark (with 20 strict-subset canonical-id mappings).
+
+The standing regression tests (always-on, not `#[ignore]`'d) live in [retrieval_quality.rs](src/crates/primer-kb-load/tests/retrieval_quality.rs) (BM25-only) and [retrieval_quality_hybrid.rs](src/crates/primer-kb-load/tests/retrieval_quality_hybrid.rs) (hybrid; the real-`fastembed` recall floor is gated on the feature, but a `StubEmbedder` structural sanity check runs on every build).
+
+The list of queries the BM25-only path is allowed to miss lives in [tests/common/mod.rs](src/crates/primer-kb-load/tests/common/mod.rs) as `KNOWN_FAILING_QUERIES`. The hybrid analogue, `KNOWN_FAILING_QUERIES_HYBRID`, is empty today — the dense leg lifted every BM25 strict miss in the benchmark, including the canonical "how does the sun shine" case (closed issue #42). New entries on the hybrid list mean either a real semantic regression or a corpus-coverage gap the dense leg can't bridge; investigate before committing.
+
+---
+
+### Recipe — Add or tune seed passages
+
+You want to add a passage on a topic the corpus doesn't cover well, or tweak an existing passage so a struggling query finally resolves. The flow is JSONL-first: the data file is the source of truth, and the test suite tells you whether the change earned its keep.
+
+**1. Edit the JSONL.** Choose the right layer. Hand-drafted, CC0 content goes in `data/seed/seed_passages.<pack>.jsonl`; new wiki content goes through the [Wikipedia ingestion pipeline](#wikipedia-ingestion-pipeline) and lands in `wiki_passages.<pack>.jsonl`. To add a third layer (say, a curriculum source), create a new `<your_layer>.<pack>.jsonl` in `data/seed/`; the discovery code picks it up automatically.
+
+A row looks like this:
+
+```jsonl
+{"id":"sun_shine_01","source":"hand-drafted-cc0","license":"CC0-1.0","attribution":"The Primer seed corpus","source_url":null,"text":"The Sun shines because of nuclear fusion in its core. Hydrogen atoms collide so fast they fuse into helium, releasing energy as light and heat.","topics":["space","sun","fusion"]}
+```
+
+`id` is the deduplication key — make it stable and unique. `source` doubles as the `sources`-table foreign key; reuse an existing source id (see existing rows) unless you are introducing a new one. `text` is the passage body (the field is `text`, not `body`). `topics` is informational only and not persisted.
+
+**2. Register the source if it is new.** If you used an `id`/`source` that doesn't appear elsewhere in the JSONL, the loader will create a `sources` row from the per-row `license`/`attribution`/`source_url` fields automatically. Just make sure those fields are correct on every row that uses the new source — the loader takes whichever value it sees first.
+
+**3. Run the BM25 quality test.** This is the always-on regression check; it must stay green:
+
+```bash
+cd src
+cargo test -p primer-kb-load --test retrieval_quality
+```
+
+If a previously-failing query now passes, remove its entry from `KNOWN_FAILING_QUERIES` in [tests/common/mod.rs](src/crates/primer-kb-load/tests/common/mod.rs). The defensive check there will reject stale entries on the next run.
+
+**4. (Optional but encouraged) Run the BM25 sweep.** This re-confirms the tuned defaults still hold up after your corpus change:
+
+```bash
+cargo test -p primer-kb-load --test retrieval_sweep -- --ignored sweep_retrieval_params --nocapture
+```
+
+**5. Run the hybrid quality + sweep.** If you have `fastembed` set up locally:
+
+```bash
+cargo test -p primer-kb-load --features fastembed --test retrieval_quality_hybrid
+cargo test -p primer-kb-load --features fastembed --test retrieval_sweep_hybrid -- --ignored sweep_retrieval_params_hybrid --nocapture
+```
+
+If a previously-failing hybrid query now passes, remove its entry from `KNOWN_FAILING_QUERIES_HYBRID`.
+
+**6. Commit JSONL + test-list change in one commit.** A single commit per "I improved retrieval on X" keeps the history reviewable. Include the recall delta in the commit message body if you have it from the sweep output.
+
+### Recipe — Add a new locale
+
+Adding a new locale means picking a stable pack id, writing a translation pack, providing a seed corpus, and exercising the locale-guard on resume. There are no schema migrations involved — locale-scoped tables are created on demand the first time `open_for_locale` sees the new pack.
+
+**1. Add the variant to `Locale`.** Edit [primer-core/src/i18n.rs](src/crates/primer-core/src/i18n.rs). Pick a stable pack id (`"de"`, `"ja"`, `"hi"` — ISO 639-1 where applicable). The pack id is what every per-locale file and table is keyed by, so it should not change once you start using it.
+
+**2. Add the TOML pack.** Mirror `primer-core/i18n/en.toml` at `primer-core/i18n/<pack_id>.toml`. Every locale-specific user-visible string lives there, including `break_suggestion_intro` with the `{minutes}` substitution token. The pattern is reusable for any future locale-aware unit substitution — the locale's TOML owns its own unit word ("minutes" / "Minuten" / etc).
+
+**3. Add the seed JSONL.** At minimum, create `data/seed/seed_passages.<pack_id>.jsonl` with hand-drafted passages. Optionally regenerate `data/seed/wiki_passages.<pack_id>.jsonl` via the [ingestion pipeline](#wikipedia-ingestion-pipeline) — Simple English Wikipedia obviously won't apply, but the same pattern adapts to any per-language MediaWiki extracts endpoint.
+
+**4. Open the KB for the new locale.** No code change beyond the call site:
+
+```rust
+let kb = SqliteKnowledgeBase::open_for_locale(path, Locale::German)?;
+```
+
+The first open creates `passages_de`, `passages_de_content`, and `embeddings_de` automatically. Existing locale tables in the same file are untouched.
+
+**5. Test the resume guard.** Open a session under the new locale, save it, then try to resume with `--language` set to a different pack. The CLI must error with the two-resolution hint (drop `--language`, or pass `--language <stored>`); the longitudinal vocabulary record depends on this. Without the guard, `concepts.concept_language_tag` would silently start tagging new rows under the wrong locale.
+
+**6. Run the locale-related tests.**
+
+```bash
+cd src
+cargo test -p primer-pedagogy locale
+cargo test -p primer-knowledge locale
+```
+
+**7. Cross-link to chapter 5 on storage.** Per-learner locale is stored alongside the session because mismatching `concept_language_tag` would silently corrupt the longitudinal vocabulary record — the same reason the resume guard exists. See chapter 5 for the `learners.locale` field added in storage schema v6.

--- a/docs/devel/04-knowledge-and-retrieval.md
+++ b/docs/devel/04-knowledge-and-retrieval.md
@@ -235,7 +235,7 @@ If a previously-failing hybrid query now passes, remove its entry from `KNOWN_FA
 
 Adding a new locale means picking a stable pack id, writing a translation pack, providing a seed corpus, and exercising the locale-guard on resume. There are no schema migrations involved — locale-scoped tables are created on demand the first time `open_for_locale` sees the new pack.
 
-**1. Add the variant to `Locale`.** Edit [primer-core/src/i18n.rs](src/crates/primer-core/src/i18n.rs). Pick a stable pack id (`"de"`, `"ja"`, `"hi"` — ISO 639-1 where applicable). The pack id is what every per-locale file and table is keyed by, so it should not change once you start using it.
+**1. Add the variant to `Locale`.** Edit [primer-core/src/i18n.rs](src/crates/primer-core/src/i18n.rs). At time of writing, `English` and `German` already exist; this recipe uses Japanese (`"ja"`) as a fresh worked example. Pick a stable ISO 639-1 pack id (`"ja"`, `"hi"`, `"fr"`, …); it is what every per-locale file and table is keyed by, so it should not change once you start using it.
 
 **2. Add the TOML pack.** Mirror `primer-core/i18n/en.toml` at `primer-core/i18n/<pack_id>.toml`. Every locale-specific user-visible string lives there, including `break_suggestion_intro` with the `{minutes}` substitution token. The pattern is reusable for any future locale-aware unit substitution — the locale's TOML owns its own unit word ("minutes" / "Minuten" / etc).
 
@@ -244,10 +244,10 @@ Adding a new locale means picking a stable pack id, writing a translation pack, 
 **4. Open the KB for the new locale.** No code change beyond the call site:
 
 ```rust
-let kb = SqliteKnowledgeBase::open_for_locale(path, Locale::German)?;
+let kb = SqliteKnowledgeBase::open_for_locale(path, Locale::Japanese)?;
 ```
 
-The first open creates `passages_de`, `passages_de_content`, and `embeddings_de` automatically. Existing locale tables in the same file are untouched.
+The first open creates `passages_ja`, `passages_ja_content`, and `embeddings_ja` automatically. Existing locale tables in the same file are untouched. Subsequent opens re-check via `CREATE IF NOT EXISTS`, so the operation is idempotent.
 
 **5. Test the resume guard.** Open a session under the new locale, save it, then try to resume with `--language` set to a different pack. The CLI must error with the two-resolution hint (drop `--language`, or pass `--language <stored>`); the longitudinal vocabulary record depends on this. Without the guard, `concepts.concept_language_tag` would silently start tagging new rows under the wrong locale.
 

--- a/docs/devel/04-knowledge-and-retrieval.md
+++ b/docs/devel/04-knowledge-and-retrieval.md
@@ -1,12 +1,12 @@
 # Knowledge and retrieval
 
-This chapter is about how the Primer grounds its replies in real, attributed text. It covers the [KnowledgeBase](src/crates/primer-core/src/knowledge.rs) trait, the SQLite + FTS5 implementation, the lexical (BM25) and hybrid (BM25 + dense-vector RRF) retrieval paths, the [Embedder](src/crates/primer-core/src/embedder.rs) trait and its three concrete backends, the multi-layer auto-seeded corpus that ships in the repo, and the locale-aware schema that lets every language live side-by-side without contaminating each other's BM25 statistics. Two recipes at the end show how to extend the seed corpus and how to add a brand-new locale.
+This chapter is about how the Primer grounds its replies in real, attributed text. It covers the [KnowledgeBase](../../src/crates/primer-core/src/knowledge.rs) trait, the SQLite + FTS5 implementation, the lexical (BM25) and hybrid (BM25 + dense-vector RRF) retrieval paths, the [Embedder](../../src/crates/primer-core/src/embedder.rs) trait and its three concrete backends, the multi-layer auto-seeded corpus that ships in the repo, and the locale-aware schema that lets every language live side-by-side without contaminating each other's BM25 statistics. Two recipes at the end show how to extend the seed corpus and how to add a brand-new locale.
 
 If you already read chapter 3 on inference and pedagogy, the dialogue manager you saw there pulls retrieved passages into the system prompt before every turn — this chapter is the back half of that pipeline.
 
 ## The KnowledgeBase trait
 
-Every retrieval surface the dialogue manager sees is one trait, defined in [knowledge.rs](src/crates/primer-core/src/knowledge.rs). The contract is small on purpose: backends decide how to store and rank passages, but the trait shape is fixed so the engine never knows whether it is talking to a SQLite FTS5 index, a future on-device vector store, or a stub.
+Every retrieval surface the dialogue manager sees is one trait, defined in [knowledge.rs](../../src/crates/primer-core/src/knowledge.rs). The contract is small on purpose: backends decide how to store and rank passages, but the trait shape is fixed so the engine never knows whether it is talking to a SQLite FTS5 index, a future on-device vector store, or a stub.
 
 ```rust
 // src/crates/primer-core/src/knowledge.rs
@@ -32,13 +32,13 @@ pub trait KnowledgeBase: Send + Sync {
 }
 ```
 
-A few details worth pinning down before you read further. `Passage` is `{ id, source, text, score }`, where `score` is "higher = more relevant" regardless of the underlying ranker — backends must normalise their internal scoring into that direction before returning. `SourceMeta` is the per-source attribution + licence record (`id`, `license`, `attribution`, `source_url`, `retrieved_at`); a passage's `source` field is a logical foreign key into `SourceMeta::id`. `RetrievalParams` is BM25-shaped (`top_k`, `min_score`, `source_filter`); `HybridParams` adds the wider candidate pool (`bm25_top_k`, `vector_top_k`) plus the RRF constant (`rrf_k`). Both `Default` impls read from [consts::retrieval](src/crates/primer-core/src/consts.rs) so any tuning change happens in one place.
+A few details worth pinning down before you read further. `Passage` is `{ id, source, text, score }`, where `score` is "higher = more relevant" regardless of the underlying ranker — backends must normalise their internal scoring into that direction before returning. `SourceMeta` is the per-source attribution + licence record (`id`, `license`, `attribution`, `source_url`, `retrieved_at`); a passage's `source` field is a logical foreign key into `SourceMeta::id`. `RetrievalParams` is BM25-shaped (`top_k`, `min_score`, `source_filter`); `HybridParams` adds the wider candidate pool (`bm25_top_k`, `vector_top_k`) plus the RRF constant (`rrf_k`). Both `Default` impls read from [consts::retrieval](../../src/crates/primer-core/src/consts.rs) so any tuning change happens in one place.
 
 > **Note:** When no `Embedder` is wired, `retrieve_hybrid`'s default trait impl falls back to BM25-only — every consumer can call it unconditionally. This is what keeps the dialogue manager free of `if cfg!(feature = "embedding")` branches.
 
 ## SqliteKnowledgeBase schema
 
-The concrete backend is [SqliteKnowledgeBase](src/crates/primer-knowledge/src/lib.rs), which uses SQLite FTS5 as its lexical index and stores per-passage `f32` vectors as BLOBs for the dense leg. It is locale-scoped: every locale gets its own pair of tables plus its own embedding store, so a German corpus and an English corpus can coexist in one file without polluting each other's term statistics.
+The concrete backend is [SqliteKnowledgeBase](../../src/crates/primer-knowledge/src/lib.rs), which uses SQLite FTS5 as its lexical index and stores per-passage `f32` vectors as BLOBs for the dense leg. It is locale-scoped: every locale gets its own pair of tables plus its own embedding store, so a German corpus and an English corpus can coexist in one file without polluting each other's term statistics.
 
 For locale `<pack_id>` (e.g. `en`, `de`), the per-locale layout is:
 
@@ -51,7 +51,7 @@ Two cross-locale tables travel alongside:
 - `sources` — licence + attribution metadata, keyed by source id. Phase 0.2 schema; populated lazily by `upsert_source`.
 - `embedding_models` — `(name, dim)` registry for every embedder ever seen on this DB. Mismatched dim under an existing name is a hard error rather than a silent fallback.
 
-The schema is at [USER_VERSION](src/crates/primer-knowledge/src/lib.rs) `3`. Migrations layer additively, each idempotent and transaction-wrapped: v2 added `sources`; v3 added `embedding_models` and the per-locale `embeddings_<pack>` tables. A pre-locale legacy `passages` table (from before the locale-aware refactor) is migrated into the requested locale's `passages_<pack>_content` pair on first open and the legacy table is dropped — the migration assumes the legacy corpus matches the locale being opened, which is the only sound assumption when locale wasn't tracked at write time.
+The schema is at [USER_VERSION](../../src/crates/primer-knowledge/src/lib.rs) `3`. Migrations layer additively, each idempotent and transaction-wrapped: v2 added `sources`; v3 added `embedding_models` and the per-locale `embeddings_<pack>` tables. A pre-locale legacy `passages` table (from before the locale-aware refactor) is migrated into the requested locale's `passages_<pack>_content` pair on first open and the legacy table is dropped — the migration assumes the legacy corpus matches the locale being opened, which is the only sound assumption when locale wasn't tracked at write time.
 
 To open a knowledge base, prefer the locale-explicit constructor:
 
@@ -77,11 +77,11 @@ Lexical search is great when the child uses the corpus's own vocabulary and shak
 `SqliteKnowledgeBase::retrieve_hybrid` does exactly that:
 
 1. Run BM25 with `top_k = bm25_top_k` (default 30 — wider than what's ultimately returned, so the fusion stage has a candidate pool to work with).
-2. Embed the query through the supplied [Embedder](src/crates/primer-core/src/embedder.rs) and run a cosine search over the per-passage vectors with `top_k = vector_top_k` (default 30).
+2. Embed the query through the supplied [Embedder](../../src/crates/primer-core/src/embedder.rs) and run a cosine search over the per-passage vectors with `top_k = vector_top_k` (default 30).
 3. Fuse the two ranked lists via Reciprocal Rank Fusion (`primer_core::rrf::fuse(&[ranked_lists], k)`) with `rrf_k = 60` — the industry-standard default. Smaller values weight the very top of each list more heavily; larger values flatten the curve.
 4. Apply `min_score` and return the top `final_top_k` (default 5).
 
-`HybridParams::default()` reads from [consts::retrieval](src/crates/primer-core/src/consts.rs); a `default_mirrors_consts` test pins the alignment so a code reviewer doesn't have to chase two sources of truth.
+`HybridParams::default()` reads from [consts::retrieval](../../src/crates/primer-core/src/consts.rs); a `default_mirrors_consts` test pins the alignment so a code reviewer doesn't have to chase two sources of truth.
 
 > **Note:** Bumping the candidate pool sizes (`KB_BM25_TOP_K`, `KB_VECTOR_TOP_K`) is cheap — it only affects in-memory work, not what ends up in the prompt. Bumping `KB_FINAL_TOP_K` is what costs prompt tokens, because every returned passage is injected into the system prompt every turn.
 
@@ -89,7 +89,7 @@ The fallback story is important. When the dialogue manager has no `Embedder` wir
 
 ## The Embedder trait
 
-The dense leg requires a way to turn text into a fixed-dimension `f32` vector. That contract lives in [embedder.rs](src/crates/primer-core/src/embedder.rs):
+The dense leg requires a way to turn text into a fixed-dimension `f32` vector. That contract lives in [embedder.rs](../../src/crates/primer-core/src/embedder.rs):
 
 ```rust
 // src/crates/primer-core/src/embedder.rs
@@ -103,23 +103,23 @@ pub trait Embedder: Named + Send + Sync {
 
 `Embedder` inherits from `Named`, which is the same single-source-of-truth `name()` trait that all the speech traits inherit from — backends never have to write `name()` twice. `model_id` is a stable identifier (e.g. `"bge-m3"`, `"stub-fxhash-v1"`) persisted alongside every stored vector so cross-model mixing is detectable at open time.
 
-Three concrete impls live in [primer-embedding](src/crates/primer-embedding/src/lib.rs):
+Three concrete impls live in [primer-embedding](../../src/crates/primer-embedding/src/lib.rs):
 
 ### StubEmbedder
 
-Always built, no feature flag. It hashes each input through FNV + xorshift to produce a deterministic, L2-normalised `f32` vector of configurable dimension (default 384). Model id is `"stub-fxhash-v1"`. This is the embedder every workspace test uses when it needs a non-trivial vector backend without a model download. See [stub.rs](src/crates/primer-embedding/src/stub.rs).
+Always built, no feature flag. It hashes each input through FNV + xorshift to produce a deterministic, L2-normalised `f32` vector of configurable dimension (default 384). Model id is `"stub-fxhash-v1"`. This is the embedder every workspace test uses when it needs a non-trivial vector backend without a model download. See [stub.rs](../../src/crates/primer-embedding/src/stub.rs).
 
 > **Gotcha:** `--embedder-backend stub` is for testing the hybrid pipeline structurally only. In production it dilutes BM25 with semantic noise from a hash function — two synonyms produce orthogonal vectors — and should never be the default. If you see suspicious recall behaviour, the first thing to check is which embedder is actually wired.
 
 ### FastEmbedBackend
 
-Behind the `fastembed` feature. Wraps [fastembed-rs](https://github.com/Anush008/fastembed-rs) `5.7.0` to load BGE-M3, a 1024-dimensional multilingual embedding model that covers EN/DE/JA/HI in one binary so the initial test cohort never hits a model swap. The int8-quantised weights weigh in at about 570 MB. See [fastembed_backend.rs](src/crates/primer-embedding/src/fastembed_backend.rs).
+Behind the `fastembed` feature. Wraps [fastembed-rs](https://github.com/Anush008/fastembed-rs) `5.7.0` to load BGE-M3, a 1024-dimensional multilingual embedding model that covers EN/DE/JA/HI in one binary so the initial test cohort never hits a model swap. The int8-quantised weights weigh in at about 570 MB. See [fastembed_backend.rs](../../src/crates/primer-embedding/src/fastembed_backend.rs).
 
 > **Gotcha:** First-run BGE-M3 download is ~570 MB into `~/.cache/primer/models/` and uses the same `cdn.pyke.io` ONNX-runtime download as the speech feature. Construction failure falls back to BM25-only with a `tracing::warn!` — the conversation still works, which is strictly better than refusing to start.
 
 ### OllamaEmbedder
 
-Behind the `ollama` feature. Calls the local Ollama daemon's `/api/embeddings` endpoint (default model `nomic-embed-text`, default URL `http://localhost:11434`). This is the developer-prototyping path — useful for trying out a different embedding model without rebuilding the binary, but not the recommended runtime backend because it adds a network hop in the hot path. See [ollama.rs](src/crates/primer-embedding/src/ollama.rs).
+Behind the `ollama` feature. Calls the local Ollama daemon's `/api/embeddings` endpoint (default model `nomic-embed-text`, default URL `http://localhost:11434`). This is the developer-prototyping path — useful for trying out a different embedding model without rebuilding the binary, but not the recommended runtime backend because it adds a network hop in the hot path. See [ollama.rs](../../src/crates/primer-embedding/src/ollama.rs).
 
 > **Gotcha:** The `embedding` and `speech` cargo features both pin `ort = "=2.0.0-rc.10"`. Bumping fastembed past `5.7.0` will break the speech build until the vendored silero/whisper/piper crates get rc.11+ patches. The two feature stacks share an ort version by load-bearing constraint, not by accident.
 
@@ -127,7 +127,7 @@ Behind the `ollama` feature. Calls the local Ollama daemon's `/api/embeddings` e
 
 ## Auto-seed and multi-file discovery
 
-A fresh KB starts empty. Rather than ask every contributor to populate one by hand, the loader at [primer-kb-load](src/crates/primer-kb-load/src/lib.rs) auto-seeds on first open if the database is empty.
+A fresh KB starts empty. Rather than ask every contributor to populate one by hand, the loader at [primer-kb-load](../../src/crates/primer-kb-load/src/lib.rs) auto-seeds on first open if the database is empty.
 
 `auto_seed_if_empty(kb, locale)` is the entry point — it is called unconditionally during CLI startup. The function checks `kb.passage_count()`; if non-zero it returns `Ok(None)` immediately. If zero, it discovers seed files for the locale and loads each in turn.
 
@@ -152,16 +152,16 @@ The loader half — `load_jsonl(kb, path)` — is idempotent. It treats `id` as 
 
 ## Wikipedia ingestion pipeline
 
-The Wikipedia layer is regenerated by a Python pipeline at [data/ingest/](data/ingest/), not at build time — the developer runs it once and commits the resulting JSONL. This keeps Rust builds hermetic (no network, no Python dep) and makes changes to the corpus reviewable as ordinary diffs.
+The Wikipedia layer is regenerated by a Python pipeline at [data/ingest/](../../data/ingest/), not at build time — the developer runs it once and commits the resulting JSONL. This keeps Rust builds hermetic (no network, no Python dep) and makes changes to the corpus reviewable as ordinary diffs.
 
 The design is: pure functions where possible; network is the test boundary, injected via an `http_client` parameter so the unit tests can run with a mocked transport. Source files live next to a `tests/` directory that exercises the pure halves directly.
 
-Two functions do the actual fetching, in [simple_wikipedia.py](data/ingest/simple_wikipedia.py):
+Two functions do the actual fetching, in [simple_wikipedia.py](../../data/ingest/simple_wikipedia.py):
 
 - `fetch_lead(title, *, http_client)` — fetch one article's lead paragraph. Raises loudly on missing pages, empty extracts, and disambiguation pages (matched by `_DISAMBIGUATION_PATTERNS` against the lead's first 300 characters; the cure is a more specific title like `Base (chemistry)` rather than `Base`).
 - `fetch_leads(titles, *, http_client)` — batched variant that fetches up to 20 titles per API call. Strictly better than calling `fetch_lead` in a loop because the MediaWiki extracts endpoint enforces a per-IP rate limit; one request for twenty leads costs a single rate-limit slot.
 
-The whitelist at [simple_wikipedia_whitelist.txt](data/ingest/simple_wikipedia_whitelist.txt) is hand-curated. To expand it, [build_whitelist.py](data/ingest/build_whitelist.py) pulls candidates from Wikipedia's Vital Articles Level 4 list — they still need manual review because the Vital list includes plenty of articles that aren't appropriate for an eight-year-old.
+The whitelist at [simple_wikipedia_whitelist.txt](../../data/ingest/simple_wikipedia_whitelist.txt) is hand-curated. To expand it, [build_whitelist.py](../../data/ingest/build_whitelist.py) pulls candidates from Wikipedia's Vital Articles Level 4 list — they still need manual review because the Vital list includes plenty of articles that aren't appropriate for an eight-year-old.
 
 To regenerate the wiki layer:
 
@@ -178,14 +178,14 @@ Re-runs are deterministic — output is sorted by `id`, JSON-serialised with `en
 
 ## Sweep tests
 
-Two sweep tests pin the retrieval defaults against the 90-passage corpus. Both live in [primer-kb-load/tests/](src/crates/primer-kb-load/tests/), not under `primer-knowledge/`, because they exercise the full ingestion + retrieval pipeline end-to-end.
+Two sweep tests pin the retrieval defaults against the 90-passage corpus. Both live in [primer-kb-load/tests/](../../src/crates/primer-kb-load/tests/), not under `primer-knowledge/`, because they exercise the full ingestion + retrieval pipeline end-to-end.
 
-- [retrieval_sweep.rs](src/crates/primer-kb-load/tests/retrieval_sweep.rs) — BM25-only sweep. Always built; `#[ignore]`'d so it doesn't run in default CI. Run via `cargo test -p primer-kb-load --test retrieval_sweep -- --ignored sweep_retrieval_params --nocapture`. The 24-cell sweep is what produced today's defaults: `KB_FINAL_TOP_K = 5` and `KB_BM25_ONLY_MIN_SCORE = 0.5`.
-- [retrieval_sweep_hybrid.rs](src/crates/primer-kb-load/tests/retrieval_sweep_hybrid.rs) — hybrid (BM25 + dense-vector RRF) sweep. Gated on `--features fastembed` AND `#[ignore]`'d, so even `cargo test --features fastembed` skips it without `--ignored`. Run via `cargo test -p primer-kb-load --features fastembed --test retrieval_sweep_hybrid -- --ignored sweep_retrieval_params_hybrid --nocapture`. The 54-cell sweep produced today's hybrid defaults: `KB_BM25_TOP_K = 30`, `KB_VECTOR_TOP_K = 30`, `KB_FINAL_TOP_K = 5`, `RRF_K = 60`. Hybrid achieves 100% loose / 100% strict recall on the 87-query benchmark (with 20 strict-subset canonical-id mappings).
+- [retrieval_sweep.rs](../../src/crates/primer-kb-load/tests/retrieval_sweep.rs) — BM25-only sweep. Always built; `#[ignore]`'d so it doesn't run in default CI. Run via `cargo test -p primer-kb-load --test retrieval_sweep -- --ignored sweep_retrieval_params --nocapture`. The 24-cell sweep is what produced today's defaults: `KB_FINAL_TOP_K = 5` and `KB_BM25_ONLY_MIN_SCORE = 0.5`.
+- [retrieval_sweep_hybrid.rs](../../src/crates/primer-kb-load/tests/retrieval_sweep_hybrid.rs) — hybrid (BM25 + dense-vector RRF) sweep. Gated on `--features fastembed` AND `#[ignore]`'d, so even `cargo test --features fastembed` skips it without `--ignored`. Run via `cargo test -p primer-kb-load --features fastembed --test retrieval_sweep_hybrid -- --ignored sweep_retrieval_params_hybrid --nocapture`. The 54-cell sweep produced today's hybrid defaults: `KB_BM25_TOP_K = 30`, `KB_VECTOR_TOP_K = 30`, `KB_FINAL_TOP_K = 5`, `RRF_K = 60`. Hybrid achieves 100% loose / 100% strict recall on the 87-query benchmark (with 20 strict-subset canonical-id mappings).
 
-The standing regression tests (always-on, not `#[ignore]`'d) live in [retrieval_quality.rs](src/crates/primer-kb-load/tests/retrieval_quality.rs) (BM25-only) and [retrieval_quality_hybrid.rs](src/crates/primer-kb-load/tests/retrieval_quality_hybrid.rs) (hybrid; the real-`fastembed` recall floor is gated on the feature, but a `StubEmbedder` structural sanity check runs on every build).
+The standing regression tests (always-on, not `#[ignore]`'d) live in [retrieval_quality.rs](../../src/crates/primer-kb-load/tests/retrieval_quality.rs) (BM25-only) and [retrieval_quality_hybrid.rs](../../src/crates/primer-kb-load/tests/retrieval_quality_hybrid.rs) (hybrid; the real-`fastembed` recall floor is gated on the feature, but a `StubEmbedder` structural sanity check runs on every build).
 
-The list of queries the BM25-only path is allowed to miss lives in [tests/common/mod.rs](src/crates/primer-kb-load/tests/common/mod.rs) as `KNOWN_FAILING_QUERIES`. The hybrid analogue, `KNOWN_FAILING_QUERIES_HYBRID`, is empty today — the dense leg lifted every BM25 strict miss in the benchmark, including the canonical "how does the sun shine" case (closed issue #42). New entries on the hybrid list mean either a real semantic regression or a corpus-coverage gap the dense leg can't bridge; investigate before committing.
+The list of queries the BM25-only path is allowed to miss lives in [tests/common/mod.rs](../../src/crates/primer-kb-load/tests/common/mod.rs) as `KNOWN_FAILING_QUERIES`. The hybrid analogue, `KNOWN_FAILING_QUERIES_HYBRID`, is empty today — the dense leg lifted every BM25 strict miss in the benchmark, including the canonical "how does the sun shine" case (closed issue #42). New entries on the hybrid list mean either a real semantic regression or a corpus-coverage gap the dense leg can't bridge; investigate before committing.
 
 ---
 
@@ -212,7 +212,7 @@ cd src
 cargo test -p primer-kb-load --test retrieval_quality
 ```
 
-If a previously-failing query now passes, remove its entry from `KNOWN_FAILING_QUERIES` in [tests/common/mod.rs](src/crates/primer-kb-load/tests/common/mod.rs). The defensive check there will reject stale entries on the next run.
+If a previously-failing query now passes, remove its entry from `KNOWN_FAILING_QUERIES` in [tests/common/mod.rs](../../src/crates/primer-kb-load/tests/common/mod.rs). The defensive check there will reject stale entries on the next run.
 
 **4. (Optional but encouraged) Run the BM25 sweep.** This re-confirms the tuned defaults still hold up after your corpus change:
 
@@ -235,7 +235,7 @@ If a previously-failing hybrid query now passes, remove its entry from `KNOWN_FA
 
 Adding a new locale means picking a stable pack id, writing a translation pack, providing a seed corpus, and exercising the locale-guard on resume. There are no schema migrations involved — locale-scoped tables are created on demand the first time `open_for_locale` sees the new pack.
 
-**1. Add the variant to `Locale`.** Edit [primer-core/src/i18n.rs](src/crates/primer-core/src/i18n.rs). At time of writing, `English` and `German` already exist; this recipe uses Japanese (`"ja"`) as a fresh worked example. Pick a stable ISO 639-1 pack id (`"ja"`, `"hi"`, `"fr"`, …); it is what every per-locale file and table is keyed by, so it should not change once you start using it.
+**1. Add the variant to `Locale`.** Edit [primer-core/src/i18n.rs](../../src/crates/primer-core/src/i18n.rs). At time of writing, `English` and `German` already exist; this recipe uses Japanese (`"ja"`) as a fresh worked example. Pick a stable ISO 639-1 pack id (`"ja"`, `"hi"`, `"fr"`, …); it is what every per-locale file and table is keyed by, so it should not change once you start using it.
 
 **2. Add the TOML pack.** Mirror `primer-core/i18n/en.toml` at `primer-core/i18n/<pack_id>.toml`. Every locale-specific user-visible string lives there, including `break_suggestion_intro` with the `{minutes}` substitution token. The pattern is reusable for any future locale-aware unit substitution — the locale's TOML owns its own unit word ("minutes" / "Minuten" / etc).
 

--- a/docs/devel/05-storage-and-sessions.md
+++ b/docs/devel/05-storage-and-sessions.md
@@ -1,6 +1,6 @@
 # Storage and sessions
 
-This chapter is about how the Primer remembers conversations. It covers the [SessionStore](src/crates/primer-core/src/storage.rs) and [LearnerStore](src/crates/primer-core/src/storage.rs) traits, the [SqliteSessionStore](src/crates/primer-storage/src/store/mod.rs) implementation, the schema-migration discipline that lets old DBs upgrade in place without ever running a destructive migration, the lookup-table normalisation rule that keeps every categorical text column in sync with its Rust enum, the append-only `save_session` invariant and the explicit backfill paths that work around it, the FTS5 sanitisation layer that lets raw child input drive search safely, and the long-term-memory + turn-embedding-on-save pipelines that surface relevant older turns into future system prompts. One recipe at the end walks through adding a new schema version end-to-end.
+This chapter is about how the Primer remembers conversations. It covers the [SessionStore](../../src/crates/primer-core/src/storage.rs) and [LearnerStore](../../src/crates/primer-core/src/storage.rs) traits, the [SqliteSessionStore](../../src/crates/primer-storage/src/store/mod.rs) implementation, the schema-migration discipline that lets old DBs upgrade in place without ever running a destructive migration, the lookup-table normalisation rule that keeps every categorical text column in sync with its Rust enum, the append-only `save_session` invariant and the explicit backfill paths that work around it, the FTS5 sanitisation layer that lets raw child input drive search safely, and the long-term-memory + turn-embedding-on-save pipelines that surface relevant older turns into future system prompts. One recipe at the end walks through adding a new schema version end-to-end.
 
 If you read chapter 3 you already saw the dialogue manager hand finished turns to a `SessionStore`; this chapter is what happens once it does.
 
@@ -14,7 +14,7 @@ The split exists because the two stores hold fundamentally different data. The s
 
 ## SessionStore and LearnerStore traits
 
-Two traits split the persistence surface, both defined in [storage.rs](src/crates/primer-core/src/storage.rs):
+Two traits split the persistence surface, both defined in [storage.rs](../../src/crates/primer-core/src/storage.rs):
 
 ```rust
 // src/crates/primer-core/src/storage.rs
@@ -58,13 +58,13 @@ pub trait LearnerStore: Send + Sync {
 }
 ```
 
-Both are implemented by [SqliteSessionStore](src/crates/primer-storage/src/store/mod.rs) — one type, two trait impls. The split is for testability and for the long-term shape: a future contributor who wants an alternative learner store (think a profile-only export tool) does not have to reimplement the much-larger session API. `SessionStore::save_turn_embedding` and `SessionStore::retrieve_session_turns_hybrid` carry default impls so that backends without vector support stay valid — the dialogue manager calls those methods unconditionally.
+Both are implemented by [SqliteSessionStore](../../src/crates/primer-storage/src/store/mod.rs) — one type, two trait impls. The split is for testability and for the long-term shape: a future contributor who wants an alternative learner store (think a profile-only export tool) does not have to reimplement the much-larger session API. `SessionStore::save_turn_embedding` and `SessionStore::retrieve_session_turns_hybrid` carry default impls so that backends without vector support stay valid — the dialogue manager calls those methods unconditionally.
 
 The `Result<Option<…>>` shape on `load_session`, `load_learner`, and `most_recent_session_learner_id` is deliberate. "Not found" is not an error — it's a normal first-run signal. Reserving `Err` for genuine I/O failures keeps the CLI free of "is this an expected miss or a real problem?" conditionals.
 
 ## Schema-migration pattern
 
-[primer-storage](src/crates/primer-storage/src/schema.rs) follows one shape across every migration. Read [schema.rs](src/crates/primer-storage/src/schema.rs) and you will see `apply_v2_migrations`, `apply_v3_migrations`, … `apply_v8_migrations` — eight migrations layered additively, each idempotent, each transaction-wrapped, each safe to run on a fresh DB or on any older DB being upgraded. The constant `USER_VERSION` lives at the top of that file (currently `8`). Open path lives in [store/mod.rs](src/crates/primer-storage/src/store/mod.rs) and runs every migration in order on every open.
+[primer-storage](../../src/crates/primer-storage/src/schema.rs) follows one shape across every migration. Read [schema.rs](../../src/crates/primer-storage/src/schema.rs) and you will see `apply_v2_migrations`, `apply_v3_migrations`, … `apply_v8_migrations` — eight migrations layered additively, each idempotent, each transaction-wrapped, each safe to run on a fresh DB or on any older DB being upgraded. The constant `USER_VERSION` lives at the top of that file (currently `8`). Open path lives in [store/mod.rs](../../src/crates/primer-storage/src/store/mod.rs) and runs every migration in order on every open.
 
 The pattern, distilled from `apply_v8_migrations`:
 
@@ -97,9 +97,9 @@ pub(crate) fn apply_v8_migrations(conn: &Connection) -> Result<()> {
 }
 ```
 
-Three things are doing all the work here. First, `conn.unchecked_transaction()` wraps the whole body so a partial failure (disk full halfway through, FK violation in step three) rolls back to the pre-migration state — no half-applied schema that subsequent saves would silently miswrite to. Second, every DDL is `CREATE … IF NOT EXISTS`, which makes the migration safe to re-run on an already-upgraded DB. Third, when a column add is needed instead of a new table, the helper `column_exists(&tx, "table", "column")` (also in [schema.rs](src/crates/primer-storage/src/schema.rs)) gates the `ALTER TABLE` so it runs once and only once. See `apply_v6_migrations` and `apply_v7_migrations` for the column-add shape.
+Three things are doing all the work here. First, `conn.unchecked_transaction()` wraps the whole body so a partial failure (disk full halfway through, FK violation in step three) rolls back to the pre-migration state — no half-applied schema that subsequent saves would silently miswrite to. Second, every DDL is `CREATE … IF NOT EXISTS`, which makes the migration safe to re-run on an already-upgraded DB. Third, when a column add is needed instead of a new table, the helper `column_exists(&tx, "table", "column")` (also in [schema.rs](../../src/crates/primer-storage/src/schema.rs)) gates the `ALTER TABLE` so it runs once and only once. See `apply_v6_migrations` and `apply_v7_migrations` for the column-add shape.
 
-After the migrations run, the open path also calls [validate_and_seed_lookup](src/crates/primer-storage/src/schema.rs) for every lookup table backed by a Rust enum — `speakers`, `pedagogical_intents`, `engagement_states`, `understanding_depths`. That helper compares what's on disk against the canonical `(id, name)` pairs from [catalog.rs](src/crates/primer-storage/src/catalog.rs) (which the Rust enums project into), inserts any missing rows, and **returns a hard error** if a known id has the wrong name or if the table has an id the build doesn't know about.
+After the migrations run, the open path also calls [validate_and_seed_lookup](../../src/crates/primer-storage/src/schema.rs) for every lookup table backed by a Rust enum — `speakers`, `pedagogical_intents`, `engagement_states`, `understanding_depths`. That helper compares what's on disk against the canonical `(id, name)` pairs from [catalog.rs](../../src/crates/primer-storage/src/catalog.rs) (which the Rust enums project into), inserts any missing rows, and **returns a hard error** if a known id has the wrong name or if the table has an id the build doesn't know about.
 
 > **Gotcha:** A schema `USER_VERSION` newer than this build is a hard error rejected at open. Older is silently upgraded. The reasoning: a newer-than-this-build DB might have rows the current code can't safely read, but an older DB is exactly what migrations are designed to bring forward.
 
@@ -107,31 +107,31 @@ After the migrations run, the open path also calls [validate_and_seed_lookup](sr
 
 Every categorical text column in this codebase is stored as an integer foreign key into a lookup table — never as inline text. That applies to `speakers`, `pedagogical_intents`, `engagement_states`, `understanding_depths`, `concepts`, `classifiers`, `comprehension_classifiers`, and the per-table `embedding_models` registries.
 
-For columns backed by a **closed** Rust enum (`Speaker`, `PedagogicalIntent`, `EngagementState`, `UnderstandingDepth`), the Rust source is the single source of truth. The DB lookup table is a derived projection — [catalog.rs](src/crates/primer-storage/src/catalog.rs) exposes `expected_speakers()`, `expected_intents()`, `expected_engagement_states()`, `expected_understanding_depths()`, all of which return `Vec<(i64, &'static str)>`. The open path runs `validate_and_seed_lookup` against each of those slices on every open. There is **no API for mutating lookup tables**. Adding a new enum variant means: edit the Rust enum, recompile, next open seeds the new row. Retired integer ids are never reused — once an id has had a meaning, that meaning is canonical.
+For columns backed by a **closed** Rust enum (`Speaker`, `PedagogicalIntent`, `EngagementState`, `UnderstandingDepth`), the Rust source is the single source of truth. The DB lookup table is a derived projection — [catalog.rs](../../src/crates/primer-storage/src/catalog.rs) exposes `expected_speakers()`, `expected_intents()`, `expected_engagement_states()`, `expected_understanding_depths()`, all of which return `Vec<(i64, &'static str)>`. The open path runs `validate_and_seed_lookup` against each of those slices on every open. There is **no API for mutating lookup tables**. Adding a new enum variant means: edit the Rust enum, recompile, next open seeds the new row. Retired integer ids are never reused — once an id has had a meaning, that meaning is canonical.
 
 For columns backed by an **open** vocabulary (`concepts`, `classifiers`, `comprehension_classifiers`), the row is created lazily on first reference. `update_turn_concepts` and friends use `INSERT OR IGNORE` patterns so that two parallel tasks racing to insert the same concept name end up with one row.
 
-A few text columns deliberately stay as JSON-in-TEXT rather than being normalised: `learners.languages`, `learners.high_engagement_topics`, `learner_concepts.notes`. Those are open-vocabulary, free-text lists owned by the learner; they're not FK targets, not queried by exact match, not shared across rows, and not bounded. Normalising them would buy nothing the `concepts` table doesn't already prove. See the long comment above `CREATE_LEARNERS_TABLE` in [schema.rs](src/crates/primer-storage/src/schema.rs) for the full reasoning.
+A few text columns deliberately stay as JSON-in-TEXT rather than being normalised: `learners.languages`, `learners.high_engagement_topics`, `learner_concepts.notes`. Those are open-vocabulary, free-text lists owned by the learner; they're not FK targets, not queried by exact match, not shared across rows, and not bounded. Normalising them would buy nothing the `concepts` table doesn't already prove. See the long comment above `CREATE_LEARNERS_TABLE` in [schema.rs](../../src/crates/primer-storage/src/schema.rs) for the full reasoning.
 
 > **Gotcha:** Drift in lookup tables is a hard error — `validate_and_seed_lookup` refuses to open a DB whose lookup-table state disagrees with the Rust enum. There is no API for mutating lookup tables. Adding a variant means recompile + reopen.
 
 ## The append-only invariant on save_session
 
-`save_session` is called after every turn, repeatedly, on the same session as it grows. To stay idempotent and cheap it does one specific thing on the `turns` table: it inserts only the turns that aren't already on disk (see the `.skip(persisted_count)` loop in [session_save.rs](src/crates/primer-storage/src/store/session_save.rs)). Turns already persisted are skipped without comparison.
+`save_session` is called after every turn, repeatedly, on the same session as it grows. To stay idempotent and cheap it does one specific thing on the `turns` table: it inserts only the turns that aren't already on disk (see the `.skip(persisted_count)` loop in [session_save.rs](../../src/crates/primer-storage/src/store/session_save.rs)). Turns already persisted are skipped without comparison.
 
 This is correct for the in-memory `Session` type, which is itself append-only — turns get added at the tail, never modified in place. But it has one consequence the dialogue manager has to work around: any data the post-response background tasks (the concept extractor, the comprehension classifier, the embedder) want to attach to a turn after `save_session` has already run cannot be attached through `save_session`. The skip rule would silently drop their writes.
 
-The fix is explicit backfill methods: [update_turn_concepts](src/crates/primer-core/src/storage.rs) and [update_exchange_concepts](src/crates/primer-core/src/storage.rs) for concept tags, [save_comprehensions](src/crates/primer-core/src/storage.rs) for per-concept depth assessments, [save_turn_embedding](src/crates/primer-core/src/storage.rs) for vectors. Each one resolves `(session_id, turn_index)` to a row id, does an `INSERT OR IGNORE` (or upsert, for embeddings) into the appropriate junction table, and returns. Calling them twice with the same data is a no-op.
+The fix is explicit backfill methods: [update_turn_concepts](../../src/crates/primer-core/src/storage.rs) and [update_exchange_concepts](../../src/crates/primer-core/src/storage.rs) for concept tags, [save_comprehensions](../../src/crates/primer-core/src/storage.rs) for per-concept depth assessments, [save_turn_embedding](../../src/crates/primer-core/src/storage.rs) for vectors. Each one resolves `(session_id, turn_index)` to a row id, does an `INSERT OR IGNORE` (or upsert, for embeddings) into the appropriate junction table, and returns. Calling them twice with the same data is a no-op.
 
 If you find yourself wanting to move concept persistence back into `save_session` because "it would be simpler" — don't. Doing so requires changing the skip rule, which breaks the append-only invariant, which then makes `save_session` non-idempotent on the turns table. The current shape is load-bearing.
 
 ## FTS5 query sanitisation
 
-`retrieve_session_turns` takes raw child input as its `query`. To pass that to FTS5's `MATCH` operator without letting punctuation, quotes, or reserved keywords crash the query parser, the storage layer runs everything through [sanitize_fts_phrase](src/crates/primer-storage/src/store/fts.rs) first.
+`retrieve_session_turns` takes raw child input as its `query`. To pass that to FTS5's `MATCH` operator without letting punctuation, quotes, or reserved keywords crash the query parser, the storage layer runs everything through [sanitize_fts_phrase](../../src/crates/primer-storage/src/store/fts.rs) first.
 
 The transformation is simple: split on whitespace, strip every non-alphanumeric character per token (kills `*`, `^`, `:`, `"`, `(`, `)`, slashes, etc.), drop the FTS5 reserved keywords `AND` / `OR` / `NOT` / `NEAR` (case-insensitive), wrap each surviving token in double quotes (so any character the tokenizer would otherwise see as special is inert), and OR-join the lot. An empty result short-circuits the query — FTS5 rejects `MATCH ''`, so the caller skips the search and returns an empty result.
 
-OR-joining (rather than implicit-AND) is a deliberate choice. If sanitization introduces noise tokens — say, a stripped contraction leaving a stray fragment — implicit-AND would torpedo the entire query. With OR, BM25 ranking + the caller's `LIMIT k` keep the result list focused on the most relevant matches and the noise tokens just don't contribute. The unit tests at the bottom of [fts.rs](src/crates/primer-storage/src/store/fts.rs) pin the behaviour for empty input, single token, multiple tokens, reserved keywords, FTS5-active punctuation, Unicode alphanumerics, and punctuation-only input.
+OR-joining (rather than implicit-AND) is a deliberate choice. If sanitization introduces noise tokens — say, a stripped contraction leaving a stray fragment — implicit-AND would torpedo the entire query. With OR, BM25 ranking + the caller's `LIMIT k` keep the result list focused on the most relevant matches and the noise tokens just don't contribute. The unit tests at the bottom of [fts.rs](../../src/crates/primer-storage/src/store/fts.rs) pin the behaviour for empty input, single token, multiple tokens, reserved keywords, FTS5-active punctuation, Unicode alphanumerics, and punctuation-only input.
 
 ## Long-term memory
 
@@ -153,7 +153,7 @@ There's one subtlety worth knowing. The just-saved turn may not have a vector ye
 
 ## Schema versions, in order
 
-Single source of truth for what each migration does is [schema.rs](src/crates/primer-storage/src/schema.rs). At a glance:
+Single source of truth for what each migration does is [schema.rs](../../src/crates/primer-storage/src/schema.rs). At a glance:
 
 | v | What it added |
 |---|---|
@@ -165,7 +165,7 @@ Single source of truth for what each migration does is [schema.rs](src/crates/pr
 | 7 | `learner_concepts.box_level` (Leitner-box scheduler, default `0`) |
 | 8 | `embedding_models` registry + `embeddings_turns` (per-turn f32 BLOB vectors for hybrid long-term memory) |
 
-If you find a discrepancy between this table and the `apply_vN_migrations` doc-comments in [schema.rs](src/crates/primer-storage/src/schema.rs), trust the source — that's the file the open path actually runs.
+If you find a discrepancy between this table and the `apply_vN_migrations` doc-comments in [schema.rs](../../src/crates/primer-storage/src/schema.rs), trust the source — that's the file the open path actually runs.
 
 ---
 
@@ -173,7 +173,7 @@ If you find a discrepancy between this table and the `apply_vN_migrations` doc-c
 
 You want to add a hypothetical "vibe" column to `turns` plus a `vibes` lookup table. The end-to-end change is six steps.
 
-**1. Bump `USER_VERSION` in [schema.rs](src/crates/primer-storage/src/schema.rs).** From `8` to `9`. While you're there, add a paragraph to the doc-comment on `USER_VERSION` describing what v9 adds — the comment block above the constant is the change-log readers turn to first.
+**1. Bump `USER_VERSION` in [schema.rs](../../src/crates/primer-storage/src/schema.rs).** From `8` to `9`. While you're there, add a paragraph to the doc-comment on `USER_VERSION` describing what v9 adds — the comment block above the constant is the change-log readers turn to first.
 
 **2. Add `apply_v9_migrations` following the `apply_v8_migrations` template.** Same shape: open `conn.unchecked_transaction()`, gate any `ALTER TABLE` on `column_exists`, use `CREATE TABLE IF NOT EXISTS` for new tables, commit, return.
 
@@ -207,12 +207,12 @@ pub(crate) fn apply_v9_migrations(conn: &Connection) -> Result<()> {
 }
 ```
 
-**3. Wire it into the open path.** In [store/mod.rs](src/crates/primer-storage/src/store/mod.rs), call `apply_v9_migrations(&conn)?` after the `apply_v8_migrations` line and before the `validate_and_seed_lookup` block. Order matters — validate-and-seed should see the post-migration schema.
+**3. Wire it into the open path.** In [store/mod.rs](../../src/crates/primer-storage/src/store/mod.rs), call `apply_v9_migrations(&conn)?` after the `apply_v8_migrations` line and before the `validate_and_seed_lookup` block. Order matters — validate-and-seed should see the post-migration schema.
 
-**4. Add a migration round-trip test.** Following the pattern in `v4_tests` at the bottom of [schema.rs](src/crates/primer-storage/src/schema.rs), add a test that builds a fresh v8 connection, asserts the new schema isn't there yet, runs `apply_v9_migrations`, and asserts the new column / table is present. Add an idempotency test (run the migration twice, assert no error and no duplicate rows). If you want full coverage, also add a fault-injection rollback test in the style of `apply_v4_migrations_rolls_back_on_failure`.
+**4. Add a migration round-trip test.** Following the pattern in `v4_tests` at the bottom of [schema.rs](../../src/crates/primer-storage/src/schema.rs), add a test that builds a fresh v8 connection, asserts the new schema isn't there yet, runs `apply_v9_migrations`, and asserts the new column / table is present. Add an idempotency test (run the migration twice, assert no error and no duplicate rows). If you want full coverage, also add a fault-injection rollback test in the style of `apply_v4_migrations_rolls_back_on_failure`.
 
-**5. If the migration touches an enum-backed lookup table**, extend [catalog.rs](src/crates/primer-storage/src/catalog.rs) with the new `expected_<table>()` function, add a `validate_and_seed_lookup` call in [store/mod.rs](src/crates/primer-storage/src/store/mod.rs) right after the existing four, and write a `expected_<table>_covers_all_variants` test that pins the projection against the Rust enum (the existing `expected_engagement_states_covers_all_variants` and `expected_understanding_depths_covers_all_variants` tests are the pattern). The "vibes" example above is open-vocabulary so this step doesn't apply, but if `Vibe` were a closed Rust enum it would.
+**5. If the migration touches an enum-backed lookup table**, extend [catalog.rs](../../src/crates/primer-storage/src/catalog.rs) with the new `expected_<table>()` function, add a `validate_and_seed_lookup` call in [store/mod.rs](../../src/crates/primer-storage/src/store/mod.rs) right after the existing four, and write a `expected_<table>_covers_all_variants` test that pins the projection against the Rust enum (the existing `expected_engagement_states_covers_all_variants` and `expected_understanding_depths_covers_all_variants` tests are the pattern). The "vibes" example above is open-vocabulary so this step doesn't apply, but if `Vibe` were a closed Rust enum it would.
 
-**6. Update [CLAUDE.md](CLAUDE.md).** There's a "Schema is at user_version 8." sentence in the `primer-storage` paragraph; bump it to 9 and add the new migration to the v2..v8 chain summary. The same paragraph notes that "the existing v2..v7 chain is the template" — extend that to v2..v8 (or whatever the current top is).
+**6. Update [CLAUDE.md](../../CLAUDE.md).** There's a "Schema is at user_version 8." sentence in the `primer-storage` paragraph; bump it to 9 and add the new migration to the v2..v8 chain summary. The same paragraph notes that "the existing v2..v7 chain is the template" — extend that to v2..v8 (or whatever the current top is).
 
 After all six steps, `cargo test -p primer-storage` should pass on a fresh DB and on every fixture from earlier versions. If any test breaks because it hardcoded an older `USER_VERSION` constant, that's the test telling you the version bump landed correctly — fix the hardcode to use `USER_VERSION` directly.

--- a/docs/devel/05-storage-and-sessions.md
+++ b/docs/devel/05-storage-and-sessions.md
@@ -1,0 +1,218 @@
+# Storage and sessions
+
+This chapter is about how the Primer remembers conversations. It covers the [SessionStore](src/crates/primer-core/src/storage.rs) and [LearnerStore](src/crates/primer-core/src/storage.rs) traits, the [SqliteSessionStore](src/crates/primer-storage/src/store/mod.rs) implementation, the schema-migration discipline that lets old DBs upgrade in place without ever running a destructive migration, the lookup-table normalisation rule that keeps every categorical text column in sync with its Rust enum, the append-only `save_session` invariant and the explicit backfill paths that work around it, the FTS5 sanitisation layer that lets raw child input drive search safely, and the long-term-memory + turn-embedding-on-save pipelines that surface relevant older turns into future system prompts. One recipe at the end walks through adding a new schema version end-to-end.
+
+If you read chapter 3 you already saw the dialogue manager hand finished turns to a `SessionStore`; this chapter is what happens once it does.
+
+## Privacy split
+
+Each child gets their own session database, kept entirely separate from the RAG corpus that lives in the knowledge base. By default the CLI puts it at `~/.primer/<slug>.db`, where `<slug>` is the NFC-normalised, Unicode-aware slug of the learner's name (so `José` and the decomposed `José` map to the same file). The directory is created on first run; an unwritable home is a hard error rather than a silent in-memory fallback.
+
+The split exists because the two stores hold fundamentally different data. The session DB holds **conversational PII**: every turn the child has spoken, the rolling LLM summary, per-turn engagement and comprehension classifications, the longitudinal concept-mastery record, and (since v8) per-turn embeddings of the child's words. The knowledge base, by contrast, holds **public-domain reference text**: hand-drafted CC0 passages and CC-BY-SA Wikipedia leads. Mixing them — even "just for prototyping" — would cross a line the project has chosen not to cross.
+
+> **Why:** Per-child session DBs are separate from the RAG corpus because they contain conversational PII; never merge them, and never mirror the session DB into a shared corpus.
+
+## SessionStore and LearnerStore traits
+
+Two traits split the persistence surface, both defined in [storage.rs](src/crates/primer-core/src/storage.rs):
+
+```rust
+// src/crates/primer-core/src/storage.rs
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    async fn save_session(&self, session: &Session) -> Result<()>;
+    async fn load_session(&self, id: Uuid) -> Result<Option<Session>>;
+
+    async fn retrieve_session_turns(
+        &self,
+        session_id: Uuid,
+        query: &str,
+        k: usize,
+        exclude_indices_at_or_after: usize,
+    ) -> Result<Vec<Turn>>;
+
+    async fn save_classification(/* … */) -> Result<()>;
+    async fn load_recent_assessments(/* … */) -> Result<Vec<EngagementAssessment>>;
+    async fn most_recent_session_learner_id(&self) -> Result<Option<Uuid>>;
+
+    async fn update_turn_concepts(
+        &self,
+        session_id: SessionId,
+        turn_index: usize,
+        concepts: &[String],
+    ) -> Result<()>;
+    async fn update_exchange_concepts(/* … */) -> Result<()>;
+    async fn save_comprehensions(/* … */) -> Result<()>;
+
+    async fn save_turn_embedding(/* … */) -> Result<()> { Ok(()) }
+
+    async fn retrieve_session_turns_hybrid(/* … */) -> Result<Vec<Turn>> {
+        // default: BM25-only fallback
+    }
+}
+
+#[async_trait]
+pub trait LearnerStore: Send + Sync {
+    async fn load_learner(&self) -> Result<Option<LearnerModel>>;
+    async fn save_learner(&self, learner: &LearnerModel) -> Result<()>;
+}
+```
+
+Both are implemented by [SqliteSessionStore](src/crates/primer-storage/src/store/mod.rs) — one type, two trait impls. The split is for testability and for the long-term shape: a future contributor who wants an alternative learner store (think a profile-only export tool) does not have to reimplement the much-larger session API. `SessionStore::save_turn_embedding` and `SessionStore::retrieve_session_turns_hybrid` carry default impls so that backends without vector support stay valid — the dialogue manager calls those methods unconditionally.
+
+The `Result<Option<…>>` shape on `load_session`, `load_learner`, and `most_recent_session_learner_id` is deliberate. "Not found" is not an error — it's a normal first-run signal. Reserving `Err` for genuine I/O failures keeps the CLI free of "is this an expected miss or a real problem?" conditionals.
+
+## Schema-migration pattern
+
+[primer-storage](src/crates/primer-storage/src/schema.rs) follows one shape across every migration. Read [schema.rs](src/crates/primer-storage/src/schema.rs) and you will see `apply_v2_migrations`, `apply_v3_migrations`, … `apply_v8_migrations` — eight migrations layered additively, each idempotent, each transaction-wrapped, each safe to run on a fresh DB or on any older DB being upgraded. The constant `USER_VERSION` lives at the top of that file (currently `8`). Open path lives in [store/mod.rs](src/crates/primer-storage/src/store/mod.rs) and runs every migration in order on every open.
+
+The pattern, distilled from `apply_v8_migrations`:
+
+```rust
+// src/crates/primer-storage/src/schema.rs
+pub(crate) fn apply_v8_migrations(conn: &Connection) -> Result<()> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| PrimerError::Storage(format!("v8 migration: failed to begin tx: {e}")))?;
+
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS embedding_models(
+            id   INTEGER PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            dim  INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS embeddings_turns(
+            turn_id   INTEGER PRIMARY KEY REFERENCES turns(id) ON DELETE CASCADE,
+            model_id  INTEGER NOT NULL REFERENCES embedding_models(id),
+            vec       BLOB NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_embeddings_turns_model
+            ON embeddings_turns(model_id);",
+    )
+    .map_err(|e| PrimerError::Storage(format!("v8 migration: create tables: {e}")))?;
+
+    tx.commit()
+        .map_err(|e| PrimerError::Storage(format!("v8 migration: commit: {e}")))?;
+    Ok(())
+}
+```
+
+Three things are doing all the work here. First, `conn.unchecked_transaction()` wraps the whole body so a partial failure (disk full halfway through, FK violation in step three) rolls back to the pre-migration state — no half-applied schema that subsequent saves would silently miswrite to. Second, every DDL is `CREATE … IF NOT EXISTS`, which makes the migration safe to re-run on an already-upgraded DB. Third, when a column add is needed instead of a new table, the helper `column_exists(&tx, "table", "column")` (also in [schema.rs](src/crates/primer-storage/src/schema.rs)) gates the `ALTER TABLE` so it runs once and only once. See `apply_v6_migrations` and `apply_v7_migrations` for the column-add shape.
+
+After the migrations run, the open path also calls [validate_and_seed_lookup](src/crates/primer-storage/src/schema.rs) for every lookup table backed by a Rust enum — `speakers`, `pedagogical_intents`, `engagement_states`, `understanding_depths`. That helper compares what's on disk against the canonical `(id, name)` pairs from [catalog.rs](src/crates/primer-storage/src/catalog.rs) (which the Rust enums project into), inserts any missing rows, and **returns a hard error** if a known id has the wrong name or if the table has an id the build doesn't know about.
+
+> **Gotcha:** A schema `USER_VERSION` newer than this build is a hard error rejected at open. Older is silently upgraded. The reasoning: a newer-than-this-build DB might have rows the current code can't safely read, but an older DB is exactly what migrations are designed to bring forward.
+
+## Lookup-table normalisation
+
+Every categorical text column in this codebase is stored as an integer foreign key into a lookup table — never as inline text. That applies to `speakers`, `pedagogical_intents`, `engagement_states`, `understanding_depths`, `concepts`, `classifiers`, `comprehension_classifiers`, and the per-table `embedding_models` registries.
+
+For columns backed by a **closed** Rust enum (`Speaker`, `PedagogicalIntent`, `EngagementState`, `UnderstandingDepth`), the Rust source is the single source of truth. The DB lookup table is a derived projection — [catalog.rs](src/crates/primer-storage/src/catalog.rs) exposes `expected_speakers()`, `expected_intents()`, `expected_engagement_states()`, `expected_understanding_depths()`, all of which return `Vec<(i64, &'static str)>`. The open path runs `validate_and_seed_lookup` against each of those slices on every open. There is **no API for mutating lookup tables**. Adding a new enum variant means: edit the Rust enum, recompile, next open seeds the new row. Retired integer ids are never reused — once an id has had a meaning, that meaning is canonical.
+
+For columns backed by an **open** vocabulary (`concepts`, `classifiers`, `comprehension_classifiers`), the row is created lazily on first reference. `update_turn_concepts` and friends use `INSERT OR IGNORE` patterns so that two parallel tasks racing to insert the same concept name end up with one row.
+
+A few text columns deliberately stay as JSON-in-TEXT rather than being normalised: `learners.languages`, `learners.high_engagement_topics`, `learner_concepts.notes`. Those are open-vocabulary, free-text lists owned by the learner; they're not FK targets, not queried by exact match, not shared across rows, and not bounded. Normalising them would buy nothing the `concepts` table doesn't already prove. See the long comment above `CREATE_LEARNERS_TABLE` in [schema.rs](src/crates/primer-storage/src/schema.rs) for the full reasoning.
+
+> **Gotcha:** Drift in lookup tables is a hard error — `validate_and_seed_lookup` refuses to open a DB whose lookup-table state disagrees with the Rust enum. There is no API for mutating lookup tables. Adding a variant means recompile + reopen.
+
+## The append-only invariant on save_session
+
+`save_session` is called after every turn, repeatedly, on the same session as it grows. To stay idempotent and cheap it does one specific thing on the `turns` table: it inserts only the turns that aren't already on disk (see the `.skip(persisted_count)` loop in [session_save.rs](src/crates/primer-storage/src/store/session_save.rs)). Turns already persisted are skipped without comparison.
+
+This is correct for the in-memory `Session` type, which is itself append-only — turns get added at the tail, never modified in place. But it has one consequence the dialogue manager has to work around: any data the post-response background tasks (the concept extractor, the comprehension classifier, the embedder) want to attach to a turn after `save_session` has already run cannot be attached through `save_session`. The skip rule would silently drop their writes.
+
+The fix is explicit backfill methods: [update_turn_concepts](src/crates/primer-core/src/storage.rs) and [update_exchange_concepts](src/crates/primer-core/src/storage.rs) for concept tags, [save_comprehensions](src/crates/primer-core/src/storage.rs) for per-concept depth assessments, [save_turn_embedding](src/crates/primer-core/src/storage.rs) for vectors. Each one resolves `(session_id, turn_index)` to a row id, does an `INSERT OR IGNORE` (or upsert, for embeddings) into the appropriate junction table, and returns. Calling them twice with the same data is a no-op.
+
+If you find yourself wanting to move concept persistence back into `save_session` because "it would be simpler" — don't. Doing so requires changing the skip rule, which breaks the append-only invariant, which then makes `save_session` non-idempotent on the turns table. The current shape is load-bearing.
+
+## FTS5 query sanitisation
+
+`retrieve_session_turns` takes raw child input as its `query`. To pass that to FTS5's `MATCH` operator without letting punctuation, quotes, or reserved keywords crash the query parser, the storage layer runs everything through [sanitize_fts_phrase](src/crates/primer-storage/src/store/fts.rs) first.
+
+The transformation is simple: split on whitespace, strip every non-alphanumeric character per token (kills `*`, `^`, `:`, `"`, `(`, `)`, slashes, etc.), drop the FTS5 reserved keywords `AND` / `OR` / `NOT` / `NEAR` (case-insensitive), wrap each surviving token in double quotes (so any character the tokenizer would otherwise see as special is inert), and OR-join the lot. An empty result short-circuits the query — FTS5 rejects `MATCH ''`, so the caller skips the search and returns an empty result.
+
+OR-joining (rather than implicit-AND) is a deliberate choice. If sanitization introduces noise tokens — say, a stripped contraction leaving a stray fragment — implicit-AND would torpedo the entire query. With OR, BM25 ranking + the caller's `LIMIT k` keep the result list focused on the most relevant matches and the noise tokens just don't contribute. The unit tests at the bottom of [fts.rs](src/crates/primer-storage/src/store/fts.rs) pin the behaviour for empty input, single token, multiple tokens, reserved keywords, FTS5-active punctuation, Unicode alphanumerics, and punctuation-only input.
+
+## Long-term memory
+
+Long-term memory is a **system-prompt concern**, not a chat-message concern. The `messages` array passed to inference is exactly `session.recent_turns(context_window_turns)` — a linear, recent-turns-only slice. Anything older lands in the system prompt as two distinct sections: the rolling LLM summary, and a small set of FTS-retrieved older turns relevant to the current child question.
+
+The summary lives on the `sessions` row (`sessions.summary`, `sessions.summary_through_turn_index`) — both columns added in v2. The dialogue manager refreshes it on a K-threshold (re-summarize when `context_window_turns` new pre-window turns have accumulated, default K=20) so per-turn dialogue doesn't trigger an LLM call every time the boundary advances. On `--resume`, a separate "is the summary stale?" check fires and re-summarises only if uncovered pre-window content exists.
+
+The retrieved-older-turns slice comes from `retrieve_session_turns` (or its hybrid variant). The dialogue manager passes the current child input as `query`, the BM25/RRF result is filtered to exclude the in-window tail (the `exclude_indices_at_or_after` parameter), and up to `k` turns are injected into the system prompt as a "you may have said this before" section.
+
+Two design wins fall out of this split. The chat timeline the model sees stays linear — no jumbled-order surprises from interleaving retrieved snippets with current dialogue. And the context budget stays bounded across hours of conversation: regardless of session length, the prompt is at most `summary + retrieved_older + recent_window` tokens, all of which have fixed caps.
+
+## Turn-embedding-on-save
+
+Hybrid retrieval over session turns (the dense leg of `retrieve_session_turns_hybrid`) needs every old turn to have an embedding. The dialogue manager handles that with a `tokio::spawn` fire-and-forget task that runs after `save_session` returns, embedding the most-recent (child, primer) turns and calling `SessionStore::save_turn_embedding` for each.
+
+The storage layer makes this safe to do without coordination. `save_turn_embedding` is idempotent at the row level — `embeddings_turns` has `turn_id` as its `PRIMARY KEY`, so a second call for the same turn overwrites the existing vector. Re-spawning over already-embedded turns, or spawning a backfill while a fresh save is running, both end at the same correct state. The `embedding_models` registry validates `(name, dim)` on every write — a mismatched dim under an existing model name is a hard error, which is exactly the bug class we want loud rather than silent.
+
+There's one subtlety worth knowing. The just-saved turn may not have a vector yet at the next call to `retrieve_session_turns_hybrid`, because the embed task is fire-and-forget and not awaited. That's fine: recent turns are inside the context window so the model sees them directly already; only **older** turns rely on retrieval, and by the time a turn is old enough to have aged out of the context window the embed task has long since completed. If the embed task ever fails outright (model load error, transient I/O), the dense leg silently has fewer candidates for that turn, the BM25 leg still works, and the next session opens with a backfill opportunity.
+
+## Schema versions, in order
+
+Single source of truth for what each migration does is [schema.rs](src/crates/primer-storage/src/schema.rs). At a glance:
+
+| v | What it added |
+|---|---|
+| 2 | `sessions.summary` + `sessions.summary_through_turn_index`; `turn_text_fts` FTS5 virtual table over `turns.text`, plus insert/delete/update triggers |
+| 3 | `engagement_states` lookup; `classifiers`; `turn_classifications` (per-turn `EngagementAssessment` rows) |
+| 4 | `understanding_depths` lookup; `learners`; `learner_concepts` (per-learner concept-mastery state) |
+| 5 | `comprehension_classifiers` lookup; `turn_comprehensions` (per `(turn, concept, classifier)` depth assessments) |
+| 6 | `learners.locale` (BCP-47 short pack id, default `'en'`) + `concepts.concept_language_tag` (default `'en'`) |
+| 7 | `learner_concepts.box_level` (Leitner-box scheduler, default `0`) |
+| 8 | `embedding_models` registry + `embeddings_turns` (per-turn f32 BLOB vectors for hybrid long-term memory) |
+
+If you find a discrepancy between this table and the `apply_vN_migrations` doc-comments in [schema.rs](src/crates/primer-storage/src/schema.rs), trust the source — that's the file the open path actually runs.
+
+---
+
+### Recipe — Add a schema migration
+
+You want to add a hypothetical "vibe" column to `turns` plus a `vibes` lookup table. The end-to-end change is six steps.
+
+**1. Bump `USER_VERSION` in [schema.rs](src/crates/primer-storage/src/schema.rs).** From `8` to `9`. While you're there, add a paragraph to the doc-comment on `USER_VERSION` describing what v9 adds — the comment block above the constant is the change-log readers turn to first.
+
+**2. Add `apply_v9_migrations` following the `apply_v8_migrations` template.** Same shape: open `conn.unchecked_transaction()`, gate any `ALTER TABLE` on `column_exists`, use `CREATE TABLE IF NOT EXISTS` for new tables, commit, return.
+
+```rust
+// src/crates/primer-storage/src/schema.rs
+pub(crate) fn apply_v9_migrations(conn: &Connection) -> Result<()> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| PrimerError::Storage(format!("v9 migration: failed to begin tx: {e}")))?;
+
+    if !column_exists(&tx, "turns", "vibe")? {
+        tx.execute_batch(
+            "ALTER TABLE turns ADD COLUMN vibe INTEGER NOT NULL DEFAULT 0;",
+        )
+        .map_err(|e| {
+            PrimerError::Storage(format!("v9 migration: ALTER turns ADD vibe: {e}"))
+        })?;
+    }
+
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS vibes (
+            id   INTEGER PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE
+        );",
+    )
+    .map_err(|e| PrimerError::Storage(format!("v9 migration: create vibes: {e}")))?;
+
+    tx.commit()
+        .map_err(|e| PrimerError::Storage(format!("v9 migration: commit: {e}")))?;
+    Ok(())
+}
+```
+
+**3. Wire it into the open path.** In [store/mod.rs](src/crates/primer-storage/src/store/mod.rs), call `apply_v9_migrations(&conn)?` after the `apply_v8_migrations` line and before the `validate_and_seed_lookup` block. Order matters — validate-and-seed should see the post-migration schema.
+
+**4. Add a migration round-trip test.** Following the pattern in `v4_tests` at the bottom of [schema.rs](src/crates/primer-storage/src/schema.rs), add a test that builds a fresh v8 connection, asserts the new schema isn't there yet, runs `apply_v9_migrations`, and asserts the new column / table is present. Add an idempotency test (run the migration twice, assert no error and no duplicate rows). If you want full coverage, also add a fault-injection rollback test in the style of `apply_v4_migrations_rolls_back_on_failure`.
+
+**5. If the migration touches an enum-backed lookup table**, extend [catalog.rs](src/crates/primer-storage/src/catalog.rs) with the new `expected_<table>()` function, add a `validate_and_seed_lookup` call in [store/mod.rs](src/crates/primer-storage/src/store/mod.rs) right after the existing four, and write a `expected_<table>_covers_all_variants` test that pins the projection against the Rust enum (the existing `expected_engagement_states_covers_all_variants` and `expected_understanding_depths_covers_all_variants` tests are the pattern). The "vibes" example above is open-vocabulary so this step doesn't apply, but if `Vibe` were a closed Rust enum it would.
+
+**6. Update [CLAUDE.md](CLAUDE.md).** There's a "Schema is at user_version 8." sentence in the `primer-storage` paragraph; bump it to 9 and add the new migration to the v2..v8 chain summary. The same paragraph notes that "the existing v2..v7 chain is the template" — extend that to v2..v8 (or whatever the current top is).
+
+After all six steps, `cargo test -p primer-storage` should pass on a fresh DB and on every fixture from earlier versions. If any test breaks because it hardcoded an older `USER_VERSION` constant, that's the test telling you the version bump landed correctly — fix the hardcode to use `USER_VERSION` directly.

--- a/docs/devel/06-classifiers-and-learner-model.md
+++ b/docs/devel/06-classifiers-and-learner-model.md
@@ -1,6 +1,6 @@
 # Classifiers and the learner model
 
-This chapter is about the three structured-output LLM tasks that run alongside the conversation — engagement, concept extraction, and per-concept comprehension — and the [LearnerModel](src/crates/primer-core/src/learner.rs) they update. They share a single shape: a small trait, an LLM-backed implementation that wraps `Arc<dyn InferenceBackend>`, and a stub for tests. They share a single execution pattern: spawn at the end of turn N, await with a bounded timeout at the start of turn N+1, detach on timeout. They share a single failure mode: never propagate. And they share a single source of truth for the data they produce: the [LearnerModel](src/crates/primer-core/src/learner.rs) umbrella struct, where the engagement-state snapshot, the concept-mastery record, and the spaced-repetition box levels all live together.
+This chapter is about the three structured-output LLM tasks that run alongside the conversation — engagement, concept extraction, and per-concept comprehension — and the [LearnerModel](../../src/crates/primer-core/src/learner.rs) they update. They share a single shape: a small trait, an LLM-backed implementation that wraps `Arc<dyn InferenceBackend>`, and a stub for tests. They share a single execution pattern: spawn at the end of turn N, await with a bounded timeout at the start of turn N+1, detach on timeout. They share a single failure mode: never propagate. And they share a single source of truth for the data they produce: the [LearnerModel](../../src/crates/primer-core/src/learner.rs) umbrella struct, where the engagement-state snapshot, the concept-mastery record, and the spaced-repetition box levels all live together.
 
 If you read chapter 3 you already saw the dialogue manager's turn loop spawn these tasks; this chapter is what they actually do.
 
@@ -10,13 +10,13 @@ Three crates, each with the same five files (`lib.rs`, `llm.rs`, `stub.rs`, `set
 
 | Crate | Trait | LLM impl | Stub | Output |
 |---|---|---|---|---|
-| [primer-classifier](src/crates/primer-classifier/src/lib.rs) | `EngagementClassifier` | `LlmEngagementClassifier` | `StubEngagementClassifier` | `EngagementAssessment` |
-| [primer-extractor](src/crates/primer-extractor/src/lib.rs) | `ConceptExtractor` | `LlmConceptExtractor` | `StubConceptExtractor` | `ConceptExtraction` |
-| [primer-comprehension](src/crates/primer-comprehension/src/lib.rs) | `ComprehensionClassifier` | `LlmComprehensionClassifier` | `StubComprehensionClassifier` | `ComprehensionResult` |
+| [primer-classifier](../../src/crates/primer-classifier/src/lib.rs) | `EngagementClassifier` | `LlmEngagementClassifier` | `StubEngagementClassifier` | `EngagementAssessment` |
+| [primer-extractor](../../src/crates/primer-extractor/src/lib.rs) | `ConceptExtractor` | `LlmConceptExtractor` | `StubConceptExtractor` | `ConceptExtraction` |
+| [primer-comprehension](../../src/crates/primer-comprehension/src/lib.rs) | `ComprehensionClassifier` | `LlmComprehensionClassifier` | `StubComprehensionClassifier` | `ComprehensionResult` |
 
 Each LLM impl wraps `Arc<dyn InferenceBackend>` rather than depending on `primer-inference` directly — that's what keeps these crates' build graphs free of the concrete backends, and what lets a memory-constrained device reuse the chat model while a bigger machine swaps in something cheaper. The wrapping is `Arc<dyn ...>` not `&dyn ...` because the dialogue manager spawns these calls into `tokio::spawn`, which requires the captured backend to be `'static`.
 
-Each stub provides two test-ergonomic constructors: `with_response(canned)` returns the same value forever, and `with_script(vec)` walks a queue and falls back to a default once exhausted. The pattern is consistent across the trio so test fixtures translate cleanly between them. See for example [stub.rs in primer-classifier](src/crates/primer-classifier/src/stub.rs) — the comprehension and extractor stubs follow the identical shape.
+Each stub provides two test-ergonomic constructors: `with_response(canned)` returns the same value forever, and `with_script(vec)` walks a queue and falls back to a default once exhausted. The pattern is consistent across the trio so test fixtures translate cleanly between them. See for example [stub.rs in primer-classifier](../../src/crates/primer-classifier/src/stub.rs) — the comprehension and extractor stubs follow the identical shape.
 
 Every LLM impl carries a stable string `identifier()` that gets persisted alongside its output. The classifier writes into `turn_classifications.classifier_id`, the comprehension classifier into `turn_comprehensions.classifier_id`. The identifier embeds the backend name and the model name, so re-classifying an old session DB with a different model later produces parallel rows rather than overwriting history. Don't mint identifiers ad hoc — the existing constructors generate them for you (`format!("llm:{}:{}", backend.name(), model)` in the extractor; `format!("llm:{model}")` in the classifier).
 
@@ -24,7 +24,7 @@ Every LLM impl carries a stable string `identifier()` that gets persisted alongs
 
 All three classifiers run on the same cadence. At the end of turn N — after the Primer's response has streamed and the session has been saved — the dialogue manager spawns two background tasks: the engagement classifier on its own, and the extractor → comprehension chain together. At the start of turn N+1, both are awaited concurrently via `tokio::join!` with a bounded timeout. On timeout the task is dropped from the await, but the underlying `tokio::spawn` future continues to run to completion in the background — its database persistence still lands.
 
-The classifier's timeout is `ClassifierSettings::blocking_timeout` (default 3000ms). The extractor → comprehension chain shares a combined budget of `ExtractorSettings::blocking_timeout + ComprehensionSettings::blocking_timeout` (default 5000 + 5000 = 10000ms). At the workspace defaults this caps the worst-case wallclock at `max(3000, 10000) = 10s` rather than the naive sum of 13s — see [background.rs](src/crates/primer-pedagogy/src/dialogue_manager/background.rs) for the `tokio::join!` site.
+The classifier's timeout is `ClassifierSettings::blocking_timeout` (default 3000ms). The extractor → comprehension chain shares a combined budget of `ExtractorSettings::blocking_timeout + ComprehensionSettings::blocking_timeout` (default 5000 + 5000 = 10000ms). At the workspace defaults this caps the worst-case wallclock at `max(3000, 10000) = 10s` rather than the naive sum of 13s — see [background.rs](../../src/crates/primer-pedagogy/src/dialogue_manager/background.rs) for the `tokio::join!` site.
 
 These numbers are deliberately generous. Smoke testing against small local models (gemma4:e4b, qwen3.5:4b) showed that a 1500ms extractor budget would have meant most chains never finished within the wait, so the in-memory state would lag two turns instead of one. The natural inter-turn pause for a child reading the previous response and thinking about a reply absorbs a 10-second budget without any UX impact — the timeout exists to catch a stuck backend, not to bound a healthy one.
 
@@ -34,7 +34,7 @@ These numbers are deliberately generous. Smoke testing against small local model
 
 The three classifiers are advisory — they sharpen the Primer's behaviour but they are not on the critical path of producing a response. A failed classification is recoverable; a propagated error that aborts a child's turn is not. So the rule across all three crates is absolute: **errors never propagate**.
 
-In practice this looks like the body of `LlmEngagementClassifier::classify` in [llm.rs](src/crates/primer-classifier/src/llm.rs):
+In practice this looks like the body of `LlmEngagementClassifier::classify` in [llm.rs](../../src/crates/primer-classifier/src/llm.rs):
 
 ```rust
 // src/crates/primer-classifier/src/llm.rs
@@ -55,7 +55,7 @@ A backend error becomes a `tracing::warn!` line plus an `Ok(EngagementAssessment
 
 ## The chain inside the dialogue manager
 
-The post-response work fans out into two independent branches: the classifier task on one side, and the extractor → comprehension chain on the other. The chain is a chain because comprehension needs the candidate concepts that extraction surfaced — there is no point asking "how deeply does the child understand X" when X hasn't been mentioned. The two branches join at the start of the next turn, where [`apply_post_response_outcome`](src/crates/primer-pedagogy/src/dialogue_manager/background.rs) applies extraction first (so any new concepts land in `learner.concepts` at depth `Aware`) and then comprehension (so [`apply_comprehension`](src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) can promote depths and advance Leitner-box levels for those concepts).
+The post-response work fans out into two independent branches: the classifier task on one side, and the extractor → comprehension chain on the other. The chain is a chain because comprehension needs the candidate concepts that extraction surfaced — there is no point asking "how deeply does the child understand X" when X hasn't been mentioned. The two branches join at the start of the next turn, where [`apply_post_response_outcome`](../../src/crates/primer-pedagogy/src/dialogue_manager/background.rs) applies extraction first (so any new concepts land in `learner.concepts` at depth `Aware`) and then comprehension (so [`apply_comprehension`](../../src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) can promote depths and advance Leitner-box levels for those concepts).
 
 DB persistence runs inside the spawned tasks themselves, not in the apply step. The extractor calls `SessionStore::update_exchange_concepts` from inside its `tokio::spawn`; the comprehension classifier calls `save_comprehensions` the same way. So the per-turn rows in `turn_concepts` and `turn_comprehensions` land as soon as the LLM returns — even if the dialogue manager has already moved on and the await fires on a stale future.
 
@@ -83,37 +83,37 @@ pub struct LearnerModel {
 
 When you extend the learner, edit the leaf type that owns the field, not the umbrella. Adding a new style preference goes in `LearningPreferences`. A new per-concept signal goes in `ConceptState`. The umbrella is just composition.
 
-The split between open-vocabulary and closed-enum data is deliberate. `LearningPreferences` serialises as JSON because children's interests don't fit a closed enum — "loves dragons" needs to coexist with "fascinated by tide pools" without a schema migration. `UnderstandingDepth`, by contrast, is a closed Rust enum (Unknown / Aware / Recall / Comprehension / Application / Analysis) backed by a normalised lookup table in [primer-storage](src/crates/primer-storage/src/store/mod.rs), because depth has a fixed semantic ladder and we want the classifier's output validated against it.
+The split between open-vocabulary and closed-enum data is deliberate. `LearningPreferences` serialises as JSON because children's interests don't fit a closed enum — "loves dragons" needs to coexist with "fascinated by tide pools" without a schema migration. `UnderstandingDepth`, by contrast, is a closed Rust enum (Unknown / Aware / Recall / Comprehension / Application / Analysis) backed by a normalised lookup table in [primer-storage](../../src/crates/primer-storage/src/store/mod.rs), because depth has a fixed semantic ladder and we want the classifier's output validated against it.
 
 > **Why:** `LearningPreferences` is JSON because children's interests don't fit a closed enum; `UnderstandingDepth` is a closed enum with a lookup table because depth has a fixed semantic ladder and we want compile-time enforcement of which values can appear in a row.
 
 ## apply_comprehension is monotonic-max
 
-`apply_comprehension` in [apply.rs](src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) is the function that turns one `ComprehensionResult` into in-memory updates to the learner. It is monotonic-max in two senses. First, depth never demotes: if the learner is recorded at `Comprehension` and a weak exchange comes in with `Aware`, the depth is left untouched. Second, the comparison is by enum order — the function only writes back when `assessment.depth > current.depth`. A weak read can never claw back ground the child has already covered.
+`apply_comprehension` in [apply.rs](../../src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) is the function that turns one `ComprehensionResult` into in-memory updates to the learner. It is monotonic-max in two senses. First, depth never demotes: if the learner is recorded at `Comprehension` and a weak exchange comes in with `Aware`, the depth is left untouched. Second, the comparison is by enum order — the function only writes back when `assessment.depth > current.depth`. A weak read can never claw back ground the child has already covered.
 
 Explicit forgetting is a deliberately-deferred concern. When it arrives it will be an algorithm running offline over the longitudinal `turn_comprehensions` record, not another in-line LLM call — the longitudinal record is already there waiting for it.
 
 Sub-threshold assessments (those with `confidence < ComprehensionSettings::confidence_threshold`, default 0.6) are NOT applied to in-memory state, but they ARE persisted to `turn_comprehensions` in full. The threshold gates the in-memory step only; the longitudinal record gets every assessment, with confidence scores intact, so an offline analyser can apply different filters later without re-running the LLM.
 
-The box-level transition runs on every accepted assessment, even when depth doesn't move. A confident re-confirmation at the same depth is the spaced-repetition mechanism for expanding intervals — without that, a concept stuck at `Comprehension` would never advance from box 1 to box 4 even after years of re-engagement. See the long comment in [apply.rs](src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) on `apply_comprehension` for why the inner confidence guard inside `apply_box_transition` is load-bearing despite looking redundant at the default settings.
+The box-level transition runs on every accepted assessment, even when depth doesn't move. A confident re-confirmation at the same depth is the spaced-repetition mechanism for expanding intervals — without that, a concept stuck at `Comprehension` would never advance from box 1 to box 4 even after years of re-engagement. See the long comment in [apply.rs](../../src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) on `apply_comprehension` for why the inner confidence guard inside `apply_box_transition` is load-bearing despite looking redundant at the default settings.
 
 ## Vocabulary spaced repetition
 
 There is no separate "vocabulary" subsystem. Vocabulary entries are `ConceptState` rows — the same rows that the comprehension classifier promotes — with their `box_level` field tracking the Leitner-box stage. Keeping the schema flat is a deliberate choice: the longitudinal record stays a single table, which preserves the future anonymisation and contribution path the roadmap calls out.
 
-The scheduler is three pure functions in [vocab.rs](src/crates/primer-core/src/vocab.rs):
+The scheduler is three pure functions in [vocab.rs](../../src/crates/primer-core/src/vocab.rs):
 
 - `apply_box_transition(current_box, depth, confidence) -> u8` decides the new box. Three zones: low confidence resets to box 0; `depth = Aware` resets to box 0 regardless of confidence; otherwise advance one box, capped at `MAX_BOX_LEVEL = 4`. Called from `apply_comprehension`.
 - `is_due(concept, now) -> bool` checks whether a concept's review interval has elapsed against the box-keyed table `[1d, 3d, 7d, 14d, 30d]`.
 - `due_concepts(learner, now, max_n) -> Vec<&ConceptState>` returns the top-N most-overdue concepts, sorted by overdue-amount descending with `concept_id` as a stable tiebreaker for reproducibility across resumes.
 
-All three take `now` as a parameter so tests drive them deterministically; production passes `chrono::Utc::now()`. The dialogue manager calls `due_concepts` once per turn in [`build_turn_prompt`](src/crates/primer-pedagogy/src/dialogue_manager/turn.rs), capped at `VocabSettings::max_per_prompt` (default 4, configurable via `--vocab-max-per-prompt`), and the prompt builder injects them as a passive review hint. The system prompt instructs the LLM to weave words in only if topically relevant — never drill, never quiz.
+All three take `now` as a parameter so tests drive them deterministically; production passes `chrono::Utc::now()`. The dialogue manager calls `due_concepts` once per turn in [`build_turn_prompt`](../../src/crates/primer-pedagogy/src/dialogue_manager/turn.rs), capped at `VocabSettings::max_per_prompt` (default 4, configurable via `--vocab-max-per-prompt`), and the prompt builder injects them as a passive review hint. The system prompt instructs the LLM to weave words in only if topically relevant — never drill, never quiz.
 
 Driving everything off the comprehension classifier means **no extra LLM call**. The same assessment that promotes `depth` also advances `box_level`. Spaced repetition is a side effect of the existing chain.
 
 ## Shared utilities
 
-Two helpers shared across all three crates live in [primer_core::llm_util](src/crates/primer-core/src/llm_util.rs):
+Two helpers shared across all three crates live in [primer_core::llm_util](../../src/crates/primer-core/src/llm_util.rs):
 
 - `extract_first_json_object(raw: &str) -> Option<&str>` walks the input bytes once, tracking string and escape state, and returns the first balanced JSON object — including outer braces, tolerating wrapper text before and after, and correctly ignoring braces inside string literals.
 - `truncate_to_chars(s: &str, max_chars: usize) -> &str` returns a prefix bounded by Unicode scalar values rather than bytes, so it never panics on a multi-byte boundary.
@@ -124,11 +124,11 @@ Both helpers used to live duplicated in each crate; they were pulled into `prime
 
 ### Recipe — Add a structured-output classifier
 
-Worked example: a hypothetical "tone classifier" that scores child turns on a `cheerful / neutral / anxious` ladder. The pattern below mirrors the engagement classifier; if you'd rather follow the per-concept shape, [primer-comprehension](src/crates/primer-comprehension/src/) is the closer template.
+Worked example: a hypothetical "tone classifier" that scores child turns on a `cheerful / neutral / anxious` ladder. The pattern below mirrors the engagement classifier; if you'd rather follow the per-concept shape, [primer-comprehension](../../src/crates/primer-comprehension/src/) is the closer template.
 
-**1. Define the trait in a new crate `primer-tone`** following the pattern at [primer-classifier/src/lib.rs](src/crates/primer-classifier/src/lib.rs). Declare the public types in `primer-core` (output struct + context struct), and expose the trait + a stable `identifier()` from the new crate. The output type is something like `ToneAssessment { tone: ToneState, confidence: f32, reasoning: Option<String> }` — with a `ToneAssessment::unknown_low_confidence(reason: String)` constructor for the soft-fail path.
+**1. Define the trait in a new crate `primer-tone`** following the pattern at [primer-classifier/src/lib.rs](../../src/crates/primer-classifier/src/lib.rs). Declare the public types in `primer-core` (output struct + context struct), and expose the trait + a stable `identifier()` from the new crate. The output type is something like `ToneAssessment { tone: ToneState, confidence: f32, reasoning: Option<String> }` — with a `ToneAssessment::unknown_low_confidence(reason: String)` constructor for the soft-fail path.
 
-**2. Implement `LlmToneClassifier`** wrapping `Arc<dyn InferenceBackend>`. Use [`extract_first_json_object`](src/crates/primer-core/src/llm_util.rs) from `primer_core::llm_util` to parse the model's response and [`truncate_to_chars`](src/crates/primer-core/src/llm_util.rs) to bound the input. Mirror the soft-fail idiom from [primer-classifier/src/llm.rs](src/crates/primer-classifier/src/llm.rs):
+**2. Implement `LlmToneClassifier`** wrapping `Arc<dyn InferenceBackend>`. Use [`extract_first_json_object`](../../src/crates/primer-core/src/llm_util.rs) from `primer_core::llm_util` to parse the model's response and [`truncate_to_chars`](../../src/crates/primer-core/src/llm_util.rs) to bound the input. Mirror the soft-fail idiom from [primer-classifier/src/llm.rs](../../src/crates/primer-classifier/src/llm.rs):
 
 ```rust
 // src/crates/primer-tone/src/llm.rs (sketch)
@@ -158,16 +158,16 @@ let assessment = match extract_first_json_object(truncated) {
 Ok(assessment)
 ```
 
-**3. Implement `StubToneClassifier`** with `with_response(ToneAssessment)` and `with_script(Vec<ToneAssessment>)` constructors. Used for tests; the script falls back to a default once exhausted. Pattern is verbatim from [primer-classifier/src/stub.rs](src/crates/primer-classifier/src/stub.rs).
+**3. Implement `StubToneClassifier`** with `with_response(ToneAssessment)` and `with_script(Vec<ToneAssessment>)` constructors. Used for tests; the script falls back to a default once exhausted. Pattern is verbatim from [primer-classifier/src/stub.rs](../../src/crates/primer-classifier/src/stub.rs).
 
-**4. Add `ToneSettings`** with every numeric (`blocking_timeout`, `recent_context_turns`, `max_output_chars`, `confidence_threshold`, `generation_max_tokens`, `generation_temperature`, `generation_top_p`) backed by constants in [primer-core/src/consts.rs](src/crates/primer-core/src/consts.rs) (or a per-crate `consts.rs` if scoped narrowly). Add a `defaults_match_consts` test mirroring the one in each existing settings file. Never inline a numeric.
+**4. Add `ToneSettings`** with every numeric (`blocking_timeout`, `recent_context_turns`, `max_output_chars`, `confidence_threshold`, `generation_max_tokens`, `generation_temperature`, `generation_top_p`) backed by constants in [primer-core/src/consts.rs](../../src/crates/primer-core/src/consts.rs) (or a per-crate `consts.rs` if scoped narrowly). Add a `defaults_match_consts` test mirroring the one in each existing settings file. Never inline a numeric.
 
 **5. Add a schema migration** if you need to persist (cross-link to chapter 5). For tone you'd add `turn_tones` UNIQUE on `(turn_id, classifier_id)`, plus a `tone_classifiers` registry, plus a `tones` lookup table seeded from the `ToneState` enum. Bump `USER_VERSION`, write `apply_v9_migrations`, wire it into the open path, add round-trip + idempotency tests. Chapter 5's recipe is the template.
 
-**6. Wire the spawn/await pattern** into the dialogue manager in [background.rs](src/crates/primer-pedagogy/src/dialogue_manager/background.rs) following the classifier model. Hold the classifier as `Arc<dyn ToneClassifier>` because `tokio::spawn` requires `'static`. Either add a third branch to `await_pending_background` or join it onto the existing classifier branch — depends on whether tone needs to influence intent (parallel branch) or just track longitudinally (fire-and-forget).
+**6. Wire the spawn/await pattern** into the dialogue manager in [background.rs](../../src/crates/primer-pedagogy/src/dialogue_manager/background.rs) following the classifier model. Hold the classifier as `Arc<dyn ToneClassifier>` because `tokio::spawn` requires `'static`. Either add a third branch to `await_pending_background` or join it onto the existing classifier branch — depends on whether tone needs to influence intent (parallel branch) or just track longitudinally (fire-and-forget).
 
-**7. Add CLI flags** following the `--classifier-*` template in [primer-cli/src/main.rs](src/crates/primer-cli/src/main.rs): `--tone-backend`, `--tone-model`, `--tone-timeout-ms`. Default to mirroring the main `--backend` / `--model` so the simple case requires zero new flags. Update the flags reference in [CLAUDE.md](CLAUDE.md).
+**7. Add CLI flags** following the `--classifier-*` template in [primer-cli/src/main.rs](../../src/crates/primer-cli/src/main.rs): `--tone-backend`, `--tone-model`, `--tone-timeout-ms`. Default to mirroring the main `--backend` / `--model` so the simple case requires zero new flags. Update the flags reference in [CLAUDE.md](../../CLAUDE.md).
 
-**8. Soft-fail tracing.** Confirm every error path inside `LlmToneClassifier` produces a `tracing::warn!(classifier = %self.identifier, ...)` line and returns `ToneAssessment::unknown_low_confidence(...)`. Never return `Result::Err` from the public API on the hot path. Follow the test pattern in [primer-classifier/src/llm.rs](src/crates/primer-classifier/src/llm.rs) — the `classify_returns_unknown_on_*` tests pin every error branch.
+**8. Soft-fail tracing.** Confirm every error path inside `LlmToneClassifier` produces a `tracing::warn!(classifier = %self.identifier, ...)` line and returns `ToneAssessment::unknown_low_confidence(...)`. Never return `Result::Err` from the public API on the hot path. Follow the test pattern in [primer-classifier/src/llm.rs](../../src/crates/primer-classifier/src/llm.rs) — the `classify_returns_unknown_on_*` tests pin every error branch.
 
-**9. Tests.** Stub-driven, following [test_support.rs](src/crates/primer-pedagogy/src/dialogue_manager/test_support.rs): feed a script of canned `ToneAssessment`s, drive a mock dialogue, assert the persistence row at the end of turn N and the in-memory `LearnerModel` state at the start of turn N+1. Add a timeout test that constructs a deliberately-slow stub and asserts that detach-on-timeout leaves prior state intact (no panic, no propagated error, log line emitted). Add a parser-failure test that returns malformed JSON and asserts the `unknown_low_confidence` fallback.
+**9. Tests.** Stub-driven, following [test_support.rs](../../src/crates/primer-pedagogy/src/dialogue_manager/test_support.rs): feed a script of canned `ToneAssessment`s, drive a mock dialogue, assert the persistence row at the end of turn N and the in-memory `LearnerModel` state at the start of turn N+1. Add a timeout test that constructs a deliberately-slow stub and asserts that detach-on-timeout leaves prior state intact (no panic, no propagated error, log line emitted). Add a parser-failure test that returns malformed JSON and asserts the `unknown_low_confidence` fallback.

--- a/docs/devel/06-classifiers-and-learner-model.md
+++ b/docs/devel/06-classifiers-and-learner-model.md
@@ -6,7 +6,7 @@ If you read chapter 3 you already saw the dialogue manager's turn loop spawn the
 
 ## The structured-output trio
 
-Three crates, each with the same four files (`lib.rs`, `llm.rs`, `stub.rs`, `settings.rs`) and the same export pattern:
+Three crates, each with the same five files (`lib.rs`, `llm.rs`, `stub.rs`, `settings.rs`, `consts.rs`) and the same export pattern:
 
 | Crate | Trait | LLM impl | Stub | Output |
 |---|---|---|---|---|
@@ -142,11 +142,19 @@ let raw = match self.backend.generate(&prompt, &params).await {
     }
 };
 let truncated = truncate_to_chars(&raw, self.settings.max_output_chars);
-let json = extract_first_json_object(truncated);
-let assessment = json
-    .and_then(|s| serde_json::from_str::<ToneOutput>(s).ok())
-    .map(Into::into)
-    .unwrap_or_else(|| ToneAssessment::unknown_low_confidence("parse error".into()));
+let assessment = match extract_first_json_object(truncated) {
+    Some(s) => match serde_json::from_str::<ToneOutput>(s) {
+        Ok(out) => out.into(),
+        Err(e) => {
+            tracing::warn!(target: "primer::tone", "parse error: {e}");
+            ToneAssessment::unknown_low_confidence(format!("parse error: {e}"))
+        }
+    },
+    None => {
+        tracing::warn!(target: "primer::tone", "no JSON object in LLM output");
+        ToneAssessment::unknown_low_confidence("no JSON object".into())
+    }
+};
 Ok(assessment)
 ```
 

--- a/docs/devel/06-classifiers-and-learner-model.md
+++ b/docs/devel/06-classifiers-and-learner-model.md
@@ -1,0 +1,165 @@
+# Classifiers and the learner model
+
+This chapter is about the three structured-output LLM tasks that run alongside the conversation — engagement, concept extraction, and per-concept comprehension — and the [LearnerModel](src/crates/primer-core/src/learner.rs) they update. They share a single shape: a small trait, an LLM-backed implementation that wraps `Arc<dyn InferenceBackend>`, and a stub for tests. They share a single execution pattern: spawn at the end of turn N, await with a bounded timeout at the start of turn N+1, detach on timeout. They share a single failure mode: never propagate. And they share a single source of truth for the data they produce: the [LearnerModel](src/crates/primer-core/src/learner.rs) umbrella struct, where the engagement-state snapshot, the concept-mastery record, and the spaced-repetition box levels all live together.
+
+If you read chapter 3 you already saw the dialogue manager's turn loop spawn these tasks; this chapter is what they actually do.
+
+## The structured-output trio
+
+Three crates, each with the same four files (`lib.rs`, `llm.rs`, `stub.rs`, `settings.rs`) and the same export pattern:
+
+| Crate | Trait | LLM impl | Stub | Output |
+|---|---|---|---|---|
+| [primer-classifier](src/crates/primer-classifier/src/lib.rs) | `EngagementClassifier` | `LlmEngagementClassifier` | `StubEngagementClassifier` | `EngagementAssessment` |
+| [primer-extractor](src/crates/primer-extractor/src/lib.rs) | `ConceptExtractor` | `LlmConceptExtractor` | `StubConceptExtractor` | `ConceptExtraction` |
+| [primer-comprehension](src/crates/primer-comprehension/src/lib.rs) | `ComprehensionClassifier` | `LlmComprehensionClassifier` | `StubComprehensionClassifier` | `ComprehensionResult` |
+
+Each LLM impl wraps `Arc<dyn InferenceBackend>` rather than depending on `primer-inference` directly — that's what keeps these crates' build graphs free of the concrete backends, and what lets a memory-constrained device reuse the chat model while a bigger machine swaps in something cheaper. The wrapping is `Arc<dyn ...>` not `&dyn ...` because the dialogue manager spawns these calls into `tokio::spawn`, which requires the captured backend to be `'static`.
+
+Each stub provides two test-ergonomic constructors: `with_response(canned)` returns the same value forever, and `with_script(vec)` walks a queue and falls back to a default once exhausted. The pattern is consistent across the trio so test fixtures translate cleanly between them. See for example [stub.rs in primer-classifier](src/crates/primer-classifier/src/stub.rs) — the comprehension and extractor stubs follow the identical shape.
+
+Every LLM impl carries a stable string `identifier()` that gets persisted alongside its output. The classifier writes into `turn_classifications.classifier_id`, the comprehension classifier into `turn_comprehensions.classifier_id`. The identifier embeds the backend name and the model name, so re-classifying an old session DB with a different model later produces parallel rows rather than overwriting history. Don't mint identifiers ad hoc — the existing constructors generate them for you (`format!("llm:{}:{}", backend.name(), model)` in the extractor; `format!("llm:{model}")` in the classifier).
+
+## The spawn / await / detach-on-timeout pattern
+
+All three classifiers run on the same cadence. At the end of turn N — after the Primer's response has streamed and the session has been saved — the dialogue manager spawns two background tasks: the engagement classifier on its own, and the extractor → comprehension chain together. At the start of turn N+1, both are awaited concurrently via `tokio::join!` with a bounded timeout. On timeout the task is dropped from the await, but the underlying `tokio::spawn` future continues to run to completion in the background — its database persistence still lands.
+
+The classifier's timeout is `ClassifierSettings::blocking_timeout` (default 3000ms). The extractor → comprehension chain shares a combined budget of `ExtractorSettings::blocking_timeout + ComprehensionSettings::blocking_timeout` (default 5000 + 5000 = 10000ms). At the workspace defaults this caps the worst-case wallclock at `max(3000, 10000) = 10s` rather than the naive sum of 13s — see [background.rs](src/crates/primer-pedagogy/src/dialogue_manager/background.rs) for the `tokio::join!` site.
+
+These numbers are deliberately generous. Smoke testing against small local models (gemma4:e4b, qwen3.5:4b) showed that a 1500ms extractor budget would have meant most chains never finished within the wait, so the in-memory state would lag two turns instead of one. The natural inter-turn pause for a child reading the previous response and thinking about a reply absorbs a 10-second budget without any UX impact — the timeout exists to catch a stuck backend, not to bound a healthy one.
+
+> **Why:** The classifier and chain awaits run with `tokio::join!` rather than sequential awaits because the two tasks write to disjoint fields of the learner. Joining them halves the worst-case wallclock and lets the next turn start sooner if either task finishes early.
+
+## Soft-fail discipline
+
+The three classifiers are advisory — they sharpen the Primer's behaviour but they are not on the critical path of producing a response. A failed classification is recoverable; a propagated error that aborts a child's turn is not. So the rule across all three crates is absolute: **errors never propagate**.
+
+In practice this looks like the body of `LlmEngagementClassifier::classify` in [llm.rs](src/crates/primer-classifier/src/llm.rs):
+
+```rust
+// src/crates/primer-classifier/src/llm.rs
+let raw = match self.backend.generate(&prompt, &params).await {
+    Ok(r) => r,
+    Err(e) => {
+        warn!(classifier = %self.identifier, error = ?e, "classifier backend call failed");
+        return Ok(EngagementAssessment::unknown_low_confidence(format!(
+            "backend error: {e}"
+        )));
+    }
+};
+```
+
+A backend error becomes a `tracing::warn!` line plus an `Ok(EngagementAssessment::unknown_low_confidence(...))`. Same shape in the extractor (`Ok(ConceptExtraction::empty())`) and the comprehension classifier (`Ok(ComprehensionResult::empty())`). Parser failures do the same. The function signature still says `Result<...>`, but the `Err` arm is structurally unreachable on the hot path — we keep it because the return type is shared with future non-LLM implementations that may legitimately want to surface a hard failure.
+
+> **Gotcha:** Classifier, extractor, and comprehension errors NEVER propagate. If you find yourself adding `?` on one of their results, you have a bug — log via `tracing::warn!` and return the empty/unknown result instead.
+
+## The chain inside the dialogue manager
+
+The post-response work fans out into two independent branches: the classifier task on one side, and the extractor → comprehension chain on the other. The chain is a chain because comprehension needs the candidate concepts that extraction surfaced — there is no point asking "how deeply does the child understand X" when X hasn't been mentioned. The two branches join at the start of the next turn, where [`apply_post_response_outcome`](src/crates/primer-pedagogy/src/dialogue_manager/background.rs) applies extraction first (so any new concepts land in `learner.concepts` at depth `Aware`) and then comprehension (so [`apply_comprehension`](src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) can promote depths and advance Leitner-box levels for those concepts).
+
+DB persistence runs inside the spawned tasks themselves, not in the apply step. The extractor calls `SessionStore::update_exchange_concepts` from inside its `tokio::spawn`; the comprehension classifier calls `save_comprehensions` the same way. So the per-turn rows in `turn_concepts` and `turn_comprehensions` land as soon as the LLM returns — even if the dialogue manager has already moved on and the await fires on a stale future.
+
+> **Gotcha:** Concepts and comprehension lag one turn for in-memory state but NOT for DB persistence. The system prompt for turn N does not include concepts surfaced in turn N — only those from earlier turns. Per-turn rows in `turn_concepts` and `turn_comprehensions` are written immediately by the spawned tasks; only the `LearnerModel.concepts` field updates at the start of the next turn.
+
+This is acceptable for v1. If it ever surprises a child ("I just told you about photosynthesis and you're acting like I didn't"), the fix is to apply extraction synchronously before the next prompt build — the storage path already works.
+
+## The LearnerModel umbrella
+
+`LearnerModel` is composition, not a leaf. It pulls four pieces together:
+
+```rust
+// src/crates/primer-core/src/learner.rs
+pub struct LearnerModel {
+    pub profile: LearnerProfile,
+    pub concepts: Vec<ConceptState>,
+    pub preferences: LearningPreferences,
+    pub current_engagement: EngagementState,
+    #[serde(default)]
+    pub recent_assessments: Vec<EngagementAssessment>,
+}
+```
+
+`LearnerProfile` carries identity (name, age, ISO 639-1 language list, bound `Locale`). `ConceptState` is one row per concept with its `depth: UnderstandingDepth`, `confidence`, `encounter_count`, `last_encountered`, free-form `notes`, and `box_level: u8` for the spaced-repetition scheduler. `LearningPreferences` is the open-vocabulary side — narrative-vs-Socratic-vs-visual-vs-kinesthetic preference scores plus a list of high-engagement topics — and `current_engagement` plus `recent_assessments` is the rolling output of the engagement classifier.
+
+When you extend the learner, edit the leaf type that owns the field, not the umbrella. Adding a new style preference goes in `LearningPreferences`. A new per-concept signal goes in `ConceptState`. The umbrella is just composition.
+
+The split between open-vocabulary and closed-enum data is deliberate. `LearningPreferences` serialises as JSON because children's interests don't fit a closed enum — "loves dragons" needs to coexist with "fascinated by tide pools" without a schema migration. `UnderstandingDepth`, by contrast, is a closed Rust enum (Unknown / Aware / Recall / Comprehension / Application / Analysis) backed by a normalised lookup table in [primer-storage](src/crates/primer-storage/src/store/mod.rs), because depth has a fixed semantic ladder and we want the classifier's output validated against it.
+
+> **Why:** `LearningPreferences` is JSON because children's interests don't fit a closed enum; `UnderstandingDepth` is a closed enum with a lookup table because depth has a fixed semantic ladder and we want compile-time enforcement of which values can appear in a row.
+
+## apply_comprehension is monotonic-max
+
+`apply_comprehension` in [apply.rs](src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) is the function that turns one `ComprehensionResult` into in-memory updates to the learner. It is monotonic-max in two senses. First, depth never demotes: if the learner is recorded at `Comprehension` and a weak exchange comes in with `Aware`, the depth is left untouched. Second, the comparison is by enum order — the function only writes back when `assessment.depth > current.depth`. A weak read can never claw back ground the child has already covered.
+
+Explicit forgetting is a deliberately-deferred concern. When it arrives it will be an algorithm running offline over the longitudinal `turn_comprehensions` record, not another in-line LLM call — the longitudinal record is already there waiting for it.
+
+Sub-threshold assessments (those with `confidence < ComprehensionSettings::confidence_threshold`, default 0.6) are NOT applied to in-memory state, but they ARE persisted to `turn_comprehensions` in full. The threshold gates the in-memory step only; the longitudinal record gets every assessment, with confidence scores intact, so an offline analyser can apply different filters later without re-running the LLM.
+
+The box-level transition runs on every accepted assessment, even when depth doesn't move. A confident re-confirmation at the same depth is the spaced-repetition mechanism for expanding intervals — without that, a concept stuck at `Comprehension` would never advance from box 1 to box 4 even after years of re-engagement. See the long comment in [apply.rs](src/crates/primer-pedagogy/src/dialogue_manager/apply.rs) on `apply_comprehension` for why the inner confidence guard inside `apply_box_transition` is load-bearing despite looking redundant at the default settings.
+
+## Vocabulary spaced repetition
+
+There is no separate "vocabulary" subsystem. Vocabulary entries are `ConceptState` rows — the same rows that the comprehension classifier promotes — with their `box_level` field tracking the Leitner-box stage. Keeping the schema flat is a deliberate choice: the longitudinal record stays a single table, which preserves the future anonymisation and contribution path the roadmap calls out.
+
+The scheduler is three pure functions in [vocab.rs](src/crates/primer-core/src/vocab.rs):
+
+- `apply_box_transition(current_box, depth, confidence) -> u8` decides the new box. Three zones: low confidence resets to box 0; `depth = Aware` resets to box 0 regardless of confidence; otherwise advance one box, capped at `MAX_BOX_LEVEL = 4`. Called from `apply_comprehension`.
+- `is_due(concept, now) -> bool` checks whether a concept's review interval has elapsed against the box-keyed table `[1d, 3d, 7d, 14d, 30d]`.
+- `due_concepts(learner, now, max_n) -> Vec<&ConceptState>` returns the top-N most-overdue concepts, sorted by overdue-amount descending with `concept_id` as a stable tiebreaker for reproducibility across resumes.
+
+All three take `now` as a parameter so tests drive them deterministically; production passes `chrono::Utc::now()`. The dialogue manager calls `due_concepts` once per turn in [`build_turn_prompt`](src/crates/primer-pedagogy/src/dialogue_manager/turn.rs), capped at `VocabSettings::max_per_prompt` (default 4, configurable via `--vocab-max-per-prompt`), and the prompt builder injects them as a passive review hint. The system prompt instructs the LLM to weave words in only if topically relevant — never drill, never quiz.
+
+Driving everything off the comprehension classifier means **no extra LLM call**. The same assessment that promotes `depth` also advances `box_level`. Spaced repetition is a side effect of the existing chain.
+
+## Shared utilities
+
+Two helpers shared across all three crates live in [primer_core::llm_util](src/crates/primer-core/src/llm_util.rs):
+
+- `extract_first_json_object(raw: &str) -> Option<&str>` walks the input bytes once, tracking string and escape state, and returns the first balanced JSON object — including outer braces, tolerating wrapper text before and after, and correctly ignoring braces inside string literals.
+- `truncate_to_chars(s: &str, max_chars: usize) -> &str` returns a prefix bounded by Unicode scalar values rather than bytes, so it never panics on a multi-byte boundary.
+
+Both helpers used to live duplicated in each crate; they were pulled into `primer-core` so a fix to either applies everywhere. Don't reintroduce per-crate copies — the duplication that motivated the move is exactly what the move solved.
+
+---
+
+### Recipe — Add a structured-output classifier
+
+Worked example: a hypothetical "tone classifier" that scores child turns on a `cheerful / neutral / anxious` ladder. The pattern below mirrors the engagement classifier; if you'd rather follow the per-concept shape, [primer-comprehension](src/crates/primer-comprehension/src/) is the closer template.
+
+**1. Define the trait in a new crate `primer-tone`** following the pattern at [primer-classifier/src/lib.rs](src/crates/primer-classifier/src/lib.rs). Declare the public types in `primer-core` (output struct + context struct), and expose the trait + a stable `identifier()` from the new crate. The output type is something like `ToneAssessment { tone: ToneState, confidence: f32, reasoning: Option<String> }` — with a `ToneAssessment::unknown_low_confidence(reason: String)` constructor for the soft-fail path.
+
+**2. Implement `LlmToneClassifier`** wrapping `Arc<dyn InferenceBackend>`. Use [`extract_first_json_object`](src/crates/primer-core/src/llm_util.rs) from `primer_core::llm_util` to parse the model's response and [`truncate_to_chars`](src/crates/primer-core/src/llm_util.rs) to bound the input. Mirror the soft-fail idiom from [primer-classifier/src/llm.rs](src/crates/primer-classifier/src/llm.rs):
+
+```rust
+// src/crates/primer-tone/src/llm.rs (sketch)
+let raw = match self.backend.generate(&prompt, &params).await {
+    Ok(r) => r,
+    Err(e) => {
+        warn!(classifier = %self.identifier, error = ?e, "tone backend call failed");
+        return Ok(ToneAssessment::unknown_low_confidence(format!(
+            "backend error: {e}"
+        )));
+    }
+};
+let truncated = truncate_to_chars(&raw, self.settings.max_output_chars);
+let json = extract_first_json_object(truncated);
+let assessment = json
+    .and_then(|s| serde_json::from_str::<ToneOutput>(s).ok())
+    .map(Into::into)
+    .unwrap_or_else(|| ToneAssessment::unknown_low_confidence("parse error".into()));
+Ok(assessment)
+```
+
+**3. Implement `StubToneClassifier`** with `with_response(ToneAssessment)` and `with_script(Vec<ToneAssessment>)` constructors. Used for tests; the script falls back to a default once exhausted. Pattern is verbatim from [primer-classifier/src/stub.rs](src/crates/primer-classifier/src/stub.rs).
+
+**4. Add `ToneSettings`** with every numeric (`blocking_timeout`, `recent_context_turns`, `max_output_chars`, `confidence_threshold`, `generation_max_tokens`, `generation_temperature`, `generation_top_p`) backed by constants in [primer-core/src/consts.rs](src/crates/primer-core/src/consts.rs) (or a per-crate `consts.rs` if scoped narrowly). Add a `defaults_match_consts` test mirroring the one in each existing settings file. Never inline a numeric.
+
+**5. Add a schema migration** if you need to persist (cross-link to chapter 5). For tone you'd add `turn_tones` UNIQUE on `(turn_id, classifier_id)`, plus a `tone_classifiers` registry, plus a `tones` lookup table seeded from the `ToneState` enum. Bump `USER_VERSION`, write `apply_v9_migrations`, wire it into the open path, add round-trip + idempotency tests. Chapter 5's recipe is the template.
+
+**6. Wire the spawn/await pattern** into the dialogue manager in [background.rs](src/crates/primer-pedagogy/src/dialogue_manager/background.rs) following the classifier model. Hold the classifier as `Arc<dyn ToneClassifier>` because `tokio::spawn` requires `'static`. Either add a third branch to `await_pending_background` or join it onto the existing classifier branch — depends on whether tone needs to influence intent (parallel branch) or just track longitudinally (fire-and-forget).
+
+**7. Add CLI flags** following the `--classifier-*` template in [primer-cli/src/main.rs](src/crates/primer-cli/src/main.rs): `--tone-backend`, `--tone-model`, `--tone-timeout-ms`. Default to mirroring the main `--backend` / `--model` so the simple case requires zero new flags. Update the flags reference in [CLAUDE.md](CLAUDE.md).
+
+**8. Soft-fail tracing.** Confirm every error path inside `LlmToneClassifier` produces a `tracing::warn!(classifier = %self.identifier, ...)` line and returns `ToneAssessment::unknown_low_confidence(...)`. Never return `Result::Err` from the public API on the hot path. Follow the test pattern in [primer-classifier/src/llm.rs](src/crates/primer-classifier/src/llm.rs) — the `classify_returns_unknown_on_*` tests pin every error branch.
+
+**9. Tests.** Stub-driven, following [test_support.rs](src/crates/primer-pedagogy/src/dialogue_manager/test_support.rs): feed a script of canned `ToneAssessment`s, drive a mock dialogue, assert the persistence row at the end of turn N and the in-memory `LearnerModel` state at the start of turn N+1. Add a timeout test that constructs a deliberately-slow stub and asserts that detach-on-timeout leaves prior state intact (no panic, no propagated error, log line emitted). Add a parser-failure test that returns malformed JSON and asserts the `unknown_low_confidence` fallback.

--- a/docs/devel/07-speech-and-voice-loop.md
+++ b/docs/devel/07-speech-and-voice-loop.md
@@ -1,0 +1,300 @@
+# Speech and the voice loop
+
+Voice mode is a working proof-of-concept today: a child speaks, Silero detects the end of the utterance, Whisper transcribes it, the dialogue manager produces a response token-stream, Piper synthesises it phrase-by-phrase, and cpal pushes the resulting audio out the speaker — all without leaving the local machine. The state machine that ties these stages together is `LISTEN → THINK → SPEAK → LISTEN`, with strict no-barge-in in either direction.
+
+The chapter is necessarily long because the voice loop is the densest invariant-laden subsystem in the codebase. The compute pieces (VAD, STT, TTS) are well-trodden problems, but the glue around them — when the mic is muted, when the audio thread drops samples, how a phrase tail makes it through a streaming resampler, what happens when a 2-line response runs into a 500 ms ringbuf — is where most of the bugs lived during Phase 0.3 development, and where the comments in [speech_loop.rs](../../src/crates/primer-cli/src/speech_loop.rs) carry hard-won detail. Read this chapter alongside that file when you touch voice code.
+
+This chapter also relies heavily on two vendored crates. That is not aesthetic; it is mechanical. Both are documented below.
+
+## The five speech traits and the Named base trait
+
+The five speech traits all live in [primer-core/src/speech.rs](../../src/crates/primer-core/src/speech.rs):
+
+| Trait | Purpose |
+|---|---|
+| [`VoiceActivityDetector`](../../src/crates/primer-core/src/speech.rs) | Audio frames in, per-chunk speech-state events out (`SpeechStart` / `SpeechEnd` / `None`). |
+| [`SpeechToText`](../../src/crates/primer-core/src/speech.rs) | One-shot: full audio buffer in, transcript out. |
+| [`StreamingSpeechToText`](../../src/crates/primer-core/src/speech.rs) | Open a [`TranscriptionSession`](../../src/crates/primer-core/src/speech.rs), push samples, drain segments. |
+| [`TextToSpeech`](../../src/crates/primer-core/src/speech.rs) | One-shot: text in, audio buffer out. |
+| [`StreamingTextToSpeech`](../../src/crates/primer-core/src/speech.rs) | Open a [`SynthesisSession`](../../src/crates/primer-core/src/speech.rs), push partial text, drain audio chunks per phrase. |
+
+Every one of those traits inherits from a single base trait, [`Named`](../../src/crates/primer-core/src/speech.rs):
+
+```rust
+// src/crates/primer-core/src/speech.rs
+pub trait Named {
+    fn name(&self) -> &str;
+}
+
+pub trait VoiceActivityDetector: Named + Send { /* ... */ }
+pub trait SpeechToText: Named + Send + Sync { /* ... */ }
+pub trait StreamingSpeechToText: Named + Send + Sync { /* ... */ }
+pub trait TextToSpeech: Named + Send + Sync { /* ... */ }
+pub trait StreamingTextToSpeech: Named + Send + Sync { /* ... */ }
+```
+
+The reason: a single backend struct often implements both the one-shot variant and the streaming variant of the same family — the Whisper backend is both `SpeechToText` and `StreamingSpeechToText`; Piper is both `TextToSpeech` and `StreamingTextToSpeech`. If `name()` were declared on both leaf traits, an implementor would have to write it twice, and every direct call site would have to disambiguate via UFCS (`<T as SpeechToText>::name(...)`). With `Named` as a super-trait, each backend writes `name()` once and every leaf gets it for free. The unit test [`named_super_trait_resolves_via_each_speech_trait`](../../src/crates/primer-core/src/speech.rs) is the canary that pins this invariant — adding a sixth speech trait should add a sixth assertion there.
+
+## Concrete backends and feature gates
+
+Stub backends always build. They live in [primer-speech/src/stub.rs](../../src/crates/primer-speech/src/stub.rs) and return canned silent buffers — they exist so the compile graph for the default workspace build stays light, and so unit tests can dispatch through trait objects without pulling in any real audio code.
+
+Real backends are gated behind cargo features in [primer-speech/Cargo.toml](../../src/crates/primer-speech/Cargo.toml):
+
+| Feature | Pulls in | Lives at |
+|---|---|---|
+| `silero` | [silero-vad-rust](../../src/vendor/silero-vad-rust/) (vendored) | [silero.rs](../../src/crates/primer-speech/src/silero.rs) |
+| `whisper` | `whisper-cpp-plus` | [whisper.rs](../../src/crates/primer-speech/src/whisper.rs) |
+| `piper` | [piper-rs](../../src/vendor/piper-rs/) (vendored) | [piper.rs](../../src/crates/primer-speech/src/piper.rs) |
+| `cpal` | `cpal` + `ringbuf` + `rubato` | [cpal_io.rs](../../src/crates/primer-speech/src/cpal_io.rs) |
+
+The four features are individually selectable for development — you can build with `--features silero` alone if you only want to exercise the VAD against a recorded WAV — but the `--speech` flag on `primer-cli` requires all four. The CLI's `speech` feature pulls them in transitively:
+
+```bash
+~/.cargo/bin/cargo build --features primer-cli/speech
+```
+
+Two pure helper modules round out the crate: [vad_debounce.rs](../../src/crates/primer-speech/src/vad_debounce.rs) carries the silence-debounce state machine ("how many consecutive silent chunks before we declare the utterance over?") and [phrase_split.rs](../../src/crates/primer-speech/src/phrase_split.rs) carries the streaming phrase splitter that the Piper backend uses to chunk LLM output on `. ! ?` boundaries. Both are dependency-free of the rest of the crate so they can be unit-tested without a backend.
+
+## Why piper-rs is vendored at src/vendor/piper-rs/
+
+The upstream `piper-rs` 0.1.9 release was built against a pre-`rc.10` revision of the [ort](https://github.com/pykeio/ort) ONNX-runtime crate. The rest of the workspace pins `ort = "=2.0.0-rc.10"` (the version that `silero-vad-rust 6.2` was built against), so dropping in upstream `piper-rs` produces a duplicate-`ort` error at link time.
+
+The vendored copy at [src/vendor/piper-rs/](../../src/vendor/piper-rs/) carries a small patch fixing three call sites where the `ort` API surface changed at `rc.10`:
+
+- `Value::from_array` now wants owned arrays.
+- `Session::run` now takes `&mut self`.
+- `try_extract_tensor` now returns `(&Shape, &[T])`.
+
+The patch is wired up in the workspace [Cargo.toml](../../src/Cargo.toml):
+
+```toml
+# src/Cargo.toml
+[patch.crates-io]
+piper-rs = { path = "vendor/piper-rs" }
+silero-vad-rust = { path = "vendor/silero-vad-rust" }
+```
+
+The intersection of `ort` versions between `piper-rs` 0.1.x and `silero-vad-rust` 6.2 is empty, so until upstream releases an `rc.10`-compatible version the fork stays. The smoke binary [tts_hello.rs](../../src/crates/primer-speech/examples/tts_hello.rs) covers the basic synth path so a future upstream update can be validated end-to-end with one command.
+
+## Why silero-vad-rust is vendored at src/vendor/silero-vad-rust/
+
+Three patches, all small:
+
+1. **`is_multiple_of(N)` → `% N == 0`.** Upstream uses the unstable `unsigned_is_multiple_of` API. The toolchain pin in [rust-toolchain.toml](../../src/rust-toolchain.toml) is not enough on its own — `is_multiple_of` is still unstable on rustc 1.97-nightly, so the call sites had to be rewritten. Stable rustc cannot compile upstream as-is.
+2. **`load-dynamic` removed from the `ort` feature list.** Removing it lets us link ONNX Runtime statically. Combined with the explicit `download-binaries` and `copy-dylibs` features that [primer-speech/Cargo.toml](../../src/crates/primer-speech/Cargo.toml) lists for `ort`, this achieves a fully static `libonnxruntime` link with no `dlopen` failure at runtime.
+3. **Crate-level `#![allow(unused_variables, dead_code)]`** to silence two upstream warnings under Primer's `-D warnings` build profile.
+
+The patch ships as the entire vendored crate at [src/vendor/silero-vad-rust/](../../src/vendor/silero-vad-rust/) and is wired into [src/Cargo.toml](../../src/Cargo.toml) alongside `piper-rs` (see snippet in the previous section). Drop the vendor patch as soon as a `silero-vad-rust` release picks up the API surface and stable Rust supports `is_multiple_of`.
+
+## The speech_loop state machine
+
+The voice loop lives in [speech_loop.rs](../../src/crates/primer-cli/src/speech_loop.rs). At runtime it cycles through four logical states:
+
+```
+LISTEN  → mic open, VAD watching for SpeechStart
+  ↓ (SpeechStart)
+LATENT_THINK + LISTEN  → child speaking; whisper streaming open;
+                         on SpeechEnd, finalize transcript
+  ↓ (SpeechEnd)
+THINK   → mic still open (cancel-on-SpeechStart aborts the LLM if
+          the child resumes); call dialogue manager; LLM streams reply
+  ↓ (response complete)
+SPEAK   → mic muted; Piper synthesises phrase by phrase; cpal pushes
+          to speakers; await drain hook
+  ↓ (drain complete)
+LISTEN  → next utterance
+```
+
+Two invariants:
+
+- **The Primer never speaks over the child.** During LATENT_THINK and THINK the mic stays open. If the child starts speaking again before the LLM has produced a complete response, the `cancel-on-SpeechStart` path aborts the in-flight inference call cleanly and re-enters LISTEN.
+- **The child never speaks over the Primer.** During SPEAK the mic is hard-muted via the `is_speaking` flag (next section) — incoming samples are drained and discarded, the active whisper session is dropped, and local buffers are cleared. The mic does not re-open until the speaker ringbuf is fully drained.
+
+> **Why:** No barge-in is pedagogical, not a POC limitation. Learning to listen — to wait for the answer rather than interrupting — is part of the educational experience the Primer is trying to deliver. Don't "fix" this by adding barge-in support; ask first.
+
+## The is_speaking flag and drain-hook discipline
+
+The mute mechanism is an `Arc<AtomicBool>` plumbed from [`run_loop`](../../src/crates/primer-cli/src/speech_loop.rs) into the audio capture thread. The audio thread polls the flag every 5 ms; while it reads `true`, it drains and discards mic samples instead of feeding them to the VAD.
+
+Around SPEAK, the flag is set to `true` before the first phrase is pushed to cpal, and cleared only after the speaker ringbuf has fully drained. The drain wait runs through the [`DrainHook`](../../src/crates/primer-cli/src/speech_loop.rs) abstraction:
+
+```rust
+// src/crates/primer-cli/src/speech_loop.rs
+pub type DrainHook = /* boxed FnMut returning a future */;
+```
+
+In production, the hook is a `tokio::task::spawn_blocking` wrapper around [`primer_speech::wait_for_drain`](../../src/crates/primer-speech/src/cpal_io.rs). `wait_for_drain` polls the speaker ringbuf's `occupied_len()` until it reads zero on three consecutive 10 ms checks (defending against momentary cpal buffer underruns being misread as "drained"), then waits an additional 80 ms grace period for cpal's own internal output buffer to flush, with a 5 s sanity cap that includes the grace window. In tests, `run_loop` accepts `None` as the hook because mock speaker sinks have no real ringbuf to drain.
+
+> **Gotcha:** Calling `std::thread::sleep` directly inside `on_audio` (which runs in the same task as `run_loop`) would block other tasks for up to 5 s and panic outright on a single-threaded tokio runtime. Going through `spawn_blocking` is what keeps the synchronous wait off the tokio worker. If you change the drain mechanism, preserve this property — the on_audio path must never sleep on the runtime thread.
+
+The speaker producer is wrapped in `Arc<Mutex<HeapProd<f32>>>` so both the `on_audio` push path and the drain hook can access it. The mutex is uncontended in practice — push and observe never overlap by the state-machine design — but is needed because Rust's type system cannot prove that on its own.
+
+## Speaker ringbuf sizing
+
+The speaker SPSC ring buffer is sized for ~5 s of 48 kHz mono audio:
+
+```rust
+// src/crates/primer-speech/src/cpal_io.rs
+const SPEAKER_RINGBUF_CAPACITY: usize = 240_000;
+```
+
+The previous size of 24,000 samples (~500 ms) had a subtle and devastating failure mode: when Piper synthesised a multi-phrase response faster than cpal drained, the ringbuf filled, the producer dropped samples on push failure, and only the first phrase made it through. The child would hear "The Sun is a star." and silence where the rest of the answer should have been. The 240,000-sample capacity comfortably absorbs a multi-second phrase without back-pressure.
+
+> **Gotcha:** Never shrink the speaker ringbuf below 240,000 samples. The previous 24,000-sample buffer dropped phrases — only the first phrase of a multi-phrase response made it through. If you find yourself reducing this for a memory-constrained build target, you need a different fix (e.g. block-on-full instead of drop-on-full), not a smaller buffer.
+
+## Markdown stripping for TTS
+
+The LLM produces markdown — `*emphasis*`, `**strong**`, `` `code` `` — and Piper has no idea what to do with asterisks or backticks. They come out as literal "asterisk asterisk" or get phonemised into something garbled. So before pushing to Piper, the speech loop runs the response through [`strip_markdown_for_tts`](../../src/crates/primer-cli/src/speech_loop.rs), which removes paired markers and leaves bare unmatched ones alone:
+
+| Input | Stripped |
+|---|---|
+| `*why*` | `why` |
+| `**important**` | `important` |
+| `` `code` `` | `code` |
+| `a* footnote` | `a* footnote` (bare unmatched stays) |
+| `5*3=15` | `5 times 3=15` (digit-flanked `*` → multiplication) |
+| `5**2` | `5 times 2` (digit-flanked `**` → exponent) |
+| `value *= 5` | `value *= 5` (operator stays) |
+
+The digit-flanking rule reads multiplication and exponent notation aloud naturally — without it, "5*3" would be voiced "five star three" or worse. The visible transcript on stdout retains the original markdown unchanged; only the TTS path strips. The complete coverage is in the [unit tests in speech_loop.rs](../../src/crates/primer-cli/src/speech_loop.rs).
+
+## The dedicated audio-capture thread
+
+The audio capture path runs on its own `std::thread`, **not** a tokio task. It owns the silero VAD instance, the active whisper streaming session, and the mic-side resampler. It emits two kinds of output:
+
+- `VadEvent`s (`SpeechStart`, `SpeechEnd`, `None`) over a `tokio::sync::mpsc` channel that `run_loop` consumes.
+- On `SpeechEnd`, the finalised transcript over a separate channel that `run_loop` reads via a [`ChannelStt`](../../src/crates/primer-cli/src/speech_loop.rs) wrapper — a thin adapter that implements `StreamingSpeechToText` against the channel so `run_loop` can treat audio capture as a regular trait object.
+
+This split keeps test/production cleanly separated: mocks bypass `cpal` entirely by injecting events and transcripts directly into those channels. The whole audio stack (cpal, ringbufs, rubato resampler, silero, whisper) is dark to unit tests, which is what makes the [speech_loop tests](../../src/crates/primer-cli/src/speech_loop.rs) tractable.
+
+There is also an ordering contract worth flagging: the audio thread MUST send the transcript on the transcript channel **before** emitting `VadEvent::SpeechEnd` on the event channel. `run_loop` relies on that ordering to call `finalize` on a session that already has its final segment queued. Reversing the order would race.
+
+## Resampler tail-handling
+
+Sample-rate conversion runs through `rubato`'s `FftFixedIn`. The mic side resamples device-rate → 16 kHz for the VAD and Whisper; the speaker side resamples voice-config rate → device output rate for cpal. Both share the same hazard: `FftFixedIn` buffers FFT state internally, and any input sample that doesn't fall on a chunk boundary is held back inside the resampler until enough trailing samples arrive to complete the next FFT.
+
+That's a problem at end-of-utterance. Without help, the last syllable or word of each phrase — and often the entire last phrase of a multi-phrase response — gets silently discarded because the resampler is still holding its tail.
+
+Two mechanisms together solve this:
+
+1. **A `leftover: Vec<f32>` buffer carried across `on_audio` calls.** Each call prepends the previous call's leftover before processing, so phrase tails are stitched into the next call rather than zero-padded mid-stream.
+2. **An end-of-turn flush sentinel.** When `on_audio` is called with an empty `Vec`, it zero-pads any remaining leftover up to the chunk boundary and then drives **four extra silence chunks** (~186 ms of input silence at the relevant rates) through the resampler to drain its FFT-buffered output. Empirically, fewer chunks were not enough — `FftFixedIn` needs a non-trivial silence tail to flush its lookahead.
+
+If you change the resampler config, validate against the multi-phrase end-of-response case specifically. A test that passes a single phrase will not catch a regression here.
+
+## espeak-ng requirement and probe
+
+Piper uses `espeak-ng` to phonemise text before feeding it into the ONNX voice model. The `espeak-rs` crate ships an embedded subset of the espeak-ng data files, but that subset is **incomplete** — it is missing files like `phontab` that most non-English voices need, and even the English voices fail in subtle ways without the full data set.
+
+The fix is to install `espeak-ng` system-wide and point Piper at the system data directory:
+
+```bash
+# macOS (Apple Silicon and Intel)
+brew install espeak-ng
+
+# Debian / Ubuntu
+sudo apt install espeak-ng-data
+
+# Fedora / RHEL
+sudo dnf install espeak-ng-data
+```
+
+At startup, [`probe_espeak_ng_data` in main.rs](../../src/crates/primer-cli/src/main.rs) walks three candidate locations and sets the `PIPER_ESPEAKNG_DATA_DIRECTORY` environment variable to the parent of the first complete `espeak-ng-data` directory it finds:
+
+```
+/opt/homebrew/share   # macOS Apple Silicon (brew install espeak-ng)
+/usr/local/share      # macOS Intel / generic
+/usr/share            # Linux (apt/dnf)
+```
+
+It checks for the presence of `espeak-ng-data/phontab` rather than just the directory existence, because `espeak-rs`'s incomplete subset would otherwise satisfy a directory-only probe and leave you with phoneme failures at runtime. If `PIPER_ESPEAKNG_DATA_DIRECTORY` is already set when the probe runs, the probe respects it.
+
+> **Gotcha:** Voice id must be passed explicitly. Pass `--voice <model-id>` matching the file stem of `--voice-onnx` (e.g. `--voice en_GB-alba-medium` for `en_GB-alba-medium.onnx`). Before this fix, `run_loop` hardcoded `VoiceProfile::default()` (`en_US-amy-medium`) as the voice profile passed to Piper's `open_session`, and Piper rejected any non-default voice with a model-id mismatch error. The CLI now also validates that `--voice` matches the `--voice-onnx` filename stem and errors at parse time if not.
+
+> **Gotcha:** Build with rustup, not Homebrew rust. This was already mentioned in [chapter 1](01-getting-started.md), but it bears repeating here because speech is where the bug surfaces hardest. [rust-toolchain.toml](../../src/rust-toolchain.toml) pins Rust 1.87+, but that pin is honoured only by rustup's proxy binaries. If a Homebrew-installed `cargo` shadows on `PATH`, Cargo silently falls back to whatever Homebrew has (often 1.86), and silero will fail to compile with a confusing trait-resolution error. Always invoke as `~/.cargo/bin/cargo` for any speech-feature build.
+
+> **Gotcha:** Voice rate is `0.9` (length_scale ≈ 1.111), not 1.0. Each phrase is followed by 200 ms of injected silence before the next chunk is pushed to cpal. Both numbers were tuned against the target audience: too fast and a 7-year-old loses the thread; too breathless and the pacing feels artificial. Adjust [`VoiceProfile.rate`](../../src/crates/primer-core/src/speech.rs) and the inter-chunk sleep in [speech_loop.rs](../../src/crates/primer-cli/src/speech_loop.rs) if needed, but treat it as a UX call, not a code call.
+
+---
+
+### Recipe — Add a speech backend
+
+Worked example: a hypothetical streaming STT backend that wraps a different upstream model (say, a `Vosk`-based one). Seven steps.
+
+**1. Pick the trait.** The five traits map cleanly to the three logical roles:
+
+| Role | Trait | Audio direction |
+|---|---|---|
+| VAD | [`VoiceActivityDetector`](../../src/crates/primer-core/src/speech.rs) | frames in, events out |
+| STT | [`SpeechToText`](../../src/crates/primer-core/src/speech.rs) (one-shot) or [`StreamingSpeechToText`](../../src/crates/primer-core/src/speech.rs) (live) | audio in, text out |
+| TTS | [`TextToSpeech`](../../src/crates/primer-core/src/speech.rs) (one-shot) or [`StreamingTextToSpeech`](../../src/crates/primer-core/src/speech.rs) (live) | text in, audio out |
+
+For a live STT backend, implement `StreamingSpeechToText` plus a [`TranscriptionSession`](../../src/crates/primer-core/src/speech.rs). For batch use, the one-shot trait alone is fine.
+
+**2. Implement it.** `Named::name()` is written once via super-trait inheritance:
+
+```rust
+// src/crates/primer-speech/src/vosk.rs (sketch)
+use primer_core::speech::{
+    Named, StreamingSpeechToText, TranscriptionSession, TranscriptSegment,
+};
+use primer_core::error::Result;
+
+pub struct VoskStt { /* model handle */ }
+
+impl Named for VoskStt {
+    fn name(&self) -> &str { "vosk" }
+}
+
+impl StreamingSpeechToText for VoskStt {
+    fn sample_rate(&self) -> u32 { 16_000 }
+
+    fn open_session(&self) -> Result<Box<dyn TranscriptionSession>> {
+        // ... allocate a per-utterance recogniser
+        todo!()
+    }
+}
+```
+
+Note that `StreamingSpeechToText` is `Send + Sync` — the backend is shared across sessions. Per-utterance state lives inside the `TranscriptionSession` (which is `Send` but not `Sync`). Don't move per-utterance buffers into the backend struct.
+
+**3. Gate behind a cargo feature.** In [primer-speech/Cargo.toml](../../src/crates/primer-speech/Cargo.toml), add the dep as `optional = true` and a feature that enables it. Naming convention: lowercase backend name, matching the existing pattern (`silero`, `whisper`, `piper`, `cpal`):
+
+```toml
+# src/crates/primer-speech/Cargo.toml
+[dependencies]
+vosk = { version = "0.x", optional = true }
+
+[features]
+vosk = ["dep:vosk"]
+```
+
+If your backend needs `ort`, list `ort` features explicitly with `default-features = false`, mirroring the pattern in the existing `[dependencies]` block — without `download-binaries` and `copy-dylibs` ONNX Runtime cannot be found at link time, and the failure mode at build time is misleading.
+
+**4. Vendor or patch incompatible deps.** If your upstream uses a different `ort` revision (or any other workspace-wide pinned dep), drop a vendored copy under [src/vendor/<crate>/](../../src/vendor/) and add the patch to [src/Cargo.toml](../../src/Cargo.toml):
+
+```toml
+# src/Cargo.toml
+[patch.crates-io]
+my-upstream-crate = { path = "vendor/my-upstream-crate" }
+```
+
+Keep the vendored copy minimal — preserve upstream `LICENSE`, `README.md`, and original `Cargo.toml.orig` (rename the original `Cargo.toml` to `Cargo.toml.orig` before editing). The patch should be the smallest possible change to make the API compatible. Note in this chapter and in the vendored crate's `BUILDING.md` what the patch does and when it can be dropped — see [vendor/piper-rs/BUILDING.md](../../src/vendor/piper-rs/BUILDING.md) for the precedent.
+
+**5. Wire into LoopBackends.** The voice loop selects backends by trait object in [speech_loop.rs](../../src/crates/primer-cli/src/speech_loop.rs). Add a feature-gated factory branch in [main.rs](../../src/crates/primer-cli/src/main.rs) that constructs your backend from CLI flags and passes it through to `LoopBackends`. Keep the construction error path graceful — a missing model file should produce a clear error message naming the flag and the file, not a panic.
+
+**6. Add a smoke example.** Following the precedent of [tts_hello.rs](../../src/crates/primer-speech/examples/tts_hello.rs), add an example at `src/crates/primer-speech/examples/<name>.rs` that exercises the backend without the full REPL — for an STT backend, that means reading a fixed WAV file and printing the transcript. Mark it `required-features` in [Cargo.toml](../../src/crates/primer-speech/Cargo.toml) so it only builds when the relevant feature is on:
+
+```toml
+# src/crates/primer-speech/Cargo.toml
+[[example]]
+name = "vosk_hello"
+required-features = ["vosk"]
+```
+
+The smoke example is what lets a contributor (and a future you, after a vendor-patch dependency bump) validate the backend in isolation in seconds.
+
+**7. Add system-dep installation notes** to [chapter 8](08-build-and-test-recipes.md) if your backend needs a system package. Piper's espeak-ng dependency lives there for exactly this reason; whisper.cpp's cmake/C++-toolchain requirement also belongs in chapter 8. If your backend is pure-Rust with no system deps, no chapter-8 entry is needed.
+
+When you're done: build with `--features primer-speech/<your-feature>`, run the smoke example, and verify it produces sensible output. Then build with `--features primer-cli/speech` — confirming that your new backend doesn't break the existing voice loop is the load-bearing integration test.

--- a/docs/devel/07-speech-and-voice-loop.md
+++ b/docs/devel/07-speech-and-voice-loop.md
@@ -295,6 +295,6 @@ required-features = ["vosk"]
 
 The smoke example is what lets a contributor (and a future you, after a vendor-patch dependency bump) validate the backend in isolation in seconds.
 
-**7. Add system-dep installation notes** to [chapter 8](08-build-and-test-recipes.md) if your backend needs a system package. Piper's espeak-ng dependency lives there for exactly this reason; whisper.cpp's cmake/C++-toolchain requirement also belongs in chapter 8. If your backend is pure-Rust with no system deps, no chapter-8 entry is needed.
+**7. Add system-dep installation notes** to [chapter 8](08-testing-and-debugging.md) if your backend needs a system package. Piper's espeak-ng dependency lives there for exactly this reason; whisper.cpp's cmake/C++-toolchain requirement also belongs in chapter 8. If your backend is pure-Rust with no system deps, no chapter-8 entry is needed.
 
 When you're done: build with `--features primer-speech/<your-feature>`, run the smoke example, and verify it produces sensible output. Then build with `--features primer-cli/speech` — confirming that your new backend doesn't break the existing voice loop is the load-bearing integration test.

--- a/docs/devel/08-testing-and-debugging.md
+++ b/docs/devel/08-testing-and-debugging.md
@@ -1,0 +1,205 @@
+# Testing and debugging
+
+This chapter is for the contributor who has cloned the repo, built per [chapter 1](01-getting-started.md), and now needs to run the test suite, get useful logs out of a running session, and diagnose the misbehaviour they were asked to fix. It does not introduce new architecture — it is a survival guide for working effectively in the codebase day to day.
+
+The tools split roughly into three layers. First, `cargo test` and the per-crate test layout — most invariants in this codebase are pinned by tests, and knowing where they live tells you both what is safe to change and where to add coverage. Second, `RUST_LOG` and `--verbose` — the former exposes [tracing](https://docs.rs/tracing) output from every crate, the latter prints a small set of high-signal pedagogy-flow lines on stderr. Third, the SQLite session DB — when something the dialogue manager did or did not do looks wrong, the persisted record is the source of truth.
+
+The chapter ends with a "common pitfalls" parade — most of these mirror gotchas in [CLAUDE.md](../../CLAUDE.md) — and two debugging recipes for the symptoms that come up most often.
+
+## Test layout
+
+Tests live next to the crate they test, never in a top-level `tests/` directory at the repo root. There are three patterns in use, each chosen for a reason:
+
+- **Inline `#[cfg(test)] mod tests`** for unit tests against private items. The 30+ characterization tests for `decide_intent` live this way at the bottom of [primer-pedagogy/src/prompt_builder.rs](../../src/crates/primer-pedagogy/src/prompt_builder.rs) (search for `mod tests`). They pin the heuristic's *current* behaviour — what intent does the Primer pick for a frustrated 6-year-old who just asked "what is gravity?" — and they are the first thing to read when changing intent routing.
+- **Per-crate `tests/` directory** for integration tests that exercise a whole crate's public surface. Examples: [primer-storage's session tests](../../src/crates/primer-storage/src/store/tests/session_tests.rs), [the retrieval-quality benchmarks](../../src/crates/primer-kb-load/tests/retrieval_quality.rs), and the BM25-only and hybrid-retrieval sweep harnesses at [retrieval_sweep.rs](../../src/crates/primer-kb-load/tests/retrieval_sweep.rs) and [retrieval_sweep_hybrid.rs](../../src/crates/primer-kb-load/tests/retrieval_sweep_hybrid.rs).
+- **Per-axis split for the dialogue manager.** [primer-pedagogy/src/dialogue_manager/tests/](../../src/crates/primer-pedagogy/src/dialogue_manager/tests/) holds three files — `lifecycle_tests.rs`, `turn_tests.rs`, `background_tests.rs` — each pinned to one axis of behaviour. Shared mocks (stub backends, stub session stores, stub classifiers) and fixture builders live in [test_support.rs](../../src/crates/primer-pedagogy/src/dialogue_manager/test_support.rs) so the three test files don't fork their setup. When you add a new method to `DialogueManager`, add the test to the file matching its responsibility — don't grow a fourth test module.
+
+> **Why:** the split mirrors the production split (`lifecycle.rs` / `turn.rs` / `background.rs`), so a reviewer reading a PR can hold one axis in their head at a time. A test that crosses axes is a smell — it usually means a method moved files but its test didn't.
+
+The retrieval sweeps are worth calling out separately. [retrieval_sweep.rs](../../src/crates/primer-kb-load/tests/retrieval_sweep.rs) is a 24-cell grid search over BM25-only retrieval parameters; [retrieval_sweep_hybrid.rs](../../src/crates/primer-kb-load/tests/retrieval_sweep_hybrid.rs) is a 54-cell sweep over the hybrid (BM25 + dense vector) parameter space, gated behind `--features fastembed --ignored`. Both produce CSVs for offline analysis. They are how the current defaults in [primer-core::consts::retrieval](../../src/crates/primer-core/src/consts.rs) were chosen, and they exist so the next time someone wants to retune, they can re-run the sweep and update the consts in one commit.
+
+## Running tests
+
+All test commands run from `src/`:
+
+```bash
+cargo test                                 # everything, default features
+cargo test -p primer-pedagogy              # one crate
+cargo test -p primer-pedagogy decide_intent  # filter by substring
+cargo test -- --nocapture                  # show stdout/stderr from passing tests
+```
+
+Feature-gated crates need their feature on the command line. The most common ones:
+
+```bash
+cargo test -p primer-embedding --features fastembed
+cargo test -p primer-speech    --features silero,whisper,piper,cpal
+cargo test -p primer-kb-load   --features fastembed -- --ignored  # hybrid sweep
+```
+
+> **Note:** `--ignored` runs tests marked `#[ignore]` *instead of* the default suite, not in addition to it. The hybrid sweep is `#[ignore]` because it downloads the BGE-M3 model on first run (~570 MB) and takes minutes to complete — it is run on demand, not in CI.
+
+Single-test substring filtering works on every test target. `cargo test -p primer-pedagogy decide_intent_routes` matches every test whose name contains that substring, which is the fastest way to iterate on the decide-intent characterization suite while editing it.
+
+## RUST_LOG and `--verbose`
+
+These are two different tools. Use the right one.
+
+**`--verbose`** is a flag on `primer-cli`. When set, the REPL prints four high-signal pedagogy-flow lines on **stderr** at the end of each turn:
+
+```
+[intent] Curious -> SocraticQuestion
+[classifier] Engaged conf=0.84 (cloud:claude-sonnet-4-6)
+             — child asked a follow-up about gravity, building on the previous turn
+[extractor] child=["gravity", "weight"] primer=["mass", "force"] (cloud:claude-sonnet-4-6)
+[comprehension] gravity=Aware(0.55) mass=Familiar(0.78) (cloud:claude-sonnet-4-6)
+```
+
+The lines are produced by the CLI directly from `dm.last_intent()`, `dm.last_assessment()`, `dm.last_extraction()`, and `dm.last_comprehension()` in [primer-cli/src/main.rs](../../src/crates/primer-cli/src/main.rs). They reflect the engine's view of the just-completed turn. Stdout stays clean — the child still sees only the Primer's response — so you can pipe stdout into a log file and read `--verbose` output live on the terminal.
+
+**`RUST_LOG`** is the standard [`tracing-subscriber`](https://docs.rs/tracing-subscriber) env var. The CLI's default filter is `info,ort=warn,whisper_cpp_plus=warn,cpal=warn` — quiet enough for everyday use, but `info`-level events from the engine will print. Override with the usual idioms:
+
+```bash
+RUST_LOG=debug cargo run --bin primer                    # firehose
+RUST_LOG=primer_pedagogy=debug cargo run --bin primer    # one crate
+RUST_LOG=primer::retry=info cargo run --bin primer       # one tracing target
+RUST_LOG=info,ort=info cargo run --bin primer -- --speech ...  # ONNX session-init logs
+```
+
+The retry helper at [primer-core::retry](../../src/crates/primer-core/src/retry.rs) emits one `info`-level event per retry decision under target `primer::retry`, which is how you confirm a flaky cloud call is being retried (and how a future voice-mode change can subscribe to play a "give me a moment" bridging phrase).
+
+> **Note:** `RUST_LOG` and `--verbose` are independent. Use `--verbose` for the four-line pedagogy summary; use `RUST_LOG` for tracing crate output. Setting both is fine and often useful — the streams interleave on stderr.
+
+## Inspecting session DBs
+
+Every conversation is persisted to a per-child SQLite file at `~/.primer/<slugified-name>.db` unless `--no-persist` was passed. The schema is documented in [chapter 5](05-storage-and-sessions.md); the relevant tables for debugging are `sessions`, `turns`, `turn_classifications`, `turn_comprehensions`, `turn_concepts`, `concepts`, `learners`, and `learner_concepts`.
+
+You don't need anything more than the system `sqlite3` CLI:
+
+```bash
+sqlite3 ~/.primer/binti.db
+```
+
+Useful starting queries:
+
+```sql
+-- most-recent session for this child
+SELECT id, started_at, ended_at, summary_through_turn_index
+FROM sessions
+ORDER BY started_at DESC
+LIMIT 1;
+```
+
+```sql
+-- engagement classifications for the most-recent session, with state names
+SELECT t.turn_index,
+       es.name AS engagement,
+       tc.confidence,
+       c.identifier AS classifier
+FROM turn_classifications tc
+JOIN turns t              ON t.id = tc.turn_id
+JOIN engagement_states es ON es.id = tc.engagement_state_id
+JOIN classifiers c        ON c.id = tc.classifier_id
+WHERE t.session_id = (SELECT id FROM sessions ORDER BY started_at DESC LIMIT 1)
+ORDER BY t.turn_index;
+```
+
+```sql
+-- per-concept comprehension assessments for the most-recent session
+SELECT t.turn_index,
+       co.name      AS concept,
+       ud.name      AS depth,
+       tcm.confidence,
+       tcm.evidence
+FROM turn_comprehensions tcm
+JOIN turns t                ON t.id = tcm.turn_id
+JOIN concepts co            ON co.id = tcm.concept_id
+JOIN understanding_depths ud ON ud.id = tcm.depth_id
+WHERE tcm.session_id = (SELECT id FROM sessions ORDER BY started_at DESC LIMIT 1)
+ORDER BY t.turn_index, co.name;
+```
+
+```sql
+-- learner's per-concept mastery state, sorted by most-recent encounter
+SELECT co.name      AS concept,
+       ud.name      AS depth,
+       lc.confidence,
+       lc.encounter_count,
+       lc.box_level,
+       lc.last_encountered
+FROM learner_concepts lc
+JOIN concepts co             ON co.id = lc.concept_id
+JOIN understanding_depths ud ON ud.id = lc.depth_id
+ORDER BY lc.last_encountered DESC
+LIMIT 20;
+```
+
+> **Gotcha:** Categorical text columns are stored as integer foreign keys, not as TEXT. Joining against the lookup table (`engagement_states`, `understanding_depths`, `concepts`, `classifiers`) is mandatory — a query that selects `engagement_state_id` directly will return integers and look like data corruption to a fresh pair of eyes. See [chapter 5](05-storage-and-sessions.md) for why.
+
+## Common pitfalls
+
+Most of these are direct mirrors of [CLAUDE.md](../../CLAUDE.md). They show up here because they bite contributors more often than anything else.
+
+> **Gotcha:** `cargo build` from the repo root fails with "could not find `Cargo.toml`". The workspace root is `src/Cargo.toml`. Run every cargo command from `src/`.
+
+> **Gotcha:** A confusing edition or feature-flag error on a fresh checkout almost always means Homebrew rust is shadowing rustup on `$PATH`. The toolchain pin in `rust-toolchain.toml` is honored only by rustup proxy binaries. Invoke as `~/.cargo/bin/cargo`, or remove Homebrew rust from `$PATH`.
+
+> **Gotcha:** `--speech` panics at startup with an espeak data error. Install `espeak-ng` system-wide (`brew install espeak-ng` on macOS, `sudo apt install espeak-ng-data` on Debian/Ubuntu). The `espeak-rs` crate ships an incomplete subset of espeak's data files that fails for most voices.
+
+> **Gotcha:** `--embedder-backend fastembed` exits with a build hint. The `embedding` cargo feature on `primer-cli` is off by default, so the fastembed backend is not compiled in. Build with `cargo build --features primer-cli/embedding` (or run with `--features primer-cli/embedding`). Same shape as `--speech` and the `speech` feature.
+
+> **Gotcha:** First fastembed run hangs for a few minutes with no output. It is downloading the BGE-M3 model (~570 MB) into `~/.cache/primer/models/` from `cdn.pyke.io`. Subsequent runs are fast. If construction fails, the dialogue manager falls back to BM25-only with a `tracing::warn!` — the conversation still works.
+
+> **Gotcha:** First `--speech` run hangs at compile time with no output. Cargo is downloading the ONNX Runtime binary (~50 MB) from `cdn.pyke.io`. Cached after the first build.
+
+> **Gotcha:** Voice rejected at runtime with a model-id mismatch. `PiperTts::open_session(voice)` errors when the requested `model_id` doesn't match the one the backend was constructed with. Pass `--voice <model-id>` matching your `.onnx` filename (e.g. `--voice en_US-amy-medium` for `en_US-amy-medium.onnx`). Multi-voice runtime switching is deferred.
+
+> **Gotcha:** Streaming hangs with no chunks ever delivered. The most common cause is a 2xx response with no body — the SSE / NDJSON parser is waiting for bytes that never come. Mid-stream errors should propagate cleanly; if they don't, see the recipe below for where to add tracing in the streaming buffer.
+
+> **Gotcha:** `[classifier]` line never prints in `--verbose` output, and `turn_classifications` is empty. The classifier is timing out; small models (e.g. `gemma3:4b`) often need >500 ms for the structured-output call. Increase `--classifier-timeout-ms` (default 3000) or follow the recipe below.
+
+> **Gotcha:** Session DB has the schema but no rows for a session you just ended. The dialogue manager saves on every turn, on `open_session`, on `resume_session`, and on `close_session`. Save failures `tracing::warn!` instead of propagating. Re-run with `RUST_LOG=primer_storage=warn` to see the failure.
+
+## Debugging a streaming hang
+
+Symptom: the REPL waits indefinitely after sending a turn to the cloud or Ollama backend, no tokens printed, no error.
+
+The streaming pipeline is a `futures::channel::mpsc::unbounded` driven by a tokio task that reads bytes from the HTTP response, frames them via [`SseBuffer`](../../src/crates/primer-inference/src/cloud/sse.rs) (Anthropic) or [`NdjsonBuffer`](../../src/crates/primer-inference/src/ollama/ndjson.rs) (Ollama), and forwards parsed events as chunks. A hang means one of three things:
+
+1. **The HTTP request never completed handshake.** Check `RUST_LOG=hyper=debug,reqwest=debug`. If you see no `Sending request` line, the issue is config (URL, port, TLS).
+2. **The response was 2xx but the body channel never delivered bytes.** This is the load-bearing case — Anthropic and Ollama can both legitimately keep a connection open with no data while the model warms up, but if it goes on past your retry budget, something is wrong server-side. Add a `tracing::trace!` inside `SseBuffer::push` / `NdjsonBuffer::push` to see whether bytes are arriving but failing to parse.
+3. **Bytes are arriving but the parser is rejecting them.** This means the upstream protocol changed shape (e.g. a new SSE event variant Anthropic added). The parsers are hand-rolled by design — they accept the formats Phase 0.1 was built against — so a protocol drift surfaces here. Capture a raw byte dump (set tracing in the HTTP body loop, not the parser) and diff against the documented format.
+
+> **Note:** Once `generate_stream` starts consuming bytes from a 2xx response, mid-stream errors propagate cleanly via the channel and the partial Primer turn is dropped at the dialogue-manager layer. Retries happen at the request-send + status-check phase only. If you find yourself wanting to retry mid-stream, that is a deeper design change — talk to maintainers first.
+
+## Debugging a quiet classifier, extractor, or comprehension
+
+Symptom: `--verbose` is on but the `[classifier]` (or `[extractor]` / `[comprehension]`) line never prints; the corresponding DB table is empty.
+
+All three structured-output crates ([primer-classifier](../../src/crates/primer-classifier/src/lib.rs), [primer-extractor](../../src/crates/primer-extractor/src/lib.rs), [primer-comprehension](../../src/crates/primer-comprehension/src/lib.rs)) follow the same pattern: a tokio-spawned task runs after the response, persists to its DB table, and the dialogue manager `await`s the result with a bounded timeout at the start of the next turn. On timeout the task is **detached, not cancelled** — DB persistence still completes if the LLM eventually returns. So an empty DB table means the LLM call is failing, not just timing out.
+
+The default timeouts are tuned for cloud latency: 3000 ms for the classifier, 5000 ms each for the extractor and comprehension classifier. Small local models behind Ollama routinely need more, especially when the extractor and comprehension run as a chained pair. Bump the relevant flag — `--classifier-timeout-ms`, `--extractor-timeout-ms`, `--comprehension-timeout-ms` — before assuming the integration is broken. The recipe below makes this concrete for the classifier; the same five-step shape works for the extractor and comprehension classifier with their respective flags.
+
+### Recipe — Diagnose a quiet classifier
+
+Symptoms: `--verbose` is on but no `[classifier]` line is printed; `turn_classifications` is empty for the current session.
+
+1. **Confirm `--verbose` is set on the command line.** Without it, the line never prints even on success. The flag is on `primer-cli` — check `--help`.
+2. **Look for the `[classifier]` line on stderr** after the most recent Primer response. The line is printed at the START of the next turn, after the spawned classifier task has been awaited (with a bounded timeout). If you only sent one turn, send a second one to trigger the await. If the line is still absent, the classifier task isn't completing within `--classifier-timeout-ms`.
+3. **Inspect `turn_classifications` for the most recent session.**
+
+   ```sql
+   SELECT COUNT(*) FROM turn_classifications
+   WHERE turn_id IN (
+       SELECT id FROM turns
+       WHERE session_id = (SELECT id FROM sessions ORDER BY started_at DESC LIMIT 1)
+   );
+   ```
+
+   If 0, the classifier task either errored (`tracing::warn!` would have logged it — re-run with `RUST_LOG=primer_classifier=warn`) or is still pending in the background. The classifier task is detached on timeout; it self-persists when it eventually completes, so checking again a few seconds later may show the row.
+
+4. **Increase `--classifier-timeout-ms`.** Default is 3000 ms. Small Ollama-served models (e.g. `gemma3:4b`, `llama3.2:3b`) often need 5000–8000 ms for the JSON-shaped classification call. The classifier is one model behind the chat — its result feeds turn N+1's intent decision, so a longer timeout adds at most that much latency to the *start* of turn N+1, not to the response on turn N.
+
+5. **Swap to `--classifier-backend stub`** to confirm the integration point. The stub classifier writes a deterministic `EngagementAssessment` to `turn_classifications` instantly. If stub-backed runs produce rows and the `[classifier]` line, the LLM call itself is the bottleneck (revisit step 4 or check the model's chat-template support). If stub-backed runs *also* produce no rows, the integration is broken — start with `RUST_LOG=primer_pedagogy=debug,primer_classifier=debug` and read the spawn-then-await flow in [dialogue_manager/background.rs](../../src/crates/primer-pedagogy/src/dialogue_manager/background.rs).
+
+The same recipe shape works for the extractor (use `--extractor-backend stub` and `--extractor-timeout-ms`, check `turn_concepts`) and the comprehension classifier (use `--comprehension-backend stub` and `--comprehension-timeout-ms`, check `turn_comprehensions`). Both lag one turn for in-memory state for the same reason the classifier does — see [chapter 6](06-classifiers-and-learner-model.md).

--- a/docs/devel/08-testing-and-debugging.md
+++ b/docs/devel/08-testing-and-debugging.md
@@ -49,13 +49,15 @@ These are two different tools. Use the right one.
 
 ```
 [intent] Curious -> SocraticQuestion
-[classifier] Engaged conf=0.84 (cloud:claude-sonnet-4-6)
+[classifier] Engaged conf=0.84 (llm:claude-sonnet-4-6)
              — child asked a follow-up about gravity, building on the previous turn
-[extractor] child=["gravity", "weight"] primer=["mass", "force"] (cloud:claude-sonnet-4-6)
-[comprehension] gravity=Aware(0.55) mass=Familiar(0.78) (cloud:claude-sonnet-4-6)
+[extractor] child=["gravity", "weight"] primer=["mass", "force"] (llm:cloud:claude-sonnet-4-6)
+[comprehension] gravity=Aware(0.55) mass=Familiar(0.78) (llm:cloud:claude-sonnet-4-6)
 ```
 
 The lines are produced by the CLI directly from `dm.last_intent()`, `dm.last_assessment()`, `dm.last_extraction()`, and `dm.last_comprehension()` in [primer-cli/src/main.rs](../../src/crates/primer-cli/src/main.rs). They reflect the engine's view of the just-completed turn. Stdout stays clean — the child still sees only the Primer's response — so you can pipe stdout into a log file and read `--verbose` output live on the terminal.
+
+> **Note on identifier asymmetry:** the classifier emits `llm:{model}`, while the extractor and comprehension emit `llm:{backend}:{model}`. The classifier shipped first and predates the convention; if you grep stderr for an identifier, account for both shapes.
 
 **`RUST_LOG`** is the standard [`tracing-subscriber`](https://docs.rs/tracing-subscriber) env var. The CLI's default filter is `info,ort=warn,whisper_cpp_plus=warn,cpal=warn` — quiet enough for everyday use, but `info`-level events from the engine will print. Override with the usual idioms:
 
@@ -158,13 +160,13 @@ Most of these are direct mirrors of [CLAUDE.md](../../CLAUDE.md). They show up h
 
 > **Gotcha:** `[classifier]` line never prints in `--verbose` output, and `turn_classifications` is empty. The classifier is timing out; small models (e.g. `gemma3:4b`) often need >500 ms for the structured-output call. Increase `--classifier-timeout-ms` (default 3000) or follow the recipe below.
 
-> **Gotcha:** Session DB has the schema but no rows for a session you just ended. The dialogue manager saves on every turn, on `open_session`, on `resume_session`, and on `close_session`. Save failures `tracing::warn!` instead of propagating. Re-run with `RUST_LOG=primer_storage=warn` to see the failure.
+> **Gotcha:** Session DB has the schema but no rows for a session you just ended. The dialogue manager saves on every turn, on `open_session`, on `resume_session`, and on `close_session`. Save failures `tracing::warn!` instead of propagating. The warnings fire from `primer_pedagogy::dialogue_manager` (not `primer_storage` — the storage layer just returns the error; the warn happens at the call site). Because `warn` is already enabled by the default filter (`info,ort=warn,...`), these messages already surface on stderr at the default log level — no `RUST_LOG` override needed. If you want to scope the firehose, `RUST_LOG=primer_pedagogy=warn` is the right target.
 
 ## Debugging a streaming hang
 
 Symptom: the REPL waits indefinitely after sending a turn to the cloud or Ollama backend, no tokens printed, no error.
 
-The streaming pipeline is a `futures::channel::mpsc::unbounded` driven by a tokio task that reads bytes from the HTTP response, frames them via [`SseBuffer`](../../src/crates/primer-inference/src/cloud/sse.rs) (Anthropic) or [`NdjsonBuffer`](../../src/crates/primer-inference/src/ollama/ndjson.rs) (Ollama), and forwards parsed events as chunks. A hang means one of three things:
+The streaming pipeline is a `futures::channel::mpsc::unbounded` driven by a tokio task that reads bytes from the HTTP response, frames them via [`SseBuffer`](../../src/crates/primer-inference/src/cloud.rs) (Anthropic; defined inline around line 147) or [`NdjsonBuffer`](../../src/crates/primer-inference/src/ollama.rs) (Ollama; defined inline around line 99), and forwards parsed events as chunks. A hang means one of three things:
 
 1. **The HTTP request never completed handshake.** Check `RUST_LOG=hyper=debug,reqwest=debug`. If you see no `Sending request` line, the issue is config (URL, port, TLS).
 2. **The response was 2xx but the body channel never delivered bytes.** This is the load-bearing case — Anthropic and Ollama can both legitimately keep a connection open with no data while the model warms up, but if it goes on past your retry budget, something is wrong server-side. Add a `tracing::trace!` inside `SseBuffer::push` / `NdjsonBuffer::push` to see whether bytes are arriving but failing to parse.

--- a/docs/devel/09-contributing.md
+++ b/docs/devel/09-contributing.md
@@ -1,0 +1,121 @@
+# Contributing
+
+Welcome. The Primer is a young open-source project — a Socratic AI learning companion for children — and outside contributions are genuinely wanted. This chapter is for the contributor who has read the previous eight chapters (or at least [chapter 1](01-getting-started.md) and [chapter 2](02-architecture-overview.md)), has a change in mind, and wants to know how to land it. It covers the repo workflow, the commit and code-style rules CI enforces, two non-negotiable codebase conventions that deserve special attention because reviewers will flag them every time, where to find work that needs doing, and what to expect when you open a pull request.
+
+The tone of the project is collaborative and direct. Reviewers will ask for changes; this is normal and not personal. The goal is shared — a codebase a child can rely on — and any PR that moves the project toward that goal is welcome, no matter how small.
+
+## Repo workflow
+
+The standard fork-and-PR workflow applies. In brief:
+
+1. Fork the repo on GitHub.
+2. Clone your fork and add the upstream remote: `git remote add upstream https://github.com/<upstream-owner>/primer.git`.
+3. Branch from `main`. Use a short, descriptive name with a category prefix:
+   - `feature/...` for new functionality (e.g. `feature/qnn-backend`)
+   - `fix/...` for bug fixes (e.g. `fix/resampler-tail-flush`)
+   - `docs/...` for documentation-only changes (e.g. `docs/devel-manual`)
+   - `refactor/...`, `test/...`, `chore/...` for the obvious cases
+4. Keep PRs focused. One logical change per PR is much easier to review than a sweep of unrelated improvements.
+5. Push to your fork and open the PR against `main` upstream.
+
+Rebase on top of `main` before opening the PR, and again if `main` advances during review. Merge commits in feature branches make `git log` noisy.
+
+> **Note:** the `src/` directory is the cargo workspace root, but it is not a git submodule — every change still goes through one PR against the repo root. See [chapter 1](01-getting-started.md) for why the workspace lives one level down.
+
+## Commit conventions
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/). The shape is `type(scope): subject`, where the type is one of the following — these are the ones in active use in `git log`:
+
+- `feat:` — new user-visible feature
+- `fix:` — bug fix
+- `docs:` — documentation only
+- `refactor:` — internal restructure with no behaviour change
+- `test:` — adding or fixing tests, no production change
+- `chore:` — build, tooling, deps
+
+Scope is optional but encouraged — `feat(speech):` or `docs(devel):` reads better than a bare `feat:` in `git log --oneline`. The subject should be imperative mood, lowercase, no trailing period: `add silero VAD wrapper`, not `Added silero VAD wrapper.`.
+
+> **Gotcha:** never use `--no-verify` to skip pre-commit hooks. Hooks exist for a reason; if one fails, fix the underlying issue instead of bypassing it. Likewise, never `git commit --amend` after pushing a branch — force-pushing rewrites history out from under reviewers and breaks line-comment threads. If you need to fix a pushed commit, add a follow-up commit; squashing happens at merge time.
+
+## Code style
+
+CI is the source of truth for style. Two commands gate every PR, both run from `src/`:
+
+```bash
+cd src
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+The CI workflow at [.github/workflows/ci.yml](../../.github/workflows/ci.yml) runs `cargo fmt --check`, `cargo clippy --workspace --all-targets` with `RUSTFLAGS=-D warnings`, and `cargo test --workspace --no-fail-fast`. A PR that fails any of these will not merge until it does. Run them locally before pushing — turnaround is faster on your machine than in GitHub Actions.
+
+Before opening a PR:
+
+```bash
+cd src
+cargo fmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```
+
+`cargo fmt` writes the changes; `cargo fmt --all -- --check` (what CI runs) only verifies. The `-D warnings` flag promotes every clippy lint to a hard error, matching CI's `RUSTFLAGS=-D warnings` setting. If clippy flags something you genuinely cannot fix, prefer a narrowly-scoped `#[allow(clippy::lint_name)]` with a comment explaining why, over a workspace-level allow.
+
+> **Note:** the `speech` and `embedding` cargo features pull heavy native deps (ONNX Runtime, espeak-ng) and are not part of the default-features CI build. If your change touches `primer-speech` or `primer-embedding`, build and test those features locally — see [chapter 7](07-speech-and-voice-loop.md) and [chapter 4](04-knowledge-and-retrieval.md).
+
+## No magic numbers
+
+Every numeric in this codebase has a home. Reviewers will flag inline literals every time, so save yourself a round-trip and place them correctly the first time:
+
+- **Invariant constants** go in [primer-core::consts](../../src/crates/primer-core/src/consts.rs), grouped by subsystem (`retry`, `retrieval`, `classifier`, etc.). These are values that have a single right answer for the whole codebase — the BM25 `K1` parameter, the FTS5 minimum-score floor, the RRF fusion `k=60`.
+- **Per-subsystem tunables** go into a `*Settings` struct (`ClassifierSettings`, `ExtractorSettings`, `ComprehensionSettings`, `HybridParams`). Every numeric field on a `*Settings` struct is backed by a default in `consts.rs` — the struct is the runtime knob; the const is the source of truth for the default.
+- **Test-only literals** can stay inline; tests are pinning specific scenarios, not establishing project-wide invariants.
+
+A drift test like `default_mirrors_consts` (see [HybridParams in primer-core](../../src/crates/primer-core/src/lib.rs)) pins the `*Settings::default()` impls to their `consts.rs` values, so changing one without the other fails the test.
+
+> **Why:** numerics that drift in two places silently degrade behaviour. Centralising them in `consts.rs` makes the next person tuning the system able to find every related value in one place — and makes the next sweep test (see [chapter 8](08-testing-and-debugging.md)) easy to write.
+
+## Categorical text columns are normalised
+
+Every categorical text column in every SQLite schema in this codebase is stored as an integer foreign key into a lookup table — never as inline text. This applies to `speakers`, `pedagogical_intents`, `understanding_depths`, `concepts`, `embedding_models`, and any future categorical column. For closed Rust enums (`Speaker`, `PedagogicalIntent`, `UnderstandingDepth`), the Rust enum is the single source of truth and the lookup table is a derived projection that the storage layer regenerates and validates on every `open()`. Drift — a known id with a different name, or an unknown id — is a hard error.
+
+The full mechanics, including how to add a new variant or a new categorical column without writing a custom migration, are in [chapter 5](05-storage-and-sessions.md). When in doubt: enum first, lookup-table seeding follows automatically.
+
+> **Why:** unbounded text in categorical columns is how schemas drift over months. The hard-error discipline catches drift the first time it happens, not the tenth.
+
+## Where to find open work
+
+Several entry points, in rough order of curation:
+
+- **[ROADMAP.md](../../ROADMAP.md)** — the phase plan. Tells you what is shipped, what is in flight, and what is next. The "what is next" section is the place to look for substantial features that match the project's direction.
+- **GitHub Issues** — bugs and feature requests, with labels for `good first issue` and `help wanted` when appropriate. If an issue is unassigned and you want to take it, comment to claim it before starting work.
+- **`// TODO` markers in source** — small, well-scoped tasks left by previous contributors. `git grep -n TODO src/crates` lists them. Each TODO usually has enough context inline to act on; if it does not, ask in the issue tracker before guessing.
+- **[SPECULATIONS_AND_IDEAS.md](../../SPECULATIONS_AND_IDEAS.md)** — open-ended ideas, possible directions, things worth exploring but not yet specced. A good place to find work if you want to propose something the maintainers have not committed to. Open an issue first to discuss before writing code against an idea here — these are exploration prompts, not commitments.
+
+For larger changes, open an issue or a draft PR first to discuss the approach. A 200-line PR that needs to be rewritten is more painful than a 20-line design sketch that can be redirected.
+
+## How to ask for review
+
+Open the PR when CI is green locally. The PR description should answer three questions:
+
+1. **What** does this change do? One paragraph, plain language.
+2. **Why** is the change needed? Link to the issue, the spec, or the user-visible symptom.
+3. **How** to verify? The exact commands a reviewer can run to see the change work — usually `cargo test -p <crate>` plus, for behaviour changes, a CLI invocation.
+
+What reviewers will check:
+
+- **Clippy clean and tests added.** Behaviour changes need test coverage; bug fixes need a regression test that fails without the fix.
+- **`decide_intent` characterization tests.** If your change touches intent routing, every existing test in the [decide_intent suite](../../src/crates/primer-pedagogy/src/prompt_builder.rs) (search for `mod tests`) must still pass, and any new branch in the heuristic needs a new characterization test pinning its behaviour. See [chapter 3](03-inference-and-pedagogy.md) for why this suite is load-bearing.
+- **CLAUDE.md updated if conventions changed.** [CLAUDE.md](../../CLAUDE.md) is the agent-facing source of truth for codebase conventions and gotchas. If your change adds, removes, or modifies a convention — a new schema version, a new background-task pattern, a new `*Settings` field, a new gotcha worth warning the next contributor about — update CLAUDE.md in the same PR.
+- **Schema migrations are idempotent and additive.** If you added a new schema version, the migration must follow the pattern in [chapter 5](05-storage-and-sessions.md) — `CREATE IF NOT EXISTS`, `pragma_table_info` checks before `ALTER`, the whole body wrapped in `conn.unchecked_transaction()`. Review will be strict here.
+- **No `unwrap()` or `expect()` in production code paths.** Test code is fine; production code propagates via `?` or maps to a `PrimerError` variant.
+
+> **Note:** the project does not currently ship a PR template under `.github/`. Use the three-question structure above and you will be in the right shape.
+
+Reviewers aim to leave first feedback within a few days. If a PR sits for longer than a week with no comment, ping it — sometimes things slip.
+
+## License
+
+The Primer is licensed under the **GNU Affero General Public License v3.0** — see [LICENSE](../../LICENSE) for the full text. The AGPL was chosen deliberately: it ensures that downstream users of the Primer (including those running it as a hosted service) retain the same right to inspect, modify, and rebuild the system that the original users have. For a children's product where the data flow includes deeply personal conversational records, that transparency is the point.
+
+Contributions are accepted under the same license — by opening a PR you agree your contribution is licensed under AGPL-3.0. The project does not currently require a separate Contributor License Agreement.

--- a/docs/devel/index.md
+++ b/docs/devel/index.md
@@ -1,0 +1,73 @@
+# Developer / contributor manual
+
+Welcome. This manual is for **external open-source contributors** who want to understand how the Primer is built, find their way around the workspace, and land changes that fit the project's pedagogical and architectural intent.
+
+It covers: how to clone and run the project, how the twelve crates fit together, where the pedagogical "soul" lives, how each subsystem (inference, retrieval, storage, classifiers, speech) is structured, how to test and debug locally, and how to send a pull request that we can merge with confidence.
+
+It does **not** cover: the product vision (see [README.md](../../README.md) and [primer_technical_spec.md](../../primer_technical_spec.md)), the long-range phase plan ([ROADMAP.md](../../ROADMAP.md)), or speculative ideas not yet on the roadmap ([SPECULATIONS_AND_IDEAS.md](../../SPECULATIONS_AND_IDEAS.md)). It is also **not** a user manual — it assumes you intend to read or change code.
+
+> **Note:** if you are an AI agent reading this, the same content (in tighter form, without the welcome) lives in [CLAUDE.md](../../CLAUDE.md) at the repo root. The two files are kept consistent by hand; if they ever drift, CLAUDE.md is authoritative for agent-facing conventions and this manual is authoritative for narrative explanation.
+
+## Reading paths
+
+Three suggested orderings depending on why you are here:
+
+- **I'm new and want to contribute** → start with [Getting started](01-getting-started.md), then [Architecture overview](02-architecture-overview.md), then [Contributing](09-contributing.md), then pick a subsystem chapter that interests you.
+- **I want to add feature X** → look up the recipe in the [How do I…?](#how-do-i) table below; each recipe links into the relevant chapter and gives numbered steps.
+- **I want to understand subsystem Y** → jump straight to its chapter. Chapters 03–07 each stand on their own; chapter 02 is recommended pre-reading but not required.
+
+## Chapters
+
+| # | Chapter | What it covers |
+|---|---|---|
+| 01 | [Getting started](01-getting-started.md) | Clone, build, first run, env files, tests, logging. |
+| 02 | [Architecture overview](02-architecture-overview.md) | Trait-based abstraction, the 12-crate graph, pedagogical principles. |
+| 03 | [Inference and pedagogy](03-inference-and-pedagogy.md) | `InferenceBackend` impls, `DialogueManager`, `decide_intent`, retry, error i18n. |
+| 04 | [Knowledge and retrieval](04-knowledge-and-retrieval.md) | FTS5 + hybrid retrieval, embedders, seed corpus, locales. |
+| 05 | [Storage and sessions](05-storage-and-sessions.md) | Session/learner stores, schema migrations, long-term memory. |
+| 06 | [Classifiers and learner model](06-classifiers-and-learner-model.md) | Classifier/extractor/comprehension trio, vocab Leitner box. |
+| 07 | [Speech and voice loop](07-speech-and-voice-loop.md) | VAD/STT/TTS, vendored crates, speech_loop state machine. |
+| 08 | [Testing and debugging](08-testing-and-debugging.md) | Test layout, RUST_LOG, common pitfalls, debugging recipes. |
+| 09 | [Contributing](09-contributing.md) | PR workflow, commits, style, where to find open work. |
+
+## How do I…?
+
+| Task | Recipe |
+|---|---|
+| Add a new `InferenceBackend` | [03-inference-and-pedagogy.md#recipe--add-a-new-inferencebackend](03-inference-and-pedagogy.md#recipe--add-a-new-inferencebackend) |
+| Add a new `PedagogicalIntent` | [03-inference-and-pedagogy.md#recipe--add-a-new-pedagogicalintent](03-inference-and-pedagogy.md#recipe--add-a-new-pedagogicalintent) |
+| Add or tune seed passages | [04-knowledge-and-retrieval.md#recipe--add-or-tune-seed-passages](04-knowledge-and-retrieval.md#recipe--add-or-tune-seed-passages) |
+| Add a new locale | [04-knowledge-and-retrieval.md#recipe--add-a-new-locale](04-knowledge-and-retrieval.md#recipe--add-a-new-locale) |
+| Add a schema migration | [05-storage-and-sessions.md#recipe--add-a-schema-migration](05-storage-and-sessions.md#recipe--add-a-schema-migration) |
+| Add a structured-output classifier | [06-classifiers-and-learner-model.md#recipe--add-a-structured-output-classifier](06-classifiers-and-learner-model.md#recipe--add-a-structured-output-classifier) |
+| Add a speech backend | [07-speech-and-voice-loop.md#recipe--add-a-speech-backend](07-speech-and-voice-loop.md#recipe--add-a-speech-backend) |
+| Diagnose a quiet classifier | [08-testing-and-debugging.md#recipe--diagnose-a-quiet-classifier](08-testing-and-debugging.md#recipe--diagnose-a-quiet-classifier) |
+| Run / test / debug locally | [08-testing-and-debugging.md](08-testing-and-debugging.md) |
+
+## Conventions used in this manual
+
+The chapters use a small set of callout markers so the eye can skip to the bit it needs:
+
+- `> **Note:**` — an aside that doesn't change behaviour, just adds context.
+- `> **Gotcha:**` — something that has bitten contributors (or the maintainer) before. Almost every CLAUDE.md "gotcha" appears as one of these in the relevant chapter; if you find a behaviour that surprised you and there is no gotcha for it yet, that is a great PR.
+- `> **Why:**` — rationale for a non-obvious design choice. When you see one of these, the answer to "why didn't they just do X instead?" is in the box.
+- `> **Recipe — <Action>:**` — a worked example with numbered steps. Recipes are linked from the [How do I…?](#how-do-i) table above.
+
+Inline code references use markdown links pointing at the relevant file (and sometimes a line range), e.g. `primer-pedagogy/src/dialogue_manager/turn.rs`. Paths are relative to `src/` (the workspace root) unless the link explicitly starts with `../` to escape into the repo root for `README.md` / `ROADMAP.md` / similar.
+
+Code blocks that show file content start with a path comment so you know where the snippet lives:
+
+```rust
+// src/crates/primer-core/src/lib.rs
+pub trait InferenceBackend: Send + Sync { /* ... */ }
+```
+
+Shell commands assume you are in `src/` unless explicitly noted, because the workspace root is `src/Cargo.toml`, not the repo root.
+
+## External resources
+
+- [README.md](../../README.md) — product pitch, status, what works today.
+- [ROADMAP.md](../../ROADMAP.md) — phase plan; what is built, what is next, what is deferred.
+- [primer_technical_spec.md](../../primer_technical_spec.md) — long-form vision and design rationale.
+- [CLAUDE.md](../../CLAUDE.md) — agent-facing conventions and gotchas (terser, denser, same content as this manual).
+- [SPECULATIONS_AND_IDEAS.md](../../SPECULATIONS_AND_IDEAS.md) — open ideas that have not yet been planned.

--- a/docs/devel/index.md
+++ b/docs/devel/index.md
@@ -25,8 +25,8 @@ Three suggested orderings depending on why you are here:
 | 03 | [Inference and pedagogy](03-inference-and-pedagogy.md) | `InferenceBackend` impls, `DialogueManager`, `decide_intent`, retry, error i18n. |
 | 04 | [Knowledge and retrieval](04-knowledge-and-retrieval.md) | FTS5 + hybrid retrieval, embedders, seed corpus, locales. |
 | 05 | [Storage and sessions](05-storage-and-sessions.md) | Session/learner stores, schema migrations, long-term memory. |
-| 06 | [Classifiers and learner model](06-classifiers-and-learner-model.md) | Classifier/extractor/comprehension trio, vocab Leitner box. |
-| 07 | [Speech and voice loop](07-speech-and-voice-loop.md) | VAD/STT/TTS, vendored crates, speech_loop state machine. |
+| 06 | [Classifiers and the learner model](06-classifiers-and-learner-model.md) | Classifier/extractor/comprehension trio, vocab Leitner box. |
+| 07 | [Speech and the voice loop](07-speech-and-voice-loop.md) | VAD/STT/TTS, vendored crates, speech_loop state machine. |
 | 08 | [Testing and debugging](08-testing-and-debugging.md) | Test layout, RUST_LOG, common pitfalls, debugging recipes. |
 | 09 | [Contributing](09-contributing.md) | PR workflow, commits, style, where to find open work. |
 
@@ -71,3 +71,4 @@ Shell commands assume you are in `src/` unless explicitly noted, because the wor
 - [primer_technical_spec.md](../../primer_technical_spec.md) — long-form vision and design rationale.
 - [CLAUDE.md](../../CLAUDE.md) — agent-facing conventions and gotchas (terser, denser, same content as this manual).
 - [SPECULATIONS_AND_IDEAS.md](../../SPECULATIONS_AND_IDEAS.md) — open ideas that have not yet been planned.
+- [LICENSE](../../LICENSE) — AGPL-3.0; see chapter 09 for what that means for contributors.

--- a/docs/superpowers/plans/2026-05-08-developer-manual.md
+++ b/docs/superpowers/plans/2026-05-08-developer-manual.md
@@ -1,0 +1,1102 @@
+# Developer/Contributor Manual Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a 10-file developer manual in `docs/devel/` that takes an external OSS contributor from "I cloned the repo" to "I can confidently submit a PR to any subsystem", with deep-linkable how-to recipes embedded in their natural chapters.
+
+**Architecture:** Per-subsystem chapter split. Numbered files for deterministic reading order; titles (not numbers) referenced in cross-links. Recipes live as h3 headings inside their natural chapter; the index has a flat "How do I…?" lookup table that deep-links to those recipe anchors. Mermaid diagrams use a manual-wide colour palette (white text on saturated dark fills + brighter strokes) tuned for legibility on both GitHub light and dark themes; an ASCII fallback follows the load-bearing crate-graph diagram.
+
+**Tech Stack:** Plain markdown (CommonMark + GitHub-flavoured). Mermaid for diagrams. No site generator — files are read directly on GitHub or in-IDE.
+
+**Spec:** [docs/superpowers/specs/2026-05-08-developer-manual-design.md](../specs/2026-05-08-developer-manual-design.md). Every task references the relevant spec section.
+
+---
+
+## Conventions enforced by every chapter task
+
+These are checked by the verification step in every chapter task. They come from spec §5.
+
+- **Callouts** use blockquote prefixes: `> **Note:**`, `> **Gotcha:**`, `> **Why:**`, `> **Recipe — <Action>:**` (note the em-dash + space; this drives the GitHub anchor slug).
+- **Code references in prose** use markdown links, never bare backticks for paths. Format: `[turn.rs:120](src/crates/primer-pedagogy/src/dialogue_manager/turn.rs#L120)`.
+- **Code blocks** are tagged with the language (` ```rust `, ` ```bash `, ` ```sql `, ` ```toml `). For files, the first line is a path comment: `// src/crates/primer-core/src/inference.rs`.
+- **Recipe headings** are h3 of the form `### Recipe — Add a new InferenceBackend.` — GitHub auto-generates the anchor `#recipe--add-a-new-inferencebackend`.
+- **Mermaid diagrams** start with the standard `%%{init: ...}%%` block from spec §5.4 and use `classDef trait/impl/ext/stub` with the manual-wide palette.
+
+---
+
+## Task 1: Create `docs/devel/` and write `01-getting-started.md`
+
+**Files:**
+- Create: `docs/devel/01-getting-started.md`
+
+**Spec reference:** §4.2.
+
+- [ ] **Step 1: Create the directory**
+
+```bash
+mkdir -p docs/devel
+```
+
+- [ ] **Step 2: Write `01-getting-started.md`**
+
+Required top-level structure (h1 → h2 only; chapter is short enough that h3s aren't needed):
+
+```markdown
+# Getting started
+
+Welcome paragraph: who this manual is for, what this chapter covers.
+
+## Prerequisites
+
+- rustup (NOT Homebrew rust)
+- (optional) espeak-ng for --speech mode
+- (optional) Anthropic API key for cloud backend
+
+> **Gotcha:** Homebrew rust shadows rustup on $PATH and ignores rust-toolchain.toml. The `silero` and `whisper` features need Rust 1.87+. Always invoke as `~/.cargo/bin/cargo` for primer commands, or remove Homebrew rust from $PATH.
+
+## Cloning and the workspace layout
+
+> **Gotcha:** The workspace root is `src/Cargo.toml`, not the repo root. Every cargo command runs from `src/`. There is no `Cargo.toml` at the repo root.
+
+```bash
+git clone https://github.com/<org>/primer.git
+cd primer/src
+cargo build
+```
+
+## First run (stub backend, no API key)
+
+```bash
+cargo run --bin primer
+```
+
+## Cloud backend (Anthropic)
+
+Env-file precedence: project-local `.env` (searched up from cwd) overrides user-global `~/.primer_env`.
+
+```bash
+cp ../.env.example ../.env
+# edit ../.env to add ANTHROPIC_API_KEY=...
+cargo run --bin primer -- --backend cloud --name Binti --age 8
+```
+
+## Ollama backend
+
+```bash
+cargo run --bin primer -- --backend ollama --model llama3.2
+```
+
+## Embeddings (hybrid retrieval)
+
+> **Note:** First run downloads BGE-M3 (~570 MB) into `~/.cache/primer/models/`. This is expected, not a hang.
+
+```bash
+cargo run --bin primer --features primer-cli/embedding -- --embedder-backend fastembed
+```
+
+## Voice mode (speech)
+
+> **Gotcha:** `--speech` requires system espeak-ng. macOS: `brew install espeak-ng`. Debian/Ubuntu: `apt install espeak-ng-data`.
+
+```bash
+cargo run --bin primer --features primer-cli/speech -- \
+  --speech \
+  --whisper-model <path>.bin \
+  --voice-onnx <path>.onnx \
+  --voice-config <path>.onnx.json \
+  --voice <model-id>
+```
+
+## Tests, logging, verbose output
+
+```bash
+cargo test                              # all tests
+cargo test -p primer-pedagogy           # one crate
+cargo test -p primer-pedagogy decide    # by substring
+RUST_LOG=debug cargo run --bin primer
+cargo run --bin primer -- --verbose     # pedagogy-flow tracing on stderr
+```
+
+## Where session data lives
+
+`~/.primer/<slugified-name>.db` by default. Pass `--no-persist` for in-memory only.
+
+## What to read next
+
+→ [02-architecture-overview.md](02-architecture-overview.md) for the big picture.
+→ [09-contributing.md](09-contributing.md) for PR workflow.
+```
+
+- [ ] **Step 3: Verify required headings are present**
+
+```bash
+grep -c '^## ' docs/devel/01-getting-started.md
+# Expected: 8 (Prerequisites, Cloning..., First run, Cloud, Ollama, Embeddings, Voice, Tests..., Where..., What...)
+# Actually 9 — adjust grep count match accordingly
+```
+
+```bash
+grep -c '> \*\*Gotcha:' docs/devel/01-getting-started.md
+# Expected: ≥ 3
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/devel/01-getting-started.md
+git commit -m "docs(devel): getting-started chapter"
+```
+
+---
+
+## Task 2: Write `02-architecture-overview.md` (with mermaid crate graph)
+
+**Files:**
+- Create: `docs/devel/02-architecture-overview.md`
+
+**Spec reference:** §4.3, §5.4 (mermaid styling).
+
+- [ ] **Step 1: Write the chapter**
+
+Required structure:
+
+```markdown
+# Architecture overview
+
+## The central design principle
+
+Trait-based hardware abstraction. Backend selection is a runtime config choice, not a code change. This is what allows Phase 0 (cloud) to share code with Phase 1 (local NPU) and Phase 2 (voice).
+
+## The crate graph
+
+The workspace is twelve crates organised in three layers: a binary at the top, a pedagogical engine in the middle, and a constellation of trait-implementing crates at the bottom that all depend on `primer-core` (which defines every public trait).
+
+> **Legend:** blue = trait/interface (defined in `primer-core`); green = concrete implementation; amber = external boundary (HTTP, filesystem, vendor); grey = stub / test-only.
+
+```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'fontSize': '16px',
+    'fontFamily': 'system-ui, -apple-system, sans-serif',
+    'primaryColor': '#1e3a5f',
+    'primaryTextColor': '#ffffff',
+    'primaryBorderColor': '#4a90d9',
+    'lineColor': '#888888',
+    'secondaryColor': '#2d5016',
+    'tertiaryColor': '#5a3a1e'
+  }
+}}%%
+graph LR
+  classDef trait fill:#1e3a5f,stroke:#4a90d9,stroke-width:2px,color:#ffffff
+  classDef impl  fill:#2d5016,stroke:#5cb85c,stroke-width:2px,color:#ffffff
+
+  CLI[primer-cli]:::impl
+  PED[primer-pedagogy]:::impl
+  CORE[primer-core<br/>traits + types]:::trait
+  INF[primer-inference]:::impl
+  KB[primer-knowledge]:::impl
+  STO[primer-storage]:::impl
+  CLS[primer-classifier]:::impl
+  EXT[primer-extractor]:::impl
+  CMP[primer-comprehension]:::impl
+  EMB[primer-embedding]:::impl
+  KBL[primer-kb-load]:::impl
+  SP[primer-speech]:::impl
+
+  CLI --> PED
+  PED --> CORE
+  INF --> CORE
+  KB --> CORE
+  STO --> CORE
+  CLS --> CORE
+  EXT --> CORE
+  CMP --> CORE
+  EMB --> CORE
+  KBL --> CORE
+  SP --> CORE
+```
+
+ASCII fallback for environments where mermaid does not render:
+
+```
+primer-cli  →  primer-pedagogy  →  primer-core  ←  primer-inference, primer-speech, primer-knowledge, primer-storage, primer-classifier, primer-comprehension, primer-extractor, primer-embedding, primer-kb-load
+```
+
+## Crate-by-crate
+
+| Crate | Owns | Chapter |
+|---|---|---|
+| `primer-core` | every trait + shared types + consts + i18n + retry | §3-§7 |
+| `primer-inference` | `InferenceBackend` impls (stub, cloud, ollama) | [03](03-inference-and-pedagogy.md) |
+| `primer-pedagogy` | `DialogueManager`, `prompt_builder`, `decide_intent` | [03](03-inference-and-pedagogy.md) |
+| `primer-knowledge` | `SqliteKnowledgeBase`, FTS5 + hybrid retrieval | [04](04-knowledge-and-retrieval.md) |
+| `primer-embedding` | `Embedder` impls (stub, fastembed, ollama) | [04](04-knowledge-and-retrieval.md) |
+| `primer-kb-load` | JSONL ingestion, auto-seed, `--reembed` | [04](04-knowledge-and-retrieval.md) |
+| `primer-storage` | `SessionStore`, `LearnerStore`, schema migrations | [05](05-storage-and-sessions.md) |
+| `primer-classifier` | engagement classifier | [06](06-classifiers-and-learner-model.md) |
+| `primer-extractor` | concept extractor | [06](06-classifiers-and-learner-model.md) |
+| `primer-comprehension` | comprehension classifier | [06](06-classifiers-and-learner-model.md) |
+| `primer-speech` | VAD/STT/TTS impls + speech_loop helpers | [07](07-speech-and-voice-loop.md) |
+| `primer-cli` | the REPL binary `primer` | [03](03-inference-and-pedagogy.md), [08](08-testing-and-debugging.md) |
+
+## The four pedagogical principles
+
+These are constraints on every change; if a change makes the Primer more answer-y or more engagement-maximising, it is wrong.
+
+1. The Primer asks more questions than it answers; pure factual questions get a direct answer, then a Socratic pivot.
+2. The Primer never tries to maximise engagement. It detects frustration/disengagement and offers breaks, scaffolding, or session close — never guilt.
+3. All learner data is local; cloud inference sends turns per-request only.
+4. Comprehension is verified through transfer questions, application, and contradiction probing — not assumed from a confident-sounding response.
+
+## Status
+
+→ [README.md](../../README.md) for what works today.
+→ [ROADMAP.md](../../ROADMAP.md) for the phase plan.
+→ [primer_technical_spec.md](../../primer_technical_spec.md) for the long-form vision.
+```
+
+- [ ] **Step 2: Verify mermaid block + ASCII fallback + 12-row table**
+
+```bash
+grep -c '```mermaid' docs/devel/02-architecture-overview.md
+# Expected: 1
+grep -c '^| primer-' docs/devel/02-architecture-overview.md
+# Expected: 12
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/devel/02-architecture-overview.md
+git commit -m "docs(devel): architecture overview with crate graph"
+```
+
+---
+
+## Task 3: Write `03-inference-and-pedagogy.md`
+
+**Files:**
+- Create: `docs/devel/03-inference-and-pedagogy.md`
+
+**Spec reference:** §4.4. Two recipes required.
+
+- [ ] **Step 1: Write the chapter**
+
+Required structure:
+
+```markdown
+# Inference and pedagogy
+
+## The `InferenceBackend` trait
+
+(Describe the three required methods: `generate`, `generate_stream`, `summarize`. Show the trait signature with a code-reference link to [inference.rs](src/crates/primer-core/src/inference.rs).)
+
+## The three concrete backends
+
+### `StubBackend`
+Canned Socratic responses, no model. The fallback path that lets the REPL run with no API key.
+
+### `CloudBackend` (Anthropic SSE)
+Hand-rolled `SseBuffer` + `parse_anthropic_event`. `Role::System` is mapped to `"user"` in the messages array because the Anthropic API has system instructions as a top-level field. Link to [cloud.rs](src/crates/primer-inference/src/cloud.rs).
+
+### `OllamaBackend` (NDJSON)
+`NdjsonBuffer` + `parse_ollama_line`. Prepends a `system`-role message because Ollama's chat API has no separate system field. Link to [ollama.rs](src/crates/primer-inference/src/ollama.rs).
+
+> **Gotcha:** The two backends differ in how they handle system messages. Watch this divergence when reworking prompt assembly.
+
+## The retry layer
+
+Pre-stream only — once `generate_stream` starts consuming bytes from a 2xx response, mid-stream errors propagate cleanly and the partial Primer turn drops at the dialogue-manager layer. Both backends wrap the pre-stream phase in `primer_core::retry::retry_with_backoff`. The retry helper is HTTP-neutral; backends translate their own status codes via `classify_anthropic_status` / `classify_ollama_status` before invoking it. Defaults: 3 attempts × ~250 ms × 2 ≈ ~1.75 s worst case before failure.
+
+## The typed `InferenceError`
+
+Six variants: `Auth`, `RateLimited`, `ServiceUnavailable`, `NetworkUnavailable`, `ModelNotFound`, `Other`.
+
+> **Why:** `Other`'s inner string is dev-facing only — it never reaches users. The i18n layer in `primer_core::i18n::render_inference_error` substitutes a generic message and the call site logs the full error via `tracing::warn!`.
+
+## `DialogueManager`
+
+Lives at [dialogue_manager/](src/crates/primer-pedagogy/src/dialogue_manager/). Directory module split by axis:
+
+- `mod.rs` — struct + glue
+- `lifecycle.rs` — new / open / resume / close
+- `turn.rs` — `respond_to_streaming` orchestrator + 7 private helpers
+- `background.rs` — await/drain/apply for classifier+extractor+comprehension tasks
+- `retrieval.rs` — knowledge + long-term-memory retrieval
+- `summary.rs` — refresh-summary cadences
+- `learner_update.rs` — engagement-state heuristic (placeholder)
+- `apply.rs` — pure free fns + their unit tests
+
+When adding a new method, place it in the file matching its responsibility and use `pub(super)` visibility for cross-module access.
+
+## `decide_intent()`
+
+The brain of the Socratic behaviour. Lives in [prompt_builder/](src/crates/primer-pedagogy/src/prompt_builder/). The most important function to test rigorously when adding pedagogical features. Characterization tests in `prompt_builder::tests` pin current behaviour (18 tests at time of writing).
+
+> **Note:** When you change intent routing, add a characterization test for the new branch BEFORE the implementation. The test pins the routing case and prevents regression.
+
+---
+
+### Recipe — Add a new `InferenceBackend`
+
+Worked example: adding a hypothetical `OpenAIBackend`.
+
+1. **Implement the trait.** Create `primer-inference/src/openai.rs`. Implement `generate`, `generate_stream`, `summarize`.
+2. **Hand-roll the streaming.** OpenAI uses SSE like Anthropic; reuse `SseBuffer` (or implement your own `parse_*_event`). Forward chunks via `futures::channel::mpsc::unbounded` driven by a spawned tokio task.
+3. **Map errors to `InferenceError`.** Add a `classify_openai_status(status: StatusCode) -> InferenceError` helper. Map 401 → `Auth`, 429 → `RateLimited` (parse `Retry-After`), 404 → `ModelNotFound`, 5xx → `ServiceUnavailable`, network → `NetworkUnavailable`, everything else → `Other`. Never embed user-facing strings in the variants.
+4. **Wrap the pre-stream phase in `retry_with_backoff`.** Pattern from `cloud.rs`:
+
+```rust
+// src/crates/primer-inference/src/openai.rs
+let resp = retry_with_backoff(retry_settings, || async {
+    let r = client.post(&url).headers(headers.clone()).json(&body).send().await?;
+    classify_openai_status(r.status()).map(|err| Err(err))?;
+    Ok(r)
+}).await?;
+```
+
+5. **Register in `primer-cli`.** Add an `OpenAi` variant to the `Backend` enum in `primer-cli/src/backend.rs`. Wire construction in the factory function.
+6. **Add the `--backend openai` clap variant.** Plus `--openai-api-key` (or env var fallback) following the `--api-key` pattern.
+7. **Write integration tests.** Stub the HTTP layer with `wiremock` or similar. Test: success → chunks arrive in order; 429 → retry honours `Retry-After`; mid-stream disconnect → error propagates without recording the partial turn.
+8. **Update `README.md`** to mention the new backend in the supported-backends list.
+
+### Recipe — Add a new `PedagogicalIntent`
+
+Worked example: adding `Celebrate` (acknowledge a breakthrough moment).
+
+1. **Add the variant to the enum.** Edit `primer-core/src/intent.rs`:
+
+```rust
+// src/crates/primer-core/src/intent.rs
+pub enum PedagogicalIntent {
+    // ...existing variants...
+    Celebrate = 10,
+}
+```
+
+The integer value is the lookup-table id. Pick the next unused id — never reuse a retired one (see [05-storage-and-sessions.md](05-storage-and-sessions.md) for why).
+
+2. **Add a routing branch in `decide_intent`.** In [prompt_builder/decide_intent.rs](src/crates/primer-pedagogy/src/prompt_builder/decide_intent.rs), add the heuristic that routes to `Celebrate`. Keep it deterministic — engagement-state overrides should still win.
+
+3. **Extend the prompt builder.** In `build_system_prompt_with_pack_and_vocab`, add a section for the `Celebrate` intent describing how the Primer should celebrate (briefly, then pivot back to inquiry — never break principle 2).
+
+4. **Add a characterization test.** In `prompt_builder::tests`:
+
+```rust
+// src/crates/primer-pedagogy/src/prompt_builder/tests.rs
+#[test]
+fn celebrate_when_child_makes_correct_synthesis() {
+    let intent = decide_intent(&fixture_for_synthesis_moment());
+    assert_eq!(intent, PedagogicalIntent::Celebrate);
+}
+```
+
+5. **Open any test session DB.** The lookup-table seeder in `primer-storage` validates the in-DB rows against the Rust enum on every `open()`; a new variant gets seeded automatically. No migration step required for the enum addition itself.
+
+6. **Update the CLAUDE.md gotcha** if the new intent has cross-cutting behaviour.
+
+---
+
+(remaining sections: see spec §4.4)
+```
+
+- [ ] **Step 2: Verify two recipe headings exist**
+
+```bash
+grep -c '^### Recipe — ' docs/devel/03-inference-and-pedagogy.md
+# Expected: 2
+```
+
+- [ ] **Step 3: Verify load-bearing internal links**
+
+```bash
+grep -c '02-architecture-overview\|05-storage-and-sessions\|src/crates/primer-' docs/devel/03-inference-and-pedagogy.md
+# Expected: ≥ 5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/devel/03-inference-and-pedagogy.md
+git commit -m "docs(devel): inference & pedagogy chapter"
+```
+
+---
+
+## Task 4: Write `04-knowledge-and-retrieval.md`
+
+**Files:**
+- Create: `docs/devel/04-knowledge-and-retrieval.md`
+
+**Spec reference:** §4.5. Two recipes required.
+
+- [ ] **Step 1: Write the chapter**
+
+Required sections (each as h2 unless noted):
+
+- `# Knowledge and retrieval`
+- `## The KnowledgeBase trait` — show signature; reference [knowledge.rs](src/crates/primer-core/src/knowledge.rs).
+- `## SqliteKnowledgeBase schema` — per-locale `passages_<pack_id>` (FTS5) + `passages_<pack_id>_meta` + `embeddings_<pack_id>`. Cross-locale: `sources`, `embedding_models`. Schema at user_version 3.
+- `## BM25 ranking` — explain the negative-rank flip in the public API.
+- `## Hybrid retrieval` — `retrieve_hybrid`, BM25 leg + dense-vector cosine leg, RRF fusion, `HybridParams::default()` from `primer_core::consts::retrieval`. Mermaid sub-diagram showing the two-leg fusion is OPTIONAL but recommended.
+- `## The Embedder trait` — three impls (`StubEmbedder`, `FastEmbedBackend`, `OllamaEmbedder`). Discuss the `embedding_models` invariant.
+- `## Auto-seed and multi-file discovery` — `$PRIMER_SEED_DIR` → `$XDG_DATA_HOME/primer/seed/` → walking up from `CARGO_MANIFEST_DIR`. Lexicographic load order. Multi-layer corpus.
+- `## Wikipedia ingestion pipeline` — `data/ingest/`, Python, network as test boundary. How to regenerate. Whitelist hand-curation.
+- `## Sweep tests` — BM25-only at `tests/retrieval_sweep.rs`, hybrid at `tests/retrieval_sweep_hybrid.rs`. Tuned defaults.
+
+Required callouts (≥ 4):
+
+- `> **Gotcha:**` — `--embedder-backend stub` is for testing only; in production it dilutes BM25 with hash noise.
+- `> **Gotcha:**` — first-run BGE-M3 download is ~570 MB; falls back to BM25-only with a `tracing::warn!` if the download fails.
+- `> **Gotcha:**` — `embedding` and `speech` features both pin `ort = "=2.0.0-rc.10"`; bumping fastembed past 5.7.0 will break the speech build.
+- `> **Note:**` — when no `Embedder` is wired, `retrieve_hybrid`'s default trait impl falls back to BM25-only, so every consumer can call it unconditionally.
+
+Required recipes (h3, two of them):
+
+`### Recipe — Add or tune seed passages`
+
+Steps:
+1. Edit `data/seed/seed_passages.<pack>.jsonl` (or add a new layer file `*.<pack>.jsonl`). Each entry needs `id`, `body`, `source` attribution.
+2. Add (or update) the corresponding row in the `sources` table seeding logic if the licence/attribution is new.
+3. Run `cargo test -p primer-knowledge --test retrieval_sweep` to check BM25-only recall hasn't regressed.
+4. Run `cargo test -p primer-knowledge --test retrieval_sweep_hybrid --features fastembed --ignored` to check hybrid recall hasn't regressed.
+5. If a previously failing query now resolves, remove its entry from `KNOWN_FAILING_QUERIES` / `KNOWN_FAILING_QUERIES_HYBRID` in `tests/common/mod.rs`.
+6. Commit the JSONL change AND the test-list change in one commit.
+
+Show the JSONL row format:
+
+```jsonl
+{"id":"sun_shine_01","body":"The Sun shines because of nuclear fusion in its core...","source":"hand-drafted-cc0"}
+```
+
+`### Recipe — Add a new locale`
+
+Steps:
+1. Add `Locale` variant to `primer-core/src/i18n.rs`. Pick a stable string id (`"de"`, `"ja"`).
+2. Add a TOML pack file under `primer-core/i18n/<id>.toml` mirroring `en.toml`. Every locale-specific user-visible string lives here, including `break_suggestion_intro` with a locale-appropriate `{minutes}` substitution.
+3. Add seed JSONL: `data/seed/seed_passages.<id>.jsonl` (and optionally `wiki_passages.<id>.jsonl` regenerated via `data/ingest/`).
+4. Open the KB with `SqliteKnowledgeBase::open_for_locale(path, locale)`. No migration step — locale-scoped tables are created on demand.
+5. Test the locale guard on `--resume`: opening a session with a different `--language` than the stored learner locale must error with the two-resolution hint.
+6. Run `cargo test -p primer-pedagogy locale` and `cargo test -p primer-knowledge locale` to confirm locale-scoping invariants.
+7. (Cross-link) See [05-storage-and-sessions.md](05-storage-and-sessions.md) for the per-learner `learners.locale` field that stores the locale alongside the session.
+
+- [ ] **Step 2: Verify recipe count and seed-discovery mention**
+
+```bash
+grep -c '^### Recipe — ' docs/devel/04-knowledge-and-retrieval.md
+# Expected: 2
+grep -c 'PRIMER_SEED_DIR\|XDG_DATA_HOME' docs/devel/04-knowledge-and-retrieval.md
+# Expected: ≥ 1 (each)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/devel/04-knowledge-and-retrieval.md
+git commit -m "docs(devel): knowledge & retrieval chapter"
+```
+
+---
+
+## Task 5: Write `05-storage-and-sessions.md`
+
+**Files:**
+- Create: `docs/devel/05-storage-and-sessions.md`
+
+**Spec reference:** §4.6. One recipe required.
+
+- [ ] **Step 1: Write the chapter**
+
+Required sections:
+
+- `# Storage and sessions`
+- `## Privacy split` — per-child session DB at `~/.primer/<slug>.db`, separate from RAG corpus.
+- `## SessionStore and LearnerStore traits` — show signatures.
+- `## Schema-migration pattern` — idempotent `CREATE IF NOT EXISTS` and `pragma_table_info` ALTER guards, transaction-wrapped, version bump, drift validation against Rust enums on every `open()`.
+- `## Lookup-table normalisation` — every categorical text column is a foreign key; closed Rust enums are the source of truth; the DB seeder regenerates and validates on every open. **Drift is a hard error.** Adding a new variant means: edit the Rust source → recompile → next `open()` seeds the row. **Retired integer IDs are never reused.**
+- `## The append-only invariant on save_session` — and why `update_turn_concepts` exists as the explicit backfill path. Don't move concept persistence back into `save_session`.
+- `## FTS5 query sanitisation` — `sanitize_fts_phrase`, OR-join with quoted tokens, BM25 + `LIMIT k`. This is what allows `retrieve_session_turns` to take raw child input safely.
+- `## Long-term memory layered into the system prompt` — chat timeline stays linear; summary + retrieved-older turns inject into system prompt.
+- `## Turn-embedding-on-save` — `tokio::spawn`, fire-and-forget. Idempotent at the storage layer.
+- `## Schema versions, in order` — table summarising v2 through v8. One line per migration.
+
+Required callouts (≥ 3):
+
+- `> **Why:**` — Privacy split: per-child session DBs are separate from the RAG corpus because they contain conversational PII; never merge them.
+- `> **Gotcha:**` — Drift in lookup tables is a hard error. There is no API for mutating lookup tables. Adding a variant means recompile + reopen.
+- `> **Gotcha:**` — Schema USER_VERSION newer than this build is a hard error (rejected on open). Older is silently upgraded.
+
+Required recipe:
+
+`### Recipe — Add a schema migration`
+
+Steps:
+1. **Bump `USER_VERSION` in `primer-storage/src/schema.rs`.** From N to N+1.
+2. **Add `apply_vN1_migrations`** following the v7/v8 template. Show full annotated example using a real recent migration as the model. Wrap the body in `conn.unchecked_transaction()`. Use `CREATE TABLE IF NOT EXISTS` and `pragma_table_info`-guarded `ALTER TABLE`.
+
+```rust
+// src/crates/primer-storage/src/schema.rs
+fn apply_v9_migrations(conn: &Connection) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+
+    if !column_exists(&tx, "turns", "vibe")? {
+        tx.execute(
+            "ALTER TABLE turns ADD COLUMN vibe INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
+    }
+
+    tx.execute(
+        "CREATE TABLE IF NOT EXISTS vibes (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE
+        )",
+        [],
+    )?;
+
+    tx.commit()?;
+    Ok(())
+}
+```
+
+3. **Wire it into the open path** in `SqliteSessionStore::open` — call after the v8 path, before drift validation.
+4. **Add a migration round-trip test.** `tests/migration_v8_to_v9.rs`: open a fixture v8 DB → assert `user_version` becomes 9 → assert new schema present → assert old data preserved.
+5. **If the migration touches an enum-backed lookup table**, extend the drift-validation `seed_and_validate_*` helper in `lookup_tables.rs`.
+6. **Update CLAUDE.md** — there's a "Schema is at version N" line; bump it.
+
+- [ ] **Step 2: Verify recipe + schema-version table**
+
+```bash
+grep -c '^### Recipe — ' docs/devel/05-storage-and-sessions.md
+# Expected: 1
+grep -E 'v[2-8]' docs/devel/05-storage-and-sessions.md | wc -l
+# Expected: ≥ 7 (one mention per version)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/devel/05-storage-and-sessions.md
+git commit -m "docs(devel): storage & sessions chapter"
+```
+
+---
+
+## Task 6: Write `06-classifiers-and-learner-model.md`
+
+**Files:**
+- Create: `docs/devel/06-classifiers-and-learner-model.md`
+
+**Spec reference:** §4.7. One recipe required.
+
+- [ ] **Step 1: Write the chapter**
+
+Required sections:
+
+- `# Classifiers and the learner model`
+- `## The structured-output trio` — engagement classifier, concept extractor, comprehension classifier. All three follow the same shape: `Trait`, `Llm*Impl` (wraps `Arc<dyn InferenceBackend>`), `Stub*` (with `with_response`/`with_script`).
+- `## The spawn / await / detach-on-timeout pattern` — applied identically across all three. Diagram (mermaid) showing the timing relative to the conversational turn loop.
+- `## Soft-fail discipline` — classifier/extractor/comprehension errors NEVER propagate; log via `tracing::warn!` and return empty/unknown.
+- `## The chain inside the dialogue manager` — `(classifier task) || (extractor → comprehension chain)`. Combined timeout. Why both lag one turn for in-memory state but not for DB persistence.
+- `## The LearnerModel umbrella` — `LearnerProfile` + `Vec<ConceptState>` + `LearningPreferences` + latest engagement snapshot. Edit the leaf, not the umbrella. `LearningPreferences` serialises as JSON (open-vocabulary); categorical leaves are closed enums backed by lookup tables.
+- `## apply_comprehension is monotonic-max` — a weak exchange never demotes depth; explicit forgetting is a future concern.
+- `## Vocabulary spaced repetition` — `primer_core::vocab::apply_box_transition`, `due_concepts`, Leitner intervals `[1d, 3d, 7d, 14d, 30d]`. Driven by the comprehension classifier, no extra LLM call. Vocab entries ARE `ConceptState` rows — not a separate table.
+- `## Shared utilities` — `extract_first_json_object`, `truncate_to_chars` in `primer_core::llm_util`. Don't reintroduce per-crate copies.
+
+Required callouts (≥ 3):
+
+- `> **Gotcha:**` — Classifier/extractor/comprehension errors NEVER propagate. If you find yourself adding `?` on one of their results, you have a bug.
+- `> **Gotcha:**` — Concepts and comprehension lag one turn for in-memory state. Per-turn DB rows are written immediately; the in-memory `LearnerModel.concepts` only updates at the start of the next turn.
+- `> **Why:**` — `LearningPreferences` is JSON because children's interests don't fit a closed enum; `UnderstandingDepth` is a closed enum because depth has a fixed semantic ladder.
+
+Required recipe:
+
+`### Recipe — Add a structured-output classifier`
+
+Worked example: a hypothetical "tone classifier" that scores child turns on a `cheerful/neutral/anxious` ladder.
+
+Steps (9 total):
+
+1. **Define the trait in your new crate `primer-tone`** following the pattern at [primer-classifier/src/lib.rs](src/crates/primer-classifier/src/lib.rs). Declare an associated output type `ToneAssessment { tone: ToneState, confidence: f32 }`.
+
+2. **Implement `LlmToneClassifier`** wrapping `Arc<dyn InferenceBackend>`. Use `extract_first_json_object` from `primer_core::llm_util` to parse the model's response. Use `truncate_to_chars` to bound the input.
+
+```rust
+// src/crates/primer-tone/src/llm.rs
+let raw = backend.generate(&prompt, params).await
+    .map_err(|e| { tracing::warn!(target: "primer::tone", "{e}"); e })
+    .ok();
+let json = raw.as_deref().and_then(extract_first_json_object);
+let assessment = json.and_then(|s| serde_json::from_str(&s).ok())
+    .unwrap_or_else(ToneAssessment::unknown_low_confidence);
+```
+
+3. **Implement `StubToneClassifier`** with `with_response(ToneAssessment)` and `with_script(VecDeque<ToneAssessment>)` constructors. Used for tests.
+
+4. **Add `ToneSettings`** with every numeric (timeout, recent_context_turns, max_output_chars, confidence_threshold, generation_*) backed by constants in `primer-core/src/consts.rs`. Never inline numerics — that's a project-wide rule.
+
+5. **Add a schema migration** if you need to persist (link to chapter 05). For tone, you'd add `turn_tones` UNIQUE on `(turn_id, classifier_id)`, plus a `tone_classifiers` registry.
+
+6. **Wire the spawn/await pattern** into `DialogueManager`'s `background.rs` following the classifier model. Hold the classifier as `Arc<dyn ToneClassifier>` because spawn requires `'static`.
+
+7. **Add CLI flags** following the `--classifier-*` template: `--tone-backend`, `--tone-model`, `--tone-timeout-ms`. Default to mirroring the main `--backend` / `--model`.
+
+8. **Soft-fail tracing.** Confirm every error path inside `LlmToneClassifier` produces a `tracing::warn!` and returns `ToneAssessment::unknown_low_confidence(...)`. Never return `Result::Err` from the public API.
+
+9. **Tests.** Stub-driven: feed a script of canned `ToneAssessment`s, drive a mock dialogue, assert the persistence row + the in-memory state at the next turn.
+
+- [ ] **Step 2: Verify recipe + soft-fail callout**
+
+```bash
+grep -c '^### Recipe — ' docs/devel/06-classifiers-and-learner-model.md
+# Expected: 1
+grep -c 'soft-fail\|Soft-fail' docs/devel/06-classifiers-and-learner-model.md
+# Expected: ≥ 2
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/devel/06-classifiers-and-learner-model.md
+git commit -m "docs(devel): classifiers & learner-model chapter"
+```
+
+---
+
+## Task 7: Write `07-speech-and-voice-loop.md`
+
+**Files:**
+- Create: `docs/devel/07-speech-and-voice-loop.md`
+
+**Spec reference:** §4.8. One recipe required.
+
+- [ ] **Step 1: Write the chapter**
+
+Required sections:
+
+- `# Speech and the voice loop`
+- `## The five speech traits and the Named base trait` — `VoiceActivityDetector`, `SpeechToText` + `StreamingSpeechToText`, `TextToSpeech` + `StreamingTextToSpeech`. All inherit from `Named` so backends write `name()` once.
+- `## Concrete backends and feature gates` — stubs always built; real backends behind `silero`, `whisper`, `piper`, `cpal` features.
+- `## Why piper-rs is vendored at src/vendor/piper-rs/` — the `ort 2.0.0-rc.10` patch (three call sites). `[patch.crates-io]` directive in `src/Cargo.toml`.
+- `## Why silero-vad-rust is vendored at src/vendor/silero-vad-rust/` — three patches: `is_multiple_of`, removed `load-dynamic` from ort features, crate-level `#![allow(...)]`.
+- `## The speech_loop state machine` — LISTEN → THINK → SPEAK → LISTEN. No barge-in in either direction.
+- `## The is_speaking AtomicBool` — gates the audio thread during SPEAK. The `DrainHook` spawn_blocking pattern; why `std::thread::sleep` directly inside on_audio would deadlock the runtime.
+- `## Speaker ringbuf sizing` — 240,000 samples ≈ 5s at 48kHz. Never shrink.
+- `## Markdown-stripping for TTS` — `strip_markdown_for_tts` removes paired markers; bare unmatched stay; digit-flanked `*` becomes " times ".
+- `## The dedicated audio-capture thread` — std::thread, not tokio task. Owns silero VAD + active whisper session.
+- `## Resampler tail-handling` — leftover buffer + flush sentinel + 4-chunk silence drain pulse.
+- `## espeak-ng requirement and probe` — `/opt/homebrew/share`, `/usr/local/share`, `/usr/share`. Sets `PIPER_ESPEAKNG_DATA_DIRECTORY`.
+
+Required callouts (≥ 4):
+
+- `> **Gotcha:**` — Build with rustup, not Homebrew rust. Repeat from chapter 01 because speech is where the bug surfaces hardest.
+- `> **Gotcha:**` — Pass `--voice <model-id>` matching the .onnx filename, or Piper rejects with model-id mismatch.
+- `> **Gotcha:**` — Never shrink the speaker ringbuf below 240,000 samples; the previous 24,000-sample buffer dropped phrases.
+- `> **Why:**` — No barge-in is pedagogical, not a POC limitation. Learning to listen is part of the educational experience.
+
+Required recipe:
+
+`### Recipe — Add a speech backend`
+
+Steps:
+1. **Pick the trait.** `VoiceActivityDetector` (audio frames in, speech-state-events out), `SpeechToText` (audio in, text out), or `TextToSpeech` (text in, audio out). Streaming variants extend the one-shot.
+2. **Implement it.** `Named::name()` is written once via the auto-impl pattern. Show the trait skeleton.
+3. **Gate behind a cargo feature** in `primer-speech/Cargo.toml`. Naming: lowercase backend name (`whisper`, `piper`).
+4. **Vendor or patch incompatible deps** under `src/vendor/<crate>/` and add `[patch.crates-io] <crate> = { path = "vendor/<crate>" }` in `src/Cargo.toml`. The vendored copy carries the smallest possible patch — preserve upstream attribution and history.
+5. **Wire into `LoopBackends`** in `primer-cli/src/speech_loop/`. The factory function selects backends from CLI flags.
+6. **Add a smoke example** in `src/examples/` (e.g. `tts_hello.rs`). One-shot binary that exercises the backend without the full REPL.
+7. **Add system-dep installation notes to [08-testing-and-debugging.md](08-testing-and-debugging.md)** if your backend needs a system package.
+
+- [ ] **Step 2: Verify vendor-patch sections + recipe**
+
+```bash
+grep -c 'vendor/piper-rs\|vendor/silero-vad-rust' docs/devel/07-speech-and-voice-loop.md
+# Expected: ≥ 2
+grep -c '^### Recipe — ' docs/devel/07-speech-and-voice-loop.md
+# Expected: 1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/devel/07-speech-and-voice-loop.md
+git commit -m "docs(devel): speech & voice-loop chapter"
+```
+
+---
+
+## Task 8: Write `08-testing-and-debugging.md`
+
+**Files:**
+- Create: `docs/devel/08-testing-and-debugging.md`
+
+**Spec reference:** §4.9. One recipe required, plus the "common pitfalls" parade (a Gotcha catalogue).
+
+- [ ] **Step 1: Write the chapter**
+
+Required sections:
+
+- `# Testing and debugging`
+- `## Test layout` — per-crate `tests/`, shared mocks in `test_support.rs`, characterization tests for `decide_intent`, sweep tests for retrieval, dialogue-manager tests split per axis (lifecycle, turn, background).
+- `## Running tests` — full / single crate / by substring; `--features` matrix for feature-gated crates (`fastembed`, `speech`).
+- `## RUST_LOG and --verbose` — when each is right. Line format: `[intent]`, `[classifier]`, `[extractor]`, `[comprehension]` on stderr.
+- `## Inspecting session DBs` — `sqlite3 ~/.primer/<slug>.db`. Useful queries shown as code blocks: most-recent session, recent turn classifications, recent comprehensions.
+- `## Common pitfalls` — the gotcha parade (≥ 8 entries from spec §4.9).
+- `## Debugging a streaming hang` — where to add tracing in the streaming buffer.
+- `## Debugging a quiet classifier/extractor/comprehension` — feeds into the recipe.
+
+Required code blocks (≥ 3 sqlite query examples):
+
+```sql
+-- most-recent session
+SELECT id, started_at, turn_count FROM sessions ORDER BY started_at DESC LIMIT 1;
+-- recent classifications
+SELECT t.idx, c.engagement_state, c.confidence FROM turn_classifications c
+  JOIN turns t ON t.id = c.turn_id WHERE c.session_id = ?1 ORDER BY t.idx DESC LIMIT 5;
+-- recent comprehensions
+SELECT t.idx, co.name, c.depth, c.confidence FROM turn_comprehensions c
+  JOIN turns t ON t.id = c.turn_id JOIN concepts co ON co.id = c.concept_id
+  WHERE c.session_id = ?1 ORDER BY t.idx DESC, c.confidence DESC LIMIT 10;
+```
+
+Required gotchas (≥ 8, each as a `> **Gotcha:**` callout):
+
+- Homebrew rust shadowing rustup → use `~/.cargo/bin/cargo`.
+- `cargo build` failed because you ran it from the repo root, not `src/`.
+- `--speech` panics with espeak data error → install `espeak-ng`.
+- `--embedder-backend fastembed` errors → enable the `embedding` feature.
+- First run of fastembed downloads ~570 MB → expected, not a hang.
+- First run of `--speech` downloads ONNX runtime → expected, not a hang.
+- Voice rejected with model-id mismatch → pass `--voice <model-id>`.
+- Streaming hangs → check 2xx-with-no-body; mid-stream errors should propagate.
+
+Required recipe:
+
+`### Recipe — Diagnose a quiet classifier`
+
+Symptoms: `--verbose` is on but no `[classifier]` line is printed; `turn_classifications` is empty.
+
+Steps:
+1. **Confirm `--verbose` is set.** Without it, the line never prints even on success.
+2. **Look for the `[classifier]` line on stderr** for the most recent turn. If absent, the classifier task isn't completing within the timeout.
+3. **Inspect `turn_classifications` for the most recent session.**
+
+```sql
+SELECT COUNT(*) FROM turn_classifications WHERE session_id = ?1;
+```
+
+If 0, the classifier never wrote a row.
+
+4. **Increase `--classifier-timeout-ms`.** Default is 3000ms. Small models need more time, especially when chained behind extractor+comprehension.
+5. **Swap to `--classifier-backend stub`** to confirm the integration point. If stub-backed classifier writes rows, the LLM call itself is the bottleneck; if not, the integration is broken.
+
+- [ ] **Step 2: Verify gotcha count + recipe**
+
+```bash
+grep -c '> \*\*Gotcha:' docs/devel/08-testing-and-debugging.md
+# Expected: ≥ 8
+grep -c '^### Recipe — ' docs/devel/08-testing-and-debugging.md
+# Expected: 1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/devel/08-testing-and-debugging.md
+git commit -m "docs(devel): testing & debugging chapter"
+```
+
+---
+
+## Task 9: Write `09-contributing.md`
+
+**Files:**
+- Create: `docs/devel/09-contributing.md`
+
+**Spec reference:** §4.10.
+
+- [ ] **Step 1: Write the chapter**
+
+Required sections:
+
+- `# Contributing`
+- `## Repo workflow` — fork, branch naming (`feature/...`, `fix/...`), PR conventions.
+- `## Commit conventions` — conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`); no `--no-verify`; no `--amend` after push.
+- `## Code style` — `cargo fmt` + `cargo clippy --workspace --all-targets`. CI runs both.
+- `## No magic numbers` — every numeric goes to `primer-core::consts` (if invariant) or a per-subsystem `*Settings` struct (if tunable). Never inline.
+- `## Categorical text columns are normalised` — link to chapter 05.
+- `## Where to find open work` — [ROADMAP.md](../../ROADMAP.md), GitHub Issues, `// TODO` markers, [SPECULATIONS_AND_IDEAS.md](../../SPECULATIONS_AND_IDEAS.md).
+- `## How to ask for review` — PR template, what reviewers check (clippy clean, tests added, CLAUDE.md updated if conventions changed).
+- `## License` — link to [LICENSE](../../LICENSE).
+
+Required commands shown in code blocks:
+
+```bash
+cd src
+cargo fmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```
+
+- [ ] **Step 2: Verify load-bearing links**
+
+```bash
+grep -c 'ROADMAP\|SPECULATIONS\|LICENSE\|05-storage' docs/devel/09-contributing.md
+# Expected: ≥ 4
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/devel/09-contributing.md
+git commit -m "docs(devel): contributing chapter"
+```
+
+---
+
+## Task 10: Write `index.md` with the lookup table
+
+**Files:**
+- Create: `docs/devel/index.md`
+
+**Spec reference:** §4.1, §5 (conventions appendix).
+
+This task is LAST among chapter writes because the lookup-table anchors must match recipe headings that now exist on disk.
+
+- [ ] **Step 1: Write `index.md`**
+
+Required structure:
+
+```markdown
+# Developer / contributor manual
+
+Welcome paragraph: who this manual is for, what it covers, what it doesn't (the "Non-goals" list from spec §1).
+
+## Reading paths
+
+Three suggested orderings:
+
+- **I'm new and want to contribute** → start with [Getting started](01-getting-started.md), then [Architecture overview](02-architecture-overview.md), then [Contributing](09-contributing.md), then pick a subsystem chapter.
+- **I want to add feature X** → look up the recipe in the table below.
+- **I want to understand subsystem Y** → jump straight to its chapter.
+
+## Chapters
+
+| # | Chapter | What it covers |
+|---|---|---|
+| 01 | [Getting started](01-getting-started.md) | Clone, build, first run, env files, tests, logging. |
+| 02 | [Architecture overview](02-architecture-overview.md) | Trait-based abstraction, the 12-crate graph, pedagogical principles. |
+| 03 | [Inference and pedagogy](03-inference-and-pedagogy.md) | `InferenceBackend` impls, `DialogueManager`, `decide_intent`, retry, error i18n. |
+| 04 | [Knowledge and retrieval](04-knowledge-and-retrieval.md) | FTS5 + hybrid retrieval, embedders, seed corpus, locales. |
+| 05 | [Storage and sessions](05-storage-and-sessions.md) | Session/learner stores, schema migrations, long-term memory. |
+| 06 | [Classifiers and learner model](06-classifiers-and-learner-model.md) | Classifier/extractor/comprehension trio, vocab Leitner box. |
+| 07 | [Speech and voice loop](07-speech-and-voice-loop.md) | VAD/STT/TTS, vendored crates, speech_loop state machine. |
+| 08 | [Testing and debugging](08-testing-and-debugging.md) | Test layout, RUST_LOG, common pitfalls, debugging recipes. |
+| 09 | [Contributing](09-contributing.md) | PR workflow, commits, style, where to find open work. |
+
+## How do I…?
+
+| Task | Recipe |
+|---|---|
+| Add a new `InferenceBackend` | [03-inference-and-pedagogy.md#recipe--add-a-new-inferencebackend](03-inference-and-pedagogy.md#recipe--add-a-new-inferencebackend) |
+| Add a new `PedagogicalIntent` | [03-inference-and-pedagogy.md#recipe--add-a-new-pedagogicalintent](03-inference-and-pedagogy.md#recipe--add-a-new-pedagogicalintent) |
+| Add or tune seed passages | [04-knowledge-and-retrieval.md#recipe--add-or-tune-seed-passages](04-knowledge-and-retrieval.md#recipe--add-or-tune-seed-passages) |
+| Add a new locale | [04-knowledge-and-retrieval.md#recipe--add-a-new-locale](04-knowledge-and-retrieval.md#recipe--add-a-new-locale) |
+| Add a schema migration | [05-storage-and-sessions.md#recipe--add-a-schema-migration](05-storage-and-sessions.md#recipe--add-a-schema-migration) |
+| Add a structured-output classifier | [06-classifiers-and-learner-model.md#recipe--add-a-structured-output-classifier](06-classifiers-and-learner-model.md#recipe--add-a-structured-output-classifier) |
+| Add a speech backend | [07-speech-and-voice-loop.md#recipe--add-a-speech-backend](07-speech-and-voice-loop.md#recipe--add-a-speech-backend) |
+| Diagnose a quiet classifier | [08-testing-and-debugging.md#recipe--diagnose-a-quiet-classifier](08-testing-and-debugging.md#recipe--diagnose-a-quiet-classifier) |
+| Run / test / debug locally | [08-testing-and-debugging.md](08-testing-and-debugging.md) |
+
+## Conventions used in this manual
+
+- `> **Note:**` — an aside that doesn't change behaviour.
+- `> **Gotcha:**` — something that has bitten contributors before. Almost every CLAUDE.md "gotcha" appears as one of these in the relevant chapter.
+- `> **Why:**` — rationale for a non-obvious design choice.
+- `> **Recipe — <Action>:**` — worked example with numbered steps.
+
+For code references in prose, the manual uses markdown links (`[turn.rs:120](src/crates/primer-pedagogy/src/dialogue_manager/turn.rs#L120)`) — never bare backticks for paths, so the IDE preserves click-through.
+
+Code samples are tagged with the language and (for files) carry a path comment on the first line:
+
+```rust
+// src/crates/primer-core/src/inference.rs
+pub trait InferenceBackend: Send + Sync {
+    async fn generate(&self, prompt: &Prompt, params: GenParams) -> Result<String>;
+}
+```
+
+## External resources
+
+- [README.md](../../README.md) — product pitch, status.
+- [ROADMAP.md](../../ROADMAP.md) — phase plan.
+- [primer_technical_spec.md](../../primer_technical_spec.md) — long-form vision.
+- [CLAUDE.md](../../CLAUDE.md) — agent-facing conventions and gotchas (the manual mirrors these in contributor-friendly tone).
+- [SPECULATIONS_AND_IDEAS.md](../../SPECULATIONS_AND_IDEAS.md) — open ideas, future directions.
+```
+
+- [ ] **Step 2: Verify all 9 lookup-table entries land on existing recipe anchors**
+
+For each anchor in the lookup table, grep the target file for the matching `### Recipe — <heading>` and confirm it exists. The slug `recipe--add-a-new-inferencebackend` corresponds to the heading text `Recipe — Add a new InferenceBackend`.
+
+```bash
+# Verify every recipe heading exists in its chapter
+grep -h '^### Recipe — ' docs/devel/03-*.md docs/devel/04-*.md docs/devel/05-*.md docs/devel/06-*.md docs/devel/07-*.md docs/devel/08-*.md
+# Expected output (one line per recipe, 9 total):
+#   ### Recipe — Add a new `InferenceBackend`
+#   ### Recipe — Add a new `PedagogicalIntent`
+#   ### Recipe — Add or tune seed passages
+#   ### Recipe — Add a new locale
+#   ### Recipe — Add a schema migration
+#   ### Recipe — Add a structured-output classifier
+#   ### Recipe — Add a speech backend
+#   ### Recipe — Diagnose a quiet classifier
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/devel/index.md
+git commit -m "docs(devel): index with lookup table"
+```
+
+---
+
+## Task 11: Add the cross-link from `README.md`
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Find the right insertion point**
+
+```bash
+grep -n '^## ' README.md | head -20
+```
+
+Look for a "Contributing" section or a natural anchor near the bottom. If neither exists, add a new section right before any "License" section.
+
+- [ ] **Step 2: Add the one-line cross-link**
+
+If a Contributing section exists, append:
+
+```markdown
+**Developer manual:** see [docs/devel/](docs/devel/) for the full contributor manual — getting started, architecture, subsystem deep-dives, and how-to recipes.
+```
+
+If no Contributing section exists, add one:
+
+```markdown
+## Contributing
+
+**Developer manual:** see [docs/devel/](docs/devel/) for the full contributor manual — getting started, architecture, subsystem deep-dives, and how-to recipes.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): link to developer manual"
+```
+
+---
+
+## Task 12: Final link-and-render verification
+
+**Files:**
+- (none modified — verification only)
+
+- [ ] **Step 1: Verify all internal markdown links resolve**
+
+```bash
+# For every link of the form ](something), check that the target exists.
+# This is a coarse-grained check; intra-doc anchors are not validated by this script.
+cd docs/devel && for f in *.md; do
+  grep -oE '\]\([^)]+\)' "$f" | sed 's/](\(.*\))/\1/' | while read link; do
+    # skip URLs and pure anchors
+    case "$link" in
+      http*|'#'*) continue;;
+    esac
+    # split off any anchor
+    target="${link%%#*}"
+    # resolve relative to docs/devel/
+    if [ -n "$target" ] && [ ! -e "$target" ] && [ ! -e "../../$target" ]; then
+      echo "BROKEN in $f: $link"
+    fi
+  done
+done
+```
+
+Expected: no `BROKEN` lines.
+
+- [ ] **Step 2: Verify mermaid renders**
+
+Open `docs/devel/02-architecture-overview.md` in VS Code's markdown preview (which has built-in mermaid support) AND on GitHub (push the branch first, view in browser, then check both light and dark themes via `?theme=dark` in the URL or your account settings).
+
+Confirm:
+- Crate-graph diagram renders.
+- Node text is readable (white on dark fill).
+- Edges are visible against both backgrounds.
+
+If a diagram fails to render, check the `%%{init: ...}%%` block — most mermaid render failures are JSON syntax errors in the config.
+
+- [ ] **Step 3: Verify recipe anchors round-trip**
+
+Pick one recipe lookup-table entry from `index.md` and confirm clicking it lands on the recipe heading.
+
+Smoke test command:
+
+```bash
+# For each anchor in index.md, confirm the heading exists in the target file.
+grep -oE '\(\d{2}-[a-z-]+\.md#recipe--[a-z-]+\)' docs/devel/index.md | tr -d '()' | while read ref; do
+  file="${ref%%#*}"
+  anchor="${ref#*#}"
+  # convert anchor back to a heading regex: recipe--add-a-new-locale → "Recipe — Add a new locale"
+  expected="${anchor#recipe--}"
+  expected_pattern="$(echo "$expected" | sed 's/-/[ -]/g')"
+  if ! grep -iqE "^### Recipe . ${expected_pattern}" "docs/devel/$file"; then
+    echo "MISSING anchor target for: $ref"
+  fi
+done
+```
+
+Expected: no `MISSING` lines.
+
+- [ ] **Step 4: Final commit (if any link fixes were needed)**
+
+```bash
+git status
+# If anything to commit:
+git add -u
+git commit -m "docs(devel): fix broken links from final verification"
+```
+
+If no fixes: nothing to commit, this task ends.
+
+---
+
+## Self-review
+
+The following checks were run on this plan after writing:
+
+**1. Spec coverage:**
+- §1 goals — covered by every chapter task; the audience tone (welcoming, not agent-flavoured) is enforced by the prose decisions in each chapter outline.
+- §1 non-goals — implicitly enforced (no API reference, no Rust tutorial, no product framing duplication).
+- §2 audience + relationship — Task 10 (index) and Task 9 (contributing) carry the cross-links.
+- §3 file layout — Tasks 1, 2-9 (chapters), 10 (index) — exactly 10 files.
+- §4.1 index — Task 10.
+- §4.2 getting-started — Task 1.
+- §4.3 architecture — Task 2.
+- §4.4-§4.10 chapters — Tasks 3-9.
+- §5.1 callout types — enforced by per-task verification greps.
+- §5.2 code samples — convention stated in plan preamble.
+- §5.3 code references — convention stated in plan preamble.
+- §5.4 mermaid styling — palette baked into Task 2's mermaid block; Task 12's render check.
+- §5.5 recipe anchors — verified by Task 10's verify step and Task 12 step 3.
+- §6 out of scope — implicit; no task addresses these.
+- §7 out-of-band coordination — Task 11 (README link); single PR is implicit (the branch carries all 12 commits).
+- §8 success criteria — addressed by Task 12's verification.
+
+**2. Placeholder scan:** No `TBD`, no `TODO`, no "fill in details", no "similar to Task N". Each chapter task includes the structural skeleton; prose flesh is delegated to the executor with explicit constraints (callouts, links, code references), which is appropriate for a docs deliverable.
+
+**3. Type consistency:** No types in this plan — it's documentation. Anchor format is consistent across §4.1 (lookup table), §5.5 (anchor convention), and Task 10 (verification grep). Recipe heading format is consistent across all chapter tasks (`### Recipe — <Action>`).

--- a/docs/superpowers/specs/2026-05-08-developer-manual-design.md
+++ b/docs/superpowers/specs/2026-05-08-developer-manual-design.md
@@ -1,0 +1,332 @@
+# Developer / Contributor Manual — design spec
+
+**Date:** 2026-05-08
+**Status:** approved (pending spec review)
+**Deliverable:** new `docs/devel/` tree, ~10 markdown files, targeting external open-source contributors.
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+- Give a stranger who just cloned the repo a clear path from "I have the source" to "I've built it, run it, and understand where to make my first change."
+- Cover every subsystem in enough depth that a contributor can reason about a change without reading every crate's source first.
+- Make "how do I do XYZ" lookups one click from the index — practical recipes with worked code samples, not just architecture description.
+- Use a tone that welcomes newcomers (not the dense agent-facing prose of `CLAUDE.md`) while still respecting Rust fluency.
+
+### Non-goals
+
+- Not a replacement for `CLAUDE.md`. `CLAUDE.md` stays as the authoritative agent-facing source of truth for conventions and gotchas; this manual mirrors the same ground in human-readable form and links back where relevant.
+- Not a Rust tutorial. Assume cargo workspace, traits, async/await fluency.
+- Not pedagogical / product documentation. The "what is the Primer for" framing belongs to `README.md` and `primer_technical_spec.md`; the manual links out for that context but does not duplicate it.
+- Not auto-generated API docs. `cargo doc` already covers per-item API. The manual covers shape, intent, and how-to.
+
+---
+
+## 2. Audience & relationship to existing docs
+
+**Primary audience:** external OSS contributors. Assume Rust + cargo fluency; do not assume any Primer-specific knowledge.
+
+**Relationship to other docs:**
+
+| Doc | Role | Manual's relationship |
+|---|---|---|
+| `README.md` | Product pitch, user-facing status | Manual links to it from `index.md` and `01-getting-started.md`; does not duplicate. |
+| `ROADMAP.md` | Phase plan | Manual links to it from `02-architecture-overview.md` (status) and `09-contributing.md` (where to look for open work). |
+| `primer_technical_spec.md` | Long-form vision | Manual links to it from `02-architecture-overview.md` for context. |
+| `CLAUDE.md` | Agent-facing conventions + gotchas | Manual covers the same conventions/gotchas in contributor-friendly tone with examples. CLAUDE.md stays authoritative; manual deep-links back where useful. |
+| `docs/background_research/` | Architecture deep-dives (i18n, inference) | Manual links to specific files when a topic is covered in more depth there. |
+| `docs/superpowers/specs/` | Design specs (including this one) | Manual links to specific specs as supporting reading; not part of the contributor flow. |
+
+When a fact lives in CLAUDE.md verbatim (e.g. the `Other`-string-never-reaches-users discipline), the manual restates it briefly in its own words and links to the CLAUDE.md section for the canonical phrasing.
+
+---
+
+## 3. File layout
+
+```
+docs/devel/
+├── index.md
+├── 01-getting-started.md
+├── 02-architecture-overview.md
+├── 03-inference-and-pedagogy.md
+├── 04-knowledge-and-retrieval.md
+├── 05-storage-and-sessions.md
+├── 06-classifiers-and-learner-model.md
+├── 07-speech-and-voice-loop.md
+├── 08-testing-and-debugging.md
+└── 09-contributing.md
+```
+
+Numerical prefixes give a deterministic reading order. The `index.md` references chapters by title (not number) so files can be renumbered later without breaking links.
+
+---
+
+## 4. Per-file content
+
+### 4.1 `index.md` — landing page
+
+- One-paragraph framing: who this manual is for, what it covers, what it doesn't.
+- **Reading paths** section — three suggested orderings:
+  - "I'm new and want to contribute" → 01 → 02 → 09 → pick a chapter.
+  - "I want to add feature X" → look up the recipe in the table below.
+  - "I want to understand subsystem Y" → jump straight to the relevant chapter.
+- **How do I…? lookup table** — flat list of every recipe in the manual, deep-linking to the recipe heading in its chapter. Anchors use the GitHub slug of `Recipe — Foo` (em-dash + space collapses to a double-hyphen):
+  - Add a new `InferenceBackend` → `03-inference-and-pedagogy.md#recipe--add-a-new-inferencebackend`
+  - Add a new `PedagogicalIntent` → `03-inference-and-pedagogy.md#recipe--add-a-new-pedagogicalintent`
+  - Add a new locale → `04-knowledge-and-retrieval.md#recipe--add-a-new-locale`
+  - Tune retrieval / add seed passages → `04-knowledge-and-retrieval.md#recipe--add-or-tune-seed-passages`
+  - Add a schema migration → `05-storage-and-sessions.md#recipe--add-a-schema-migration`
+  - Add a structured-output classifier → `06-classifiers-and-learner-model.md#recipe--add-a-structured-output-classifier`
+  - Add a speech backend → `07-speech-and-voice-loop.md#recipe--add-a-speech-backend`
+  - Diagnose a quiet classifier → `08-testing-and-debugging.md#recipe--diagnose-a-quiet-classifier`
+  - Run / test / debug locally → `08-testing-and-debugging.md`
+- **Conventions used in this manual** — explains the four callout types, the file:line link convention, and the code-sample format.
+- **External links** — README, ROADMAP, primer_technical_spec, CLAUDE.md, GitHub Issues.
+
+### 4.2 `01-getting-started.md`
+
+- Prerequisites: rustup (NOT Homebrew rust — explain the silent-fail with the toolchain pin); optional system deps for opt-in features (espeak-ng for speech; nothing else).
+- Cloning and the **`src/` workspace gotcha** — every cargo command runs from `src/`, the repo root has no `Cargo.toml`. Spelled out as a callout.
+- First build (default, no API key needed): `cargo build && cargo run --bin primer` with stub backend.
+- Running with cloud (Anthropic): env-file locations, `.env` vs `~/.primer_env`, the API key.
+- Running with Ollama.
+- Running with embeddings: `--features primer-cli/embedding --embedder-backend fastembed`. Note ~570 MB BGE-M3 download on first run.
+- Running with speech: `--features primer-cli/speech`, espeak-ng, voice ONNX paths.
+- Running tests: `cargo test`, `cargo test -p <crate>`, single test by substring.
+- Logging: `RUST_LOG=debug` and `--verbose`.
+- Where session DBs live (`~/.primer/<slug>.db`), how to opt out (`--no-persist`).
+- "Now what?" — pointer to chapter 02 for architecture, chapter 09 for contributing.
+
+### 4.3 `02-architecture-overview.md`
+
+- The central design principle: **trait-based hardware abstraction**. Backend selection is a runtime config choice, not a code change. This is what allows Phase 0 (cloud) to share code with Phase 1 (local NPU) and Phase 2 (voice).
+- The 12-crate layered graph as a **mermaid diagram** (see §5 for styling) plus an ASCII fallback.
+- One-paragraph summary table: each crate name links to the relevant subsystem chapter, with a one-line "owns the X" description.
+- The four pedagogical principles encoded in the prompt (asks more than answers; never engagement-maximising; local-first data; comprehension via transfer/probing). These are constraints on every change.
+- Status: what's done (link to README) vs. what's TODO (link to ROADMAP).
+
+### 4.4 `03-inference-and-pedagogy.md`
+
+Topics:
+- The `InferenceBackend` trait shape (`generate`, `generate_stream`, `summarize`).
+- The three concrete backends: `StubBackend`, `CloudBackend` (Anthropic SSE), `OllamaBackend` (NDJSON). Mention the `Role::System` mapping divergence.
+- `DialogueManager` as orchestrator: directory module layout (`lifecycle.rs`, `turn.rs`, `background.rs`, `retrieval.rs`, `summary.rs`, `learner_update.rs`, `apply.rs`).
+- `prompt_builder` and `decide_intent()`: the heuristic, why characterization tests matter.
+- The retry layer (`primer_core::retry::retry_with_backoff`) — pre-stream only; mid-stream errors propagate cleanly.
+- The typed `InferenceError` and the i18n boundary — `Other`'s inner string is dev-facing only.
+
+Recipes:
+- **Recipe — Add a new `InferenceBackend`.** Eight numbered steps: implement trait, hand-roll streaming if needed (callout pointing to the SSE/NDJSON helpers), add typed-error mapping, hook `retry_with_backoff` for the pre-stream phase, register in `primer-cli`'s backend factory, add `--backend` enum variant, write integration tests using the stub pattern, update README.
+- **Recipe — Add a new `PedagogicalIntent`.** Six steps: add the variant to the enum (the source of truth), add a routing branch in `decide_intent`, extend the prompt builder section selector, add a characterization test pinning the routing case, restart any DB to let the lookup-table seeder pick up the new variant, link to chapter 05 for the lookup-table mechanics.
+
+### 4.5 `04-knowledge-and-retrieval.md`
+
+Topics:
+- `KnowledgeBase` trait, `Passage` type.
+- `SqliteKnowledgeBase` schema: per-locale `passages_<pack_id>` FTS5 + `passages_<pack_id>_meta` + `embeddings_<pack_id>`. Cross-locale tables: `sources`, `embedding_models`. Schema at user_version 3.
+- BM25 ranking: how the negative-rank flip works in the public API.
+- Hybrid retrieval: `retrieve_hybrid`, BM25 leg + dense-vector cosine leg, RRF fusion via `primer_core::rrf::fuse`. `HybridParams::default()` reads from `primer_core::consts::retrieval`.
+- The `Embedder` trait and three impls: `StubEmbedder` (always built; FNV+xorshift hash), `FastEmbedBackend` (BGE-M3, ~570 MB), `OllamaEmbedder`. The `embedding_models` invariant — mismatched dim is a hard error.
+- `auto_seed_if_empty` and multi-file seed discovery: env precedence, lexicographic load order, multi-layer corpus (CC0 hand-drafted + CC-BY-SA-3.0 Wikipedia).
+- Wikipedia ingestion pipeline at `data/ingest/` — Python; pure functions; network as the test boundary; how to regenerate.
+- Sweep tests as the basis for default tuning (BM25-only and hybrid).
+
+Recipes:
+- **Recipe — Add or tune seed passages.** Four steps: edit the JSONL (id, body, source attribution), bump the sweep test's expected recall if needed, run the sweep (`cargo test -p primer-knowledge --test retrieval_sweep`), update `KNOWN_FAILING_QUERIES_HYBRID` in `tests/common/mod.rs` if a new query becomes resolvable.
+- **Recipe — Add a new locale.** Seven steps: add `Locale` variant to `primer-core::i18n`, add the TOML pack file, add seed JSONL files (`seed_passages.<pack>.jsonl`, optionally `wiki_passages.<pack>.jsonl`), open the KB with `open_for_locale` (no migration step needed — tables are created on demand), test the locale guard on `--resume`, regenerate the wiki layer via `data/ingest/` if applicable, link to chapter 05 for the per-learner locale persistence.
+
+### 4.6 `05-storage-and-sessions.md`
+
+Topics:
+- The privacy split: per-child session DB at `~/.primer/<slug>.db`, separate from the RAG corpus.
+- `SessionStore` and `LearnerStore` traits.
+- Schema-migration pattern: idempotent `CREATE IF NOT EXISTS` and `pragma_table_info` ALTER guards, transaction-wrapped, version bump, drift validation against Rust enums on every `open()`.
+- The append-only invariant on `save_session` and why `update_turn_concepts` is the explicit backfill path.
+- FTS5 query sanitisation (`sanitize_fts_phrase`).
+- Long-term memory layered into the system prompt — summary + retrieved-older turns; the chat timeline stays linear.
+- Turn-embedding-on-save fire-and-forget pattern.
+- The current schema version (8) and what each version added (one-line summary per migration).
+
+Recipes:
+- **Recipe — Add a schema migration.** Six steps: bump `USER_VERSION` in `schema.rs`, write `apply_vN_migrations` following the v7/v8 template (callout with annotated example), wire it into the open path, add a migration round-trip test (open old DB → apply → assert schema), add a drift-validation entry if the migration touches a lookup-table-seeded enum, document the migration in CLAUDE.md's "Schema is at version N" line.
+
+### 4.7 `06-classifiers-and-learner-model.md`
+
+Topics:
+- The classifier / extractor / comprehension trio: trait, `Llm*` impl wrapping `Arc<dyn InferenceBackend>`, `Stub*` for tests with `with_response` / `with_script`.
+- The spawn / await / detach-on-timeout pattern, applied identically across all three.
+- Soft-fail discipline: classifier/extractor/comprehension errors NEVER propagate; log via `tracing::warn!` and return an empty / unknown result.
+- The classifier-extractor-comprehension chain inside the dialogue manager's background task; combined timeout budget; why both lag one turn.
+- `LearnerModel` umbrella: `LearnerProfile` + `Vec<ConceptState>` + `LearningPreferences` + latest engagement snapshot. Edit the leaf, not the umbrella.
+- `apply_comprehension` is monotonic-max; sub-threshold assessments still persist for offline analysis.
+- Vocab Leitner-box scheduler in `primer_core::vocab`; passive review hints injected via the prompt builder, never drilled.
+- Shared utilities: `extract_first_json_object` and `truncate_to_chars` in `primer_core::llm_util`.
+
+Recipes:
+- **Recipe — Add a structured-output classifier.** Nine steps: define the trait in your crate, add the `Llm*` impl (callout with the JSON-extraction pattern using `llm_util`), add the `Stub*` impl with `with_response`/`with_script`, add a `*Settings` struct with all numerics in `primer-core::consts`, add a schema migration if you need to persist (link to chapter 05), wire the spawn/await pattern into `DialogueManager`'s background module, add CLI flags following the `--classifier-*` template, add the soft-fail tracing-warn path, add stub-driven tests.
+
+### 4.8 `07-speech-and-voice-loop.md`
+
+Topics:
+- The five speech traits all inheriting from `Named`: `VoiceActivityDetector`, `SpeechToText` + `StreamingSpeechToText`, `TextToSpeech` + `StreamingTextToSpeech`.
+- Concrete backends: stubs + real backends behind features (`silero`, `whisper`, `piper`, `cpal`).
+- Why `piper-rs 0.1.9` is vendored at `src/vendor/piper-rs/` — the `ort 2.0.0-rc.10` patch.
+- Why `silero-vad-rust 6.2.1` is vendored at `src/vendor/silero-vad-rust/` — three patches; how to verify with `~/.cargo/bin/cargo`.
+- The `speech_loop` state machine: LISTEN → THINK → SPEAK → LISTEN, no barge-in invariant in either direction.
+- The `is_speaking` `AtomicBool` and the drain-hook discipline; why `spawn_blocking` matters for the synchronous wait.
+- Speaker ringbuf sizing (240 000 samples ≈ 5 s at 48 kHz) — never shrink.
+- Markdown-stripping for TTS; the `*` → " times " heuristic for digits.
+- The dedicated audio-capture thread (not a tokio task); resampler tail-handling with `leftover` + flush sentinel + drain pulse.
+- espeak-ng requirement and the data-directory probe.
+
+Recipes:
+- **Recipe — Add a speech backend.** Seven steps: pick the trait (VAD, STT, or TTS), implement it with `Named`'s `name()` impl once, gate behind a cargo feature in `primer-speech/Cargo.toml`, vendor or patch any incompatible deps under `src/vendor/` and add the `[patch.crates-io]` entry in `src/Cargo.toml`, wire into the `LoopBackends` factory in `primer-cli`, add a smoke example in `examples/`, add system-dep installation notes to `08-testing-and-debugging.md`.
+
+### 4.9 `08-testing-and-debugging.md`
+
+Topics:
+- Test layout: per-crate `tests/`, shared mocks in `test_support.rs`, characterization tests for `decide_intent`, sweep tests for retrieval.
+- Running tests: `cargo test`, `cargo test -p <crate>`, single test by substring; `--features` matrix for feature-gated crates.
+- `RUST_LOG` and `--verbose`: when each is the right tool. The `[intent]` / `[classifier]` / `[extractor]` / `[comprehension]` line format.
+- Inspecting session DBs: `sqlite3 ~/.primer/<slug>.db`, useful queries (most recent session, turn classifications, comprehensions).
+- Common pitfalls (the "gotcha" parade — most of these are direct mirrors of CLAUDE.md gotchas):
+  - Homebrew rust shadowing rustup → use `~/.cargo/bin/cargo`.
+  - `cargo build` fails because you ran it from the repo root, not `src/`.
+  - `--speech` panics with espeak data error → install `espeak-ng`.
+  - `--embedder-backend fastembed` errors → enable the `embedding` feature.
+  - First run of fastembed downloads ~570 MB → expected, not a hang.
+  - First run of `--speech` downloads ONNX runtime → expected, not a hang.
+  - Voice rejected with model-id mismatch → pass `--voice <model-id>` matching the ONNX filename.
+  - Streaming hangs forever → check that you're not using a 2xx response with no body; mid-stream errors should propagate.
+- How to debug a streaming hang (point at where to add tracing).
+- How to debug a classifier/extractor that's not firing (`--verbose` + check the timeout knobs).
+
+Recipe:
+- **Recipe — Diagnose a quiet classifier.** Five steps: set `--verbose`, look for the `[classifier]` line, if missing inspect `turn_classifications` for the last session, increase `--classifier-timeout-ms`, swap to `--classifier-backend stub` to confirm the integration point isn't the LLM call.
+
+### 4.10 `09-contributing.md`
+
+- Repo workflow: fork, branch naming (`feature/...`, `fix/...`), PR conventions.
+- Commit conventions: conventional commits style (visible in `git log`), no `--no-verify`, no `--amend` after push.
+- Code style: `cargo fmt` + `cargo clippy --workspace --all-targets`. CI runs both; PRs that fail either get a cleanup pass.
+- The "no magic numbers" rule: in this codebase, numerics live in `primer-core::consts` (if invariant) or in per-subsystem `*Settings` structs (if tunable) — never inline.
+- The "categorical text columns are normalised" rule: link to chapter 05.
+- Where to find open work: ROADMAP, GitHub Issues, the `// TODO` markers in source, `SPECULATIONS_AND_IDEAS.md`.
+- How to ask for review: PR template, what reviewers will check (clippy clean, tests added, CLAUDE.md updated if conventions changed).
+- License and contributor agreement (link out, not duplicated).
+
+---
+
+## 5. Conventions used in the manual
+
+### 5.1 Callout types
+
+Four blockquote-based callout types. Plain markdown means they render correctly on GitHub, in IDEs, and in offline viewers — no custom directives.
+
+```
+> **Note:** an aside that doesn't change behaviour.
+
+> **Gotcha:** something that has bitten contributors before. Almost every CLAUDE.md "gotcha" becomes one of these.
+
+> **Why:** rationale for a non-obvious design choice.
+
+> **Recipe — Add a new X:** worked example with numbered steps and code blocks.
+```
+
+### 5.2 Code samples
+
+- Fenced code blocks tagged with the language (`rust`, `bash`, `sql`, `toml`).
+- Where the snippet lives in the repo, the first line of the block is a comment with the path: `// src/crates/primer-core/src/inference.rs`.
+- For commands: prefix with `$` only when paired with output; otherwise bare command lines.
+- Snippets stay short — the manual prefers a 5-line illustrative excerpt with a link to the file over a 40-line copy.
+
+### 5.3 Code references in prose
+
+Use the markdown link convention from the VSCode extension context:
+
+- File: `[inference.rs](src/crates/primer-core/src/inference.rs)`
+- File at line: `[dialogue_manager/turn.rs:120](src/crates/primer-pedagogy/src/dialogue_manager/turn.rs#L120)`
+
+Never use bare backticks for file paths — readers in the IDE lose the click-through.
+
+### 5.4 Mermaid diagram styling
+
+Every diagram must be **legible on both light and dark GitHub themes** without modification. To achieve this:
+
+- Use `%%{init: ...}%%` directives at the top of each diagram to set theme variables.
+- Use **white text on saturated dark fills**, which gives ≥ 7:1 text-on-fill contrast (well above the WCAG 4.5:1 text threshold) and works identically against both light (`#ffffff`) and dark (`#0d1117`) page backgrounds.
+- Pair every fill with a brighter stroke (the colours below are ~2x lighter than their fill) so node edges stay visible against the dark theme background; this exceeds the WCAG 3:1 threshold for graphical elements.
+- Use `font-size: 16px` minimum for node labels, `14px` for edge labels.
+- Keep node count per diagram under ~12; break larger graphs into multiple diagrams.
+- Use `classDef` to apply consistent palette across diagrams in the manual.
+
+**Manual-wide palette** (intended to read clearly on both themes):
+
+| Role | Fill | Stroke | Text |
+|---|---|---|---|
+| Trait / interface (primer-core) | `#1e3a5f` (deep blue) | `#4a90d9` | `#ffffff` |
+| Concrete impl (other crates) | `#2d5016` (deep green) | `#5cb85c` | `#ffffff` |
+| External boundary (HTTP, FS, vendor) | `#5a3a1e` (deep amber) | `#d9a14a` | `#ffffff` |
+| Stub / test only | `#4a4a4a` (neutral) | `#888888` | `#ffffff` |
+
+Each chapter that uses these colours includes a one-line legend under the first diagram.
+
+**Reference template** (used at the top of every diagram in the manual):
+
+```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'fontSize': '16px',
+    'fontFamily': 'system-ui, -apple-system, sans-serif',
+    'primaryColor': '#1e3a5f',
+    'primaryTextColor': '#ffffff',
+    'primaryBorderColor': '#4a90d9',
+    'lineColor': '#888888',
+    'secondaryColor': '#2d5016',
+    'tertiaryColor': '#5a3a1e'
+  }
+}}%%
+graph LR
+  classDef trait fill:#1e3a5f,stroke:#4a90d9,stroke-width:2px,color:#ffffff
+  classDef impl  fill:#2d5016,stroke:#5cb85c,stroke-width:2px,color:#ffffff
+  classDef ext   fill:#5a3a1e,stroke:#d9a14a,stroke-width:2px,color:#ffffff
+  classDef stub  fill:#4a4a4a,stroke:#888888,stroke-width:2px,color:#ffffff
+```
+
+The crate-graph diagram in `02-architecture-overview.md` also ships an **ASCII fallback** (the existing one in `CLAUDE.md`) immediately after the mermaid block, so the manual remains useful in environments where mermaid does not render.
+
+### 5.5 Recipe heading anchors
+
+Each recipe uses an h3 heading of the form `### Recipe — Add a new InferenceBackend`. GitHub auto-generates the anchor (`#recipe--add-a-new-inferencebackend`); the index uses these anchors verbatim.
+
+---
+
+## 6. Out of scope (explicit non-deliverables)
+
+- API reference docs. Use `cargo doc`.
+- Per-method walkthroughs of `DialogueManager::respond_to_streaming`. Manual covers the orchestration shape; the source is the source.
+- Build instructions for embedded targets (Phase 1 NPU work). Add when those backends land.
+- Translations of the manual. English-only initially; add when locale stories close.
+
+---
+
+## 7. Out-of-band coordination
+
+- After writing, the manual is committed in a single PR titled `docs(devel): contributor manual`.
+- `README.md` gets a one-line addition: "**Contributing?** See [docs/devel/](docs/devel/) for the developer manual."
+- `CLAUDE.md` gets no changes; the manual cross-links into it, not the other way around.
+
+---
+
+## 8. Success criteria
+
+The manual succeeds when:
+
+1. A new contributor can clone, build, and run the Primer with stub backend in under 10 minutes using only `01-getting-started.md`.
+2. Every recipe has been validated by walking through it against the actual codebase — code samples paste-runnable, line numbers correct.
+3. Every "gotcha" in `CLAUDE.md` either appears in the manual (as a `> **Gotcha:**` callout in the relevant chapter) or has been judged irrelevant to external contributors with a note in this spec.
+4. The mermaid diagrams render legibly on GitHub light theme, GitHub dark theme, and at least one offline viewer (VS Code's preview).
+5. Every internal link in the manual resolves; the index's "How do I…?" table reaches each recipe in one click.


### PR DESCRIPTION
## Summary

Adds a developer / contributor manual at [docs/devel/](docs/devel/) — 10 markdown files (index + 9 chapters) covering every subsystem, with 8 paste-runnable how-to recipes deep-linked from the index lookup table. Targets external open-source contributors joining the project.

> **Note on base branch:** stacked on #49 (hybrid retrieval tuning) so the diff stays clean. GitHub will auto-retarget to `main` once #49 merges; if not, retarget manually.

## What's in it

| # | Chapter | Covers |
|---|---|---|
| 01 | Getting started | Clone, build (default / cloud / Ollama / embedding / speech), env files, tests, logging |
| 02 | Architecture overview | Trait-based abstraction, 12-crate graph (mermaid + ASCII fallback), 4 pedagogical principles |
| 03 | Inference and pedagogy | `InferenceBackend`, `DialogueManager`, `decide_intent`, retry, error i18n + 2 recipes |
| 04 | Knowledge and retrieval | FTS5 + hybrid retrieval, embedders, seed corpus, locales + 2 recipes |
| 05 | Storage and sessions | Session/learner stores, schema migrations, long-term memory + 1 recipe |
| 06 | Classifiers and the learner model | Classifier/extractor/comprehension trio, vocab Leitner box + 1 recipe |
| 07 | Speech and the voice loop | VAD/STT/TTS, vendored crates, speech_loop state machine + 1 recipe |
| 08 | Testing and debugging | Test layout, RUST_LOG, common pitfalls, debugging recipes + 1 recipe |
| 09 | Contributing | PR workflow, commits, style, where to find open work |

8 recipes cover the high-traffic contributor surfaces: add a backend, intent, seed passages, locale, schema migration, structured-output classifier, speech backend, and diagnose a quiet classifier.

## Process

The manual was developed via the brainstorming → writing-plans → subagent-driven-development workflow. Spec at [docs/superpowers/specs/2026-05-08-developer-manual-design.md](docs/superpowers/specs/2026-05-08-developer-manual-design.md); plan at [docs/superpowers/plans/2026-05-08-developer-manual.md](docs/superpowers/plans/2026-05-08-developer-manual.md). Each chapter passed an independent spec-compliance + code-quality review; a final cross-cutting review caught the only systemic issue (bare repo-root link paths in chapters 3-6) and landed the mechanical fix.

Source verification during implementation caught and corrected ≥10 stale plan-vs-source claims (e.g. `PedagogicalIntent` lives in `conversation.rs` not `intent.rs`; sweep tests live under `primer-kb-load/tests/` not `primer-knowledge/tests/`; the FTS5 external-content table is `_content` not `_meta`).

## Conventions

- Welcoming-but-technical tone targeted at external Rust developers (NOT a Rust tutorial; assumes cargo workspace fluency).
- Four blockquote callout types: `> **Note:**`, `> **Gotcha:**`, `> **Why:**`, `> **Recipe — <Action>:**`.
- Mermaid palette tuned for legibility on both GitHub light and dark themes (white text on saturated dark fills, brighter strokes for graphical-element contrast).
- Cross-links use `../../` to escape `docs/devel/` for repo-root targets.

README.md gets a one-line link to the manual under a new Contributing section.

## Test plan

- [ ] All ten files render cleanly on GitHub (light and dark themes).
- [ ] Mermaid diagram in chapter 02 renders.
- [ ] Every recipe anchor in `index.md` lookup table lands on a real `### Recipe — ...` heading (verified by automated check).
- [ ] All `../../src/crates/...` and `../../README.md`-style links resolve to real files (verified by automated check — 0 broken).

## Out of scope

- API reference docs (use `cargo doc`).
- Per-method walkthroughs of `DialogueManager::respond_to_streaming` — covered in shape but not line-by-line.
- Translations of the manual; English only initially.
- Build instructions for embedded targets (Phase 1 NPU work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)