### PR TITLE
feat(gui): settings persistence + session lifecycle commands

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3421,8 +3421,28 @@ dependencies = [
 name = "primer-gui"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "primer-classifier",
+ "primer-comprehension",
+ "primer-core",
+ "primer-embedding",
+ "primer-engine",
+ "primer-extractor",
+ "primer-inference",
+ "primer-kb-load",
+ "primer-knowledge",
+ "primer-pedagogy",
+ "primer-storage",
+ "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/src/crates/primer-cli/src/main.rs
+++ b/src/crates/primer-cli/src/main.rs
@@ -257,7 +257,6 @@ fn parse_mic_silence_ms(s: &str) -> std::result::Result<u32, String> {
     Ok(n)
 }
 
-
 #[cfg(feature = "speech")]
 fn validate_speech_assets(
     whisper_model: &Path,
@@ -303,7 +302,6 @@ fn validate_speech_assets(
     }
     Ok(())
 }
-
 
 /// Probe common system locations for an `espeak-ng-data` directory and
 /// set `PIPER_ESPEAKNG_DATA_DIRECTORY` to the parent of the first complete
@@ -697,7 +695,8 @@ async fn async_main() -> anyhow::Result<()> {
     // only for testing the hybrid pipeline; with no semantic signal it
     // dilutes BM25 with noise, so it is not the production default.
     // `fastembed` and `ollama` need their respective cargo features;
-    // if missing, the dispatch helpers exit with a clear error.
+    // if missing, the dispatch helpers return Err and the CLI exits
+    // with the message (the GUI surfaces the same Err inline).
     //
     // Real-backend construction failures fall back to BM25-only with a
     // tracing warn — the conversation still works, which is strictly
@@ -708,14 +707,25 @@ async fn async_main() -> anyhow::Result<()> {
     {
         "none" => None,
         "stub" => Some(Arc::new(primer_embedding::StubEmbedder::new()) as _),
-        "fastembed" => build_fastembed_embedder(cli.embedder_model.as_deref()),
-        "ollama" => {
-            build_ollama_embedder(
-                cli.embedder_ollama_url.as_deref(),
-                cli.embedder_model.as_deref(),
-            )
-            .await
-        }
+        "fastembed" => match build_fastembed_embedder(cli.embedder_model.as_deref()) {
+            Ok(opt) => opt,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        },
+        "ollama" => match build_ollama_embedder(
+            cli.embedder_ollama_url.as_deref(),
+            cli.embedder_model.as_deref(),
+        )
+        .await
+        {
+            Ok(opt) => opt,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        },
         other => {
             eprintln!(
                 "Error: unknown --embedder-backend {other:?}; expected one of none, stub, fastembed, ollama"
@@ -913,7 +923,6 @@ async fn async_main() -> anyhow::Result<()> {
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -942,7 +951,6 @@ mod tests {
         assert!(parse_mic_silence_ms("").is_err());
         assert!(parse_mic_silence_ms("-100").is_err());
     }
-
 
     #[test]
     fn no_persist_conflicts_with_resume_at_parse_time() {

--- a/src/crates/primer-engine/src/lib.rs
+++ b/src/crates/primer-engine/src/lib.rs
@@ -13,8 +13,12 @@ pub mod learner;
 pub mod paths;
 pub mod wiring;
 
-pub use learner::{create_learner_with_id, reconcile_persisted_learner, verify_resume_locale_match};
-pub use paths::{IN_MEMORY, PRIMER_HOME_DIR, resolve_session_db_path, should_show_first_run_banner, slug};
+pub use learner::{
+    create_learner_with_id, reconcile_persisted_learner, verify_resume_locale_match,
+};
+pub use paths::{
+    IN_MEMORY, PRIMER_HOME_DIR, resolve_session_db_path, should_show_first_run_banner, slug,
+};
 pub use wiring::{
     BackendParams, build_backend, build_classifier, build_comprehension, build_extractor,
     build_fastembed_embedder, build_ollama_embedder,

--- a/src/crates/primer-engine/src/wiring.rs
+++ b/src/crates/primer-engine/src/wiring.rs
@@ -289,14 +289,22 @@ pub async fn build_comprehension(
     }
 }
 
-/// Construct a fastembed-rs-backed `Embedder`. Returns `None` and emits
-/// a stderr error when the `embedding` cargo feature is not compiled
-/// in or when fastembed init fails. Failure is *not* fatal — the
-/// caller falls back to BM25-only retrieval.
+/// Construct a fastembed-rs-backed `Embedder`.
+///
+/// Return-value semantics:
+/// - `Ok(Some(arc))` — feature compiled in AND init succeeded.
+/// - `Ok(None)` — feature compiled in but init failed (e.g. model
+///   download failed). Caller falls back to BM25-only retrieval; a
+///   warning is emitted to stderr so a CLI user sees it.
+/// - `Err(msg)` — feature not compiled in. The user explicitly asked
+///   for fastembed; surfacing this as an error lets the binary decide
+///   whether to exit (CLI) or render it inline (GUI). Earlier
+///   versions called `std::process::exit(1)` here which is hostile to
+///   any caller that isn't a CLI — never re-introduce that.
 #[cfg(feature = "embedding")]
 pub fn build_fastembed_embedder(
     model: Option<&str>,
-) -> Option<Arc<dyn primer_core::embedder::Embedder>> {
+) -> std::result::Result<Option<Arc<dyn primer_core::embedder::Embedder>>, String> {
     use primer_embedding::FastEmbedBackend;
     let m = model.unwrap_or(primer_embedding::BGE_M3_MODEL_ID);
     if m != primer_embedding::BGE_M3_MODEL_ID {
@@ -308,10 +316,10 @@ pub fn build_fastembed_embedder(
         "Loading fastembed model {m}; first run downloads ~570 MB into ~/.cache/primer/models/."
     );
     match FastEmbedBackend::new() {
-        Ok(b) => Some(Arc::new(b) as _),
+        Ok(b) => Ok(Some(Arc::new(b) as _)),
         Err(e) => {
             eprintln!("fastembed init failed ({e}); falling back to BM25-only retrieval.");
-            None
+            Ok(None)
         }
     }
 }
@@ -319,30 +327,30 @@ pub fn build_fastembed_embedder(
 #[cfg(not(feature = "embedding"))]
 pub fn build_fastembed_embedder(
     _model: Option<&str>,
-) -> Option<Arc<dyn primer_core::embedder::Embedder>> {
-    eprintln!(
-        "Error: --embedder-backend fastembed requires the `embedding` cargo feature. \
-         Build with `cargo run --features primer-cli/embedding -- ...` (or use --embedder-backend none)."
-    );
-    std::process::exit(1);
+) -> std::result::Result<Option<Arc<dyn primer_core::embedder::Embedder>>, String> {
+    Err(
+        "fastembed embedder requires the `embedding` cargo feature. \
+         Build with `cargo run --features primer-cli/embedding -- ...` (or use embedder = none)."
+            .to_string(),
+    )
 }
 
 #[cfg(feature = "ollama-embedding")]
 pub async fn build_ollama_embedder(
     url: Option<&str>,
     model: Option<&str>,
-) -> Option<Arc<dyn primer_core::embedder::Embedder>> {
+) -> std::result::Result<Option<Arc<dyn primer_core::embedder::Embedder>>, String> {
     use primer_embedding::{DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL, OllamaEmbedder};
     let url = url.unwrap_or(DEFAULT_OLLAMA_URL);
     let model = model.unwrap_or(DEFAULT_OLLAMA_MODEL);
     match OllamaEmbedder::with_endpoint(url, model).await {
         Ok(b) => {
             eprintln!("Embedder: ollama {model} at {url}");
-            Some(Arc::new(b) as _)
+            Ok(Some(Arc::new(b) as _))
         }
         Err(e) => {
             eprintln!("ollama embedder init failed ({e}); falling back to BM25-only retrieval.");
-            None
+            Ok(None)
         }
     }
 }
@@ -351,12 +359,12 @@ pub async fn build_ollama_embedder(
 pub async fn build_ollama_embedder(
     _url: Option<&str>,
     _model: Option<&str>,
-) -> Option<Arc<dyn primer_core::embedder::Embedder>> {
-    eprintln!(
-        "Error: --embedder-backend ollama requires the `ollama-embedding` cargo feature. \
+) -> std::result::Result<Option<Arc<dyn primer_core::embedder::Embedder>>, String> {
+    Err(
+        "ollama embedder requires the `ollama-embedding` cargo feature. \
          Build with `cargo run --features primer-cli/ollama-embedding -- ...`"
-    );
-    std::process::exit(1);
+            .to_string(),
+    )
 }
 
 #[cfg(test)]

--- a/src/crates/primer-gui/Cargo.toml
+++ b/src/crates/primer-gui/Cargo.toml
@@ -18,8 +18,44 @@ tauri-build = { workspace = true }
 # its Runtime type parameter.
 tauri = { workspace = true, features = ["wry"] }
 
-# Engine + pedagogy deps and the `embedding` / `ollama-embedding` feature
-# forwards land in step 3 alongside the first session-lifecycle commands.
+# JSON serialisation for GuiConfig + frontend DTOs.
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+# Structured logging for the same RUST_LOG=… surface the CLI exposes.
+# Without this, tracing::warn! calls inside the pedagogy/inference
+# stack disappear silently when the GUI drives them.
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+# Shared engine wiring + pedagogy stack the GUI drives.
+primer-engine.workspace = true
+primer-core.workspace = true
+primer-pedagogy.workspace = true
+primer-knowledge.workspace = true
+primer-storage.workspace = true
+primer-kb-load.workspace = true
+primer-classifier.workspace = true
+primer-extractor.workspace = true
+primer-comprehension.workspace = true
+primer-embedding.workspace = true
+primer-inference = { path = "../primer-inference" }
+
+tokio.workspace = true
+uuid.workspace = true
+chrono.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [features]
 default = []
+
+# Hybrid retrieval via fastembed-rs (BGE-M3). Mirrors primer-cli's flag
+# so the GUI can opt in independently. Forwards through to primer-engine
+# for the cfg-gated dispatch arms.
+embedding = ["primer-engine/embedding"]
+
+# Lightweight Ollama-backed embedder.
+ollama-embedding = ["primer-engine/ollama-embedding"]

--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -1,0 +1,26 @@
+//! Tauri commands exposed to the frontend.
+//!
+//! Each sub-module groups commands by the part of the app they
+//! manage. The free function [`register`] mounts every command on a
+//! Tauri builder in one place so `main.rs` doesn't accumulate one
+//! `.invoke_handler` line per new command.
+
+pub mod session;
+pub mod settings;
+
+use tauri::Wry;
+
+/// Register every command from every sub-module on a Tauri builder.
+///
+/// Adding a new command means appending it inside `tauri::generate_handler!`
+/// — the function signature stays generic so `main.rs` doesn't need to
+/// import the per-module command symbols.
+pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
+    builder.invoke_handler(tauri::generate_handler![
+        settings::get_settings,
+        settings::update_settings,
+        session::start_session,
+        session::close_session,
+        session::current_session_info,
+    ])
+}

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -1,0 +1,97 @@
+//! Session lifecycle commands: start, close, query.
+//!
+//! `start_session` builds an [`ActiveSession`] from the persisted
+//! `GuiConfig` and stores it in `AppState`. `close_session` drops it.
+//! `current_session_info` returns a serialisable summary so the
+//! frontend can render its header.
+//!
+//! `send_message` (the streaming command that drives a turn through
+//! `DialogueManager`) lands in step 4. `resume_session` + `list_sessions`
+//! land in step 9 alongside the picker.
+
+use crate::state::{ActiveSession, AppState};
+use crate::types::{LearnerSummary, SessionInfo};
+use crate::wiring;
+
+/// Construct an `ActiveSession` from the persisted settings and store
+/// it in `AppState`. Errors surface as `String` for inline rendering.
+///
+/// If a session is already open, it is closed first (no resource leak
+/// even if the frontend forgets to close before re-starting). The
+/// previous learner's state is saved before the new session opens.
+#[tauri::command]
+pub async fn start_session(state: tauri::State<'_, AppState>) -> Result<SessionInfo, String> {
+    // Close any pre-existing session first so the Arcs from the old
+    // construction drop before we build the new ones.
+    close_session_inner(&state).await?;
+
+    let cfg = state.config.lock().await.clone();
+    let active = wiring::build_active_session(&state.home, &cfg).await?;
+    let info = info_from(&active).await;
+    *state.session.lock().await = Some(active);
+    Ok(info)
+}
+
+/// Drop the active session, if any. Idempotent — calling it with no
+/// active session is a no-op (returns Ok).
+///
+/// Persists the current learner state on the way out so the next
+/// `start_session` (or the next CLI run) sees the latest box-levels
+/// / concept counts / engagement history.
+#[tauri::command]
+pub async fn close_session(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    close_session_inner(&state).await
+}
+
+/// Return a summary of the active session, or `None` if no session is
+/// open. Used by the frontend on launch to decide whether to render
+/// the picker or the chat view.
+#[tauri::command]
+pub async fn current_session_info(
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<SessionInfo>, String> {
+    let guard = state.session.lock().await;
+    if let Some(active) = guard.as_ref() {
+        Ok(Some(info_from(active).await))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Internal helper used by both `close_session` and `start_session` so
+/// the persistence-then-drop flow is centralised. Lock is released
+/// before the (potentially I/O-heavy) `save_learner` call so other
+/// commands aren't blocked on slow disk.
+async fn close_session_inner(state: &tauri::State<'_, AppState>) -> Result<(), String> {
+    let to_save = {
+        let mut guard = state.session.lock().await;
+        if let Some(active) = guard.take() {
+            let snapshot = active.learner.lock().await.clone();
+            Some((std::sync::Arc::clone(&active.learner_store), snapshot))
+        } else {
+            None
+        }
+    };
+    if let Some((store, snapshot)) = to_save {
+        if let Err(e) = store.save_learner(&snapshot).await {
+            tracing::warn!("save_learner on close failed: {e}");
+        }
+    }
+    Ok(())
+}
+
+async fn info_from(active: &ActiveSession) -> SessionInfo {
+    let learner = active.learner.lock().await;
+    SessionInfo {
+        session_id: active.session_id,
+        learner: LearnerSummary {
+            id: learner.profile.id,
+            name: learner.profile.name.clone(),
+            age: learner.profile.age,
+            concept_count: learner.concepts.len(),
+        },
+        backend_kind: active.backend_name.clone(),
+        main_model: active.main_model.clone(),
+        locale: active.locale.pack_id().to_string(),
+    }
+}

--- a/src/crates/primer-gui/src/commands/settings.rs
+++ b/src/crates/primer-gui/src/commands/settings.rs
@@ -1,0 +1,38 @@
+//! Settings commands: load, return, persist.
+//!
+//! `get_settings` is a pure read of the in-memory copy held by
+//! `AppState`. `update_settings` swaps the in-memory copy AND atomically
+//! writes the JSON to disk so a crash between IPC round-trips never
+//! leaves the user's settings out of sync.
+
+use crate::config::{self, GuiConfig};
+use crate::state::AppState;
+
+/// Return the current GUI settings. Always succeeds — even when no
+/// config file exists on disk (defaults are returned).
+#[tauri::command]
+pub async fn get_settings(state: tauri::State<'_, AppState>) -> Result<GuiConfig, String> {
+    Ok(state.config.lock().await.clone())
+}
+
+/// Replace the current GUI settings.
+///
+/// Order matters: persist to disk first (so a panic between the disk
+/// write and the in-memory swap never leaves disk lagging memory),
+/// then update the in-memory copy. Returns the validation/error
+/// string for the frontend to render inline.
+///
+/// **Active-session impact:** the in-memory ActiveSession (if any) is
+/// NOT mutated here. Settings that affect the active session (backend,
+/// model, locale, embedder) take effect only after the next
+/// `start_session` — this matches the "Save & start new session"
+/// flow planned for the settings modal in step 8.
+#[tauri::command]
+pub async fn update_settings(
+    state: tauri::State<'_, AppState>,
+    config: GuiConfig,
+) -> Result<(), String> {
+    config::save(&state.home, &config).map_err(|e| e.to_string())?;
+    *state.config.lock().await = config;
+    Ok(())
+}

--- a/src/crates/primer-gui/src/commands/settings.rs
+++ b/src/crates/primer-gui/src/commands/settings.rs
@@ -1,26 +1,34 @@
 //! Settings commands: load, return, persist.
 //!
-//! `get_settings` is a pure read of the in-memory copy held by
-//! `AppState`. `update_settings` swaps the in-memory copy AND atomically
-//! writes the JSON to disk so a crash between IPC round-trips never
-//! leaves the user's settings out of sync.
+//! `get_settings` returns a redacted view ([`GuiConfigView`]) so the
+//! inline API key never crosses the IPC boundary. `update_settings`
+//! consumes a [`GuiConfigUpdate`] whose `ApiKeyUpdate::Keep` variant
+//! lets the frontend save the rest of the config without ever holding
+//! the secret. Validation runs *before* the disk write so a bad config
+//! never lands on disk.
 
-use crate::config::{self, GuiConfig};
+use crate::config::{self, GuiConfigUpdate, GuiConfigView};
 use crate::state::AppState;
+use crate::validation;
 
-/// Return the current GUI settings. Always succeeds — even when no
-/// config file exists on disk (defaults are returned).
+/// Return the current GUI settings (redacted view — no inline API key).
+/// Always succeeds; missing-on-disk returns the in-memory defaults
+/// loaded at startup.
 #[tauri::command]
-pub async fn get_settings(state: tauri::State<'_, AppState>) -> Result<GuiConfig, String> {
-    Ok(state.config.lock().await.clone())
+pub async fn get_settings(state: tauri::State<'_, AppState>) -> Result<GuiConfigView, String> {
+    Ok((&*state.config.lock().await).into())
 }
 
 /// Replace the current GUI settings.
 ///
-/// Order matters: persist to disk first (so a panic between the disk
-/// write and the in-memory swap never leaves disk lagging memory),
-/// then update the in-memory copy. Returns the validation/error
-/// string for the frontend to render inline.
+/// Steps, in order:
+/// 1. Resolve the update against the persisted value (so
+///    `ApiKeyUpdate::Keep` carries forward the existing secret).
+/// 2. Validate — surface obviously-bad configs (unknown backend kind,
+///    embedder kind, locale, etc.) here rather than at the next
+///    `start_session`.
+/// 3. Atomically persist to disk.
+/// 4. Swap the in-memory copy.
 ///
 /// **Active-session impact:** the in-memory ActiveSession (if any) is
 /// NOT mutated here. Settings that affect the active session (backend,
@@ -30,9 +38,12 @@ pub async fn get_settings(state: tauri::State<'_, AppState>) -> Result<GuiConfig
 #[tauri::command]
 pub async fn update_settings(
     state: tauri::State<'_, AppState>,
-    config: GuiConfig,
+    config: GuiConfigUpdate,
 ) -> Result<(), String> {
-    config::save(&state.home, &config).map_err(|e| e.to_string())?;
-    *state.config.lock().await = config;
+    let mut guard = state.config.lock().await;
+    let resolved = config.into_config(&guard);
+    validation::validate(&resolved)?;
+    config::save(&state.home, &resolved).map_err(|e| e.to_string())?;
+    *guard = resolved;
     Ok(())
 }

--- a/src/crates/primer-gui/src/config.rs
+++ b/src/crates/primer-gui/src/config.rs
@@ -8,6 +8,12 @@
 //!
 //! Defaults are derived from the CLI's clap defaults so a brand-new
 //! install behaves identically to `primer` with no flags.
+//!
+//! **Secret handling:** the inline API key never crosses the IPC
+//! boundary in either direction *unless explicitly being set*. The
+//! [`view`] / [`update`] DTOs are the only types serialised on the
+//! frontend round-trip; [`GuiConfig`] itself is reserved for disk and
+//! the Rust-side wiring path. See [`ApiKeySource`] / [`ApiKeyUpdate`].
 
 use std::fs;
 use std::io::Write;
@@ -85,6 +91,12 @@ impl Default for BackendConfig {
 /// environment at session-start time. `Inline` keeps the key in the
 /// config JSON (file mode 0600). The two-variant shape mirrors the
 /// CLI's "`--api-key` OR env" behaviour.
+///
+/// **Disk-only.** This type is intentionally NOT exposed to the
+/// frontend — every serialisation site that crosses the IPC boundary
+/// uses [`ApiKeySourceView`] (read) or [`ApiKeyUpdate`] (write).
+/// Re-exposing the inline key over IPC would let any compromised
+/// frontend JS exfiltrate the secret.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ApiKeySource {
@@ -95,6 +107,56 @@ pub enum ApiKeySource {
 impl Default for ApiKeySource {
     fn default() -> Self {
         Self::Env
+    }
+}
+
+/// Frontend-safe projection of [`ApiKeySource`].
+///
+/// `Inline { has_key }` carries a boolean — *whether* a key is stored,
+/// not the key itself — so the settings UI can render "inline key is
+/// set" without ever seeing the secret.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ApiKeySourceView {
+    Env,
+    Inline { has_key: bool },
+}
+
+impl From<&ApiKeySource> for ApiKeySourceView {
+    fn from(s: &ApiKeySource) -> Self {
+        match s {
+            ApiKeySource::Env => Self::Env,
+            ApiKeySource::Inline { key } => Self::Inline {
+                has_key: !key.is_empty(),
+            },
+        }
+    }
+}
+
+/// Update intent for the inline API key on the [`update_settings`](crate::commands::settings::update_settings) write path.
+///
+/// `Keep` is the workhorse — the frontend rendered the redacted view
+/// and isn't touching the secret, so the persisted value carries
+/// through. `Env` and `Inline` switch the source explicitly.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ApiKeyUpdate {
+    /// Preserve whatever's already persisted on disk.
+    Keep,
+    Env,
+    Inline {
+        key: String,
+    },
+}
+
+impl ApiKeyUpdate {
+    /// Resolve to a concrete [`ApiKeySource`] given the currently-persisted value.
+    pub fn resolve(self, current: &ApiKeySource) -> ApiKeySource {
+        match self {
+            Self::Keep => current.clone(),
+            Self::Env => ApiKeySource::Env,
+            Self::Inline { key } => ApiKeySource::Inline { key },
+        }
     }
 }
 
@@ -237,8 +299,19 @@ pub enum ConfigError {
         #[source]
         source: std::io::Error,
     },
+    /// JSON decode failure on `load`.
     #[error("config JSON decode failed at {path}: {source}")]
     Parse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    /// JSON encode failure on `save`. Practically never happens for
+    /// our `Serialize`-derived types, but keeping it distinct from
+    /// `Parse` prevents the misleading "decode failed" message when
+    /// the failing direction was an encode.
+    #[error("config JSON encode failed for {path}: {source}")]
+    Serialize {
         path: PathBuf,
         #[source]
         source: serde_json::Error,
@@ -247,7 +320,8 @@ pub enum ConfigError {
 
 /// Resolve the absolute path of the GUI config file from a home directory.
 pub fn config_path(home: &Path) -> PathBuf {
-    home.join(primer_engine::PRIMER_HOME_DIR).join(CONFIG_FILENAME)
+    home.join(primer_engine::PRIMER_HOME_DIR)
+        .join(CONFIG_FILENAME)
 }
 
 /// Load the GUI config from disk.
@@ -283,7 +357,7 @@ pub fn save(home: &Path, config: &GuiConfig) -> Result<(), ConfigError> {
         source,
     })?;
 
-    let json = serde_json::to_string_pretty(config).map_err(|source| ConfigError::Parse {
+    let json = serde_json::to_string_pretty(config).map_err(|source| ConfigError::Serialize {
         path: path.clone(),
         source,
     })?;
@@ -294,10 +368,11 @@ pub fn save(home: &Path, config: &GuiConfig) -> Result<(), ConfigError> {
             path: tmp.clone(),
             source,
         })?;
-        f.write_all(json.as_bytes()).map_err(|source| ConfigError::Io {
-            path: tmp.clone(),
-            source,
-        })?;
+        f.write_all(json.as_bytes())
+            .map_err(|source| ConfigError::Io {
+                path: tmp.clone(),
+                source,
+            })?;
         f.sync_all().map_err(|source| ConfigError::Io {
             path: tmp.clone(),
             source,
@@ -316,6 +391,117 @@ pub fn save(home: &Path, config: &GuiConfig) -> Result<(), ConfigError> {
         source,
     })?;
     Ok(())
+}
+
+// ─── Frontend-facing DTOs ────────────────────────────────────────────
+//
+// `GuiConfigView` mirrors `GuiConfig` but uses [`BackendConfigView`]
+// (which redacts the inline API key). `GuiConfigUpdate` mirrors it on
+// the write path with [`BackendConfigUpdate`] (which carries
+// [`ApiKeyUpdate::Keep`] when the frontend isn't touching the key).
+//
+// Every IPC boundary uses these — never `GuiConfig` directly.
+
+/// Frontend-safe projection of [`GuiConfig`] (read path).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GuiConfigView {
+    pub learner: LearnerConfig,
+    pub backend: BackendConfigView,
+    pub classifier: SubsystemConfig,
+    pub extractor: SubsystemConfig,
+    pub comprehension: SubsystemConfig,
+    pub embedder: EmbedderConfig,
+    pub vocab: VocabConfig,
+    pub breaks: BreakConfig,
+    pub persistence: PersistenceConfig,
+    pub ui: UiConfig,
+}
+
+/// Frontend-safe projection of [`BackendConfig`] (read path).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BackendConfigView {
+    pub kind: String,
+    pub model: Option<String>,
+    pub ollama_url: String,
+    pub api_key_source: ApiKeySourceView,
+}
+
+impl From<&GuiConfig> for GuiConfigView {
+    fn from(c: &GuiConfig) -> Self {
+        Self {
+            learner: c.learner.clone(),
+            backend: BackendConfigView {
+                kind: c.backend.kind.clone(),
+                model: c.backend.model.clone(),
+                ollama_url: c.backend.ollama_url.clone(),
+                api_key_source: (&c.backend.api_key_source).into(),
+            },
+            classifier: c.classifier.clone(),
+            extractor: c.extractor.clone(),
+            comprehension: c.comprehension.clone(),
+            embedder: c.embedder.clone(),
+            vocab: c.vocab.clone(),
+            breaks: c.breaks.clone(),
+            persistence: c.persistence.clone(),
+            ui: c.ui.clone(),
+        }
+    }
+}
+
+/// Update intent for [`GuiConfig`] (write path).
+///
+/// Same shape as `GuiConfig` except `backend.api_key_source` is an
+/// [`ApiKeyUpdate`] — `Keep` (the common case) preserves whatever
+/// secret is already on disk so the frontend never has to handle it.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GuiConfigUpdate {
+    pub learner: LearnerConfig,
+    pub backend: BackendConfigUpdate,
+    pub classifier: SubsystemConfig,
+    pub extractor: SubsystemConfig,
+    pub comprehension: SubsystemConfig,
+    pub embedder: EmbedderConfig,
+    pub vocab: VocabConfig,
+    pub breaks: BreakConfig,
+    pub persistence: PersistenceConfig,
+    pub ui: UiConfig,
+}
+
+/// Update intent for [`BackendConfig`] (write path).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct BackendConfigUpdate {
+    pub kind: String,
+    pub model: Option<String>,
+    pub ollama_url: String,
+    pub api_key_source: ApiKeyUpdate,
+}
+
+impl GuiConfigUpdate {
+    /// Resolve to a concrete [`GuiConfig`] using the currently-persisted
+    /// value to fill in any field the update keeps (today only the
+    /// inline API key).
+    pub fn into_config(self, current: &GuiConfig) -> GuiConfig {
+        GuiConfig {
+            learner: self.learner,
+            backend: BackendConfig {
+                kind: self.backend.kind,
+                model: self.backend.model,
+                ollama_url: self.backend.ollama_url,
+                api_key_source: self
+                    .backend
+                    .api_key_source
+                    .resolve(&current.backend.api_key_source),
+            },
+            classifier: self.classifier,
+            extractor: self.extractor,
+            comprehension: self.comprehension,
+            embedder: self.embedder,
+            vocab: self.vocab,
+            breaks: self.breaks,
+            persistence: self.persistence,
+            ui: self.ui,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -435,6 +621,110 @@ mod tests {
         assert_eq!(cfg.backend, BackendConfig::default());
         assert_eq!(cfg.embedder, EmbedderConfig::default());
         assert_eq!(cfg.ui, UiConfig::default());
+    }
+
+    // ─── View / Update DTO tests ─────────────────────────────────────
+
+    #[test]
+    fn view_redacts_inline_api_key() {
+        // The single most important security test: the inline key must
+        // never appear in the JSON the frontend receives.
+        let mut cfg = GuiConfig::default();
+        cfg.backend.api_key_source = ApiKeySource::Inline {
+            key: "sk-secret-token-aaa".to_string(),
+        };
+        let view: GuiConfigView = (&cfg).into();
+        let json = serde_json::to_string(&view).unwrap();
+        assert!(
+            !json.contains("sk-secret-token-aaa"),
+            "redacted view must not contain the key: {json}"
+        );
+        assert!(
+            json.contains("\"has_key\":true"),
+            "view must signal a key is set: {json}"
+        );
+    }
+
+    #[test]
+    fn view_redacts_empty_inline_key_as_has_key_false() {
+        let mut cfg = GuiConfig::default();
+        cfg.backend.api_key_source = ApiKeySource::Inline { key: String::new() };
+        let view: GuiConfigView = (&cfg).into();
+        assert_eq!(
+            view.backend.api_key_source,
+            ApiKeySourceView::Inline { has_key: false }
+        );
+    }
+
+    #[test]
+    fn view_passes_env_source_through() {
+        let cfg = GuiConfig::default();
+        let view: GuiConfigView = (&cfg).into();
+        assert_eq!(view.backend.api_key_source, ApiKeySourceView::Env);
+    }
+
+    #[test]
+    fn update_keep_preserves_existing_inline_key() {
+        let mut current = GuiConfig::default();
+        current.backend.api_key_source = ApiKeySource::Inline {
+            key: "sk-original".to_string(),
+        };
+        let update_json = r#"{
+            "learner": {"name": "Ada", "age": 7, "locale": "en"},
+            "backend": {
+                "kind": "cloud",
+                "model": null,
+                "ollama_url": "http://localhost:11434",
+                "api_key_source": {"kind": "keep"}
+            },
+            "classifier": {"match_main": true, "kind": null, "model": null, "timeout_ms": 3000},
+            "extractor": {"match_main": true, "kind": null, "model": null, "timeout_ms": 5000},
+            "comprehension": {"match_main": true, "kind": null, "model": null, "timeout_ms": 5000},
+            "embedder": {"kind": "none", "model": null, "ollama_url": null},
+            "vocab": {"max_per_prompt": null},
+            "breaks": {"after_mins": 30},
+            "persistence": {"session_db": null, "knowledge_db": null, "no_persist": false},
+            "ui": {"sidebar_open": true, "last_section": "current_turn"}
+        }"#;
+        let update: GuiConfigUpdate = serde_json::from_str(update_json).unwrap();
+        let resolved = update.into_config(&current);
+        assert_eq!(
+            resolved.backend.api_key_source,
+            ApiKeySource::Inline {
+                key: "sk-original".to_string()
+            },
+            "Keep variant must carry forward the persisted key"
+        );
+        // Other fields come from the update, not the current.
+        assert_eq!(resolved.learner.name, "Ada");
+    }
+
+    #[test]
+    fn update_inline_overwrites_existing_key() {
+        let mut current = GuiConfig::default();
+        current.backend.api_key_source = ApiKeySource::Inline {
+            key: "sk-original".to_string(),
+        };
+        let new = ApiKeyUpdate::Inline {
+            key: "sk-rotated".to_string(),
+        };
+        let resolved = new.resolve(&current.backend.api_key_source);
+        assert_eq!(
+            resolved,
+            ApiKeySource::Inline {
+                key: "sk-rotated".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn update_env_clears_existing_inline_key() {
+        let mut current = GuiConfig::default();
+        current.backend.api_key_source = ApiKeySource::Inline {
+            key: "sk-original".to_string(),
+        };
+        let resolved = ApiKeyUpdate::Env.resolve(&current.backend.api_key_source);
+        assert_eq!(resolved, ApiKeySource::Env);
     }
 
     #[test]

--- a/src/crates/primer-gui/src/config.rs
+++ b/src/crates/primer-gui/src/config.rs
@@ -1,0 +1,459 @@
+//! `GuiConfig` — the GUI's persisted settings.
+//!
+//! Mirrors the [`primer-cli`](../../primer-cli) flag set 1-for-1 so a
+//! parent who has used the CLI can switch to the GUI without learning
+//! a new vocabulary. Persisted to `~/.primer/gui-config.json` (atomic
+//! temp-file write + rename, mode 0600 since the file may carry an
+//! inline API key).
+//!
+//! Defaults are derived from the CLI's clap defaults so a brand-new
+//! install behaves identically to `primer` with no flags.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Filename inside `~/.primer/` where the GUI config is persisted.
+pub const CONFIG_FILENAME: &str = "gui-config.json";
+
+/// Top-level container for every GUI setting.
+///
+/// Each sub-struct groups one CLI subsystem so the settings modal can
+/// render them as collapsible sections without bookkeeping.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct GuiConfig {
+    pub learner: LearnerConfig,
+    pub backend: BackendConfig,
+    pub classifier: SubsystemConfig,
+    pub extractor: SubsystemConfig,
+    pub comprehension: SubsystemConfig,
+    pub embedder: EmbedderConfig,
+    pub vocab: VocabConfig,
+    pub breaks: BreakConfig,
+    pub persistence: PersistenceConfig,
+    pub ui: UiConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LearnerConfig {
+    pub name: String,
+    pub age: u8,
+    /// Locale pack id (BCP-47 short — "en", "de", ...).
+    pub locale: String,
+}
+
+impl Default for LearnerConfig {
+    fn default() -> Self {
+        Self {
+            name: "Explorer".to_string(),
+            age: 8,
+            locale: "en".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BackendConfig {
+    /// "stub" | "cloud" | "ollama"
+    pub kind: String,
+    /// Model id. None means "use the CLI's per-kind default".
+    pub model: Option<String>,
+    pub ollama_url: String,
+    /// Where to read the API key from when `kind == "cloud"`.
+    pub api_key_source: ApiKeySource,
+}
+
+impl Default for BackendConfig {
+    fn default() -> Self {
+        Self {
+            kind: "stub".to_string(),
+            model: None,
+            ollama_url: "http://localhost:11434".to_string(),
+            api_key_source: ApiKeySource::default(),
+        }
+    }
+}
+
+/// How the cloud backend obtains its API key.
+///
+/// Default is `Env` — read `ANTHROPIC_API_KEY` from the process
+/// environment at session-start time. `Inline` keeps the key in the
+/// config JSON (file mode 0600). The two-variant shape mirrors the
+/// CLI's "`--api-key` OR env" behaviour.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ApiKeySource {
+    Env,
+    Inline { key: String },
+}
+
+impl Default for ApiKeySource {
+    fn default() -> Self {
+        Self::Env
+    }
+}
+
+/// Settings for the classifier / extractor / comprehension subsystems.
+///
+/// `match_main = true` collapses all override fields — the subsystem
+/// uses the main backend and main model. `match_main = false` requires
+/// the kind/model/timeout fields to be respected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SubsystemConfig {
+    pub match_main: bool,
+    /// "stub" | "cloud" | "ollama"
+    pub kind: Option<String>,
+    pub model: Option<String>,
+    pub timeout_ms: u64,
+}
+
+impl SubsystemConfig {
+    /// Default for the classifier — 3000 ms timeout, matching CLI.
+    pub fn default_classifier() -> Self {
+        Self {
+            match_main: true,
+            kind: None,
+            model: None,
+            timeout_ms: primer_classifier::consts::DEFAULT_BLOCKING_TIMEOUT_MS,
+        }
+    }
+
+    /// Default for the extractor — 5000 ms timeout, matching CLI.
+    pub fn default_extractor() -> Self {
+        Self {
+            match_main: true,
+            kind: None,
+            model: None,
+            timeout_ms: primer_extractor::consts::DEFAULT_BLOCKING_TIMEOUT_MS,
+        }
+    }
+
+    /// Default for the comprehension classifier — 5000 ms timeout, matching CLI.
+    pub fn default_comprehension() -> Self {
+        Self {
+            match_main: true,
+            kind: None,
+            model: None,
+            timeout_ms: primer_comprehension::consts::DEFAULT_BLOCKING_TIMEOUT_MS,
+        }
+    }
+}
+
+impl Default for SubsystemConfig {
+    fn default() -> Self {
+        Self::default_classifier()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EmbedderConfig {
+    /// "none" | "stub" | "fastembed" | "ollama"
+    pub kind: String,
+    pub model: Option<String>,
+    pub ollama_url: Option<String>,
+}
+
+impl Default for EmbedderConfig {
+    fn default() -> Self {
+        Self {
+            kind: "none".to_string(),
+            model: None,
+            ollama_url: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct VocabConfig {
+    /// Top-K most-overdue concepts to inject into the system prompt as
+    /// passive review hints. `None` keeps the CLI default.
+    pub max_per_prompt: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BreakConfig {
+    /// Minutes between break-suggestion nudges. Must be >= 1.
+    pub after_mins: u32,
+}
+
+impl Default for BreakConfig {
+    fn default() -> Self {
+        Self {
+            after_mins: primer_core::consts::break_suggest::DEFAULT_INTERVAL_MINUTES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistenceConfig {
+    /// Explicit session DB path. `None` → default to
+    /// `~/.primer/<slug(name)>.db` at session-start time.
+    pub session_db: Option<PathBuf>,
+    /// Knowledge DB path. `None` → `:memory:`.
+    pub knowledge_db: Option<PathBuf>,
+    /// When true, neither DB is written to disk and `session_db` /
+    /// `knowledge_db` are ignored.
+    pub no_persist: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UiConfig {
+    /// Right sidebar default-open state. Step 5+ remembers this across launches.
+    pub sidebar_open: bool,
+    /// Last-active sidebar section: "current_turn" | "learner" | "session".
+    /// Free-text on disk so adding a section in a later step doesn't break older
+    /// configs.
+    pub last_section: String,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            sidebar_open: true,
+            last_section: "current_turn".to_string(),
+        }
+    }
+}
+
+/// Errors load/save can produce. Distinguished from a missing file
+/// (which is returned as `Ok(Default::default())` so the GUI always
+/// has *something* to render).
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("config I/O error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("config JSON decode failed at {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// Resolve the absolute path of the GUI config file from a home directory.
+pub fn config_path(home: &Path) -> PathBuf {
+    home.join(primer_engine::PRIMER_HOME_DIR).join(CONFIG_FILENAME)
+}
+
+/// Load the GUI config from disk.
+///
+/// - Missing file → returns `Ok(GuiConfig::default())` so the GUI can
+///   always boot. The caller is responsible for writing the defaults
+///   back on first save (no implicit write here — we keep this pure).
+/// - Malformed JSON → `Err(ConfigError::Parse)` so the frontend can
+///   surface "your config is broken; here's the path" rather than
+///   silently clobbering user state.
+pub fn load(home: &Path) -> Result<GuiConfig, ConfigError> {
+    let path = config_path(home);
+    match fs::read_to_string(&path) {
+        Ok(s) => serde_json::from_str(&s).map_err(|source| ConfigError::Parse { path, source }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(GuiConfig::default()),
+        Err(source) => Err(ConfigError::Io { path, source }),
+    }
+}
+
+/// Atomically save the GUI config to disk.
+///
+/// - Creates `~/.primer/` if missing.
+/// - Writes to `<file>.tmp` then renames over the destination so a
+///   concurrent reader never sees a partial file.
+/// - On Unix, sets the destination to mode 0600 because it may carry
+///   an inline `ApiKeySource::Inline { key }`. Best-effort on platforms
+///   without Unix permissions; the rename still succeeds.
+pub fn save(home: &Path, config: &GuiConfig) -> Result<(), ConfigError> {
+    let path = config_path(home);
+    let parent = path.parent().expect("config_path always has a parent");
+    fs::create_dir_all(parent).map_err(|source| ConfigError::Io {
+        path: parent.to_path_buf(),
+        source,
+    })?;
+
+    let json = serde_json::to_string_pretty(config).map_err(|source| ConfigError::Parse {
+        path: path.clone(),
+        source,
+    })?;
+
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut f = fs::File::create(&tmp).map_err(|source| ConfigError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+        f.write_all(json.as_bytes()).map_err(|source| ConfigError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+        f.sync_all().map_err(|source| ConfigError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        let _ = fs::set_permissions(&tmp, perms);
+    }
+
+    fs::rename(&tmp, &path).map_err(|source| ConfigError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_missing_returns_defaults() {
+        let dir = TempDir::new().unwrap();
+        let cfg = load(dir.path()).unwrap();
+        assert_eq!(cfg, GuiConfig::default());
+        // Missing file does NOT create one — pure read.
+        assert!(!config_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn load_malformed_surfaces_parse_error() {
+        let dir = TempDir::new().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"{ this is not json").unwrap();
+
+        let err = load(dir.path()).unwrap_err();
+        match err {
+            ConfigError::Parse { path: p, .. } => {
+                assert_eq!(p, path, "error must name the offending path");
+            }
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = GuiConfig::default();
+        cfg.learner.name = "Binti".to_string();
+        cfg.learner.age = 9;
+        cfg.learner.locale = "de".to_string();
+        cfg.backend.kind = "cloud".to_string();
+        cfg.backend.model = Some("claude-sonnet-4-6".to_string());
+        cfg.backend.api_key_source = ApiKeySource::Inline {
+            key: "test-key-not-real".to_string(),
+        };
+        cfg.embedder.kind = "fastembed".to_string();
+        cfg.vocab.max_per_prompt = Some(6);
+        cfg.breaks.after_mins = 45;
+        cfg.persistence.no_persist = true;
+
+        save(dir.path(), &cfg).unwrap();
+        let round_trip = load(dir.path()).unwrap();
+        assert_eq!(round_trip, cfg);
+    }
+
+    #[test]
+    fn save_creates_primer_subdirectory_if_missing() {
+        let dir = TempDir::new().unwrap();
+        let primer_dir = dir.path().join(primer_engine::PRIMER_HOME_DIR);
+        assert!(!primer_dir.exists());
+
+        save(dir.path(), &GuiConfig::default()).unwrap();
+        assert!(primer_dir.is_dir());
+        assert!(config_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn save_is_atomic_no_temp_left_on_success() {
+        let dir = TempDir::new().unwrap();
+        save(dir.path(), &GuiConfig::default()).unwrap();
+        let tmp = config_path(dir.path()).with_extension("json.tmp");
+        assert!(!tmp.exists(), "temp file must be renamed away on success");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_sets_mode_0600_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        save(dir.path(), &GuiConfig::default()).unwrap();
+        let metadata = fs::metadata(config_path(dir.path())).unwrap();
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "config file must be user-read-write only");
+    }
+
+    #[test]
+    fn forward_compatibility_unknown_field_is_ignored() {
+        // Adding a future field shouldn't poison existing configs; serde
+        // skips unknown fields by default. This test pins that contract.
+        let dir = TempDir::new().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let json = r#"{
+            "learner": {"name": "Binti", "age": 9, "locale": "de"},
+            "future_field_we_dont_know_about": {"x": 1}
+        }"#;
+        fs::write(&path, json).unwrap();
+
+        let cfg = load(dir.path()).unwrap();
+        assert_eq!(cfg.learner.name, "Binti");
+        assert_eq!(cfg.learner.age, 9);
+        assert_eq!(cfg.learner.locale, "de");
+    }
+
+    #[test]
+    fn partial_json_fills_unspecified_fields_with_defaults() {
+        // serde(default) on every field/section means an older config
+        // missing newer sections still loads cleanly.
+        let dir = TempDir::new().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let json = r#"{"learner": {"name": "Ada", "age": 7, "locale": "en"}}"#;
+        fs::write(&path, json).unwrap();
+
+        let cfg = load(dir.path()).unwrap();
+        assert_eq!(cfg.learner.name, "Ada");
+        // All other sections come from defaults.
+        assert_eq!(cfg.backend, BackendConfig::default());
+        assert_eq!(cfg.embedder, EmbedderConfig::default());
+        assert_eq!(cfg.ui, UiConfig::default());
+    }
+
+    #[test]
+    fn subsystem_defaults_match_consts() {
+        let cls = SubsystemConfig::default_classifier();
+        assert_eq!(
+            cls.timeout_ms,
+            primer_classifier::consts::DEFAULT_BLOCKING_TIMEOUT_MS
+        );
+        assert!(cls.match_main);
+        let ext = SubsystemConfig::default_extractor();
+        assert_eq!(
+            ext.timeout_ms,
+            primer_extractor::consts::DEFAULT_BLOCKING_TIMEOUT_MS
+        );
+        let cmp = SubsystemConfig::default_comprehension();
+        assert_eq!(
+            cmp.timeout_ms,
+            primer_comprehension::consts::DEFAULT_BLOCKING_TIMEOUT_MS
+        );
+    }
+}

--- a/src/crates/primer-gui/src/lib.rs
+++ b/src/crates/primer-gui/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commands;
 pub mod config;
 pub mod state;
 pub mod types;
+pub mod validation;
 pub mod wiring;
 
 use std::path::PathBuf;

--- a/src/crates/primer-gui/src/lib.rs
+++ b/src/crates/primer-gui/src/lib.rs
@@ -1,0 +1,56 @@
+//! The Primer GUI library — Tauri commands, app state, settings.
+//!
+//! The binary at `src/main.rs` is a thin shim around [`run`]; everything
+//! interesting (commands, state, persistence) lives here so it can be
+//! unit-tested without the Tauri WebView in the loop.
+
+pub mod commands;
+pub mod config;
+pub mod state;
+pub mod types;
+pub mod wiring;
+
+use std::path::PathBuf;
+
+/// Resolve `$HOME` and return a default path if it isn't set, mirroring
+/// the CLI's tolerance for missing-HOME (the binary itself fails later
+/// only when an unset HOME would force an empty session-DB path).
+pub fn resolve_home() -> PathBuf {
+    std::env::var("HOME").map(PathBuf::from).unwrap_or_default()
+}
+
+/// Entry point used by `main.rs`. Initialises tracing, builds the
+/// `AppState` (loading the persisted `GuiConfig` from `~/.primer/`),
+/// registers every Tauri command, and starts the WebView event loop.
+///
+/// Returns once the user closes the window. A startup-time tracing
+/// init failure is non-fatal — we log a stderr line and continue with
+/// the unconfigured default subscriber, the same posture the CLI takes.
+pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing();
+
+    let home = resolve_home();
+    let config = config::load(&home).unwrap_or_else(|e| {
+        // A malformed on-disk config shouldn't keep the GUI from
+        // booting — the user needs an interface to fix it. Log and
+        // start with defaults; `update_settings` will overwrite on
+        // first save.
+        tracing::error!("loading gui-config.json failed: {e}; using defaults");
+        config::GuiConfig::default()
+    });
+    let state = state::AppState::new(home, config);
+
+    let builder = tauri::Builder::default().manage(state);
+    let builder = commands::register(builder);
+    builder
+        .run(tauri::generate_context!())
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+}
+
+fn init_tracing() {
+    use tracing_subscriber::EnvFilter;
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    if let Err(e) = tracing_subscriber::fmt().with_env_filter(filter).try_init() {
+        eprintln!("tracing init failed: {e}");
+    }
+}

--- a/src/crates/primer-gui/src/main.rs
+++ b/src/crates/primer-gui/src/main.rs
@@ -1,8 +1,9 @@
 //! The Primer GUI — a Tauri desktop UI for testing and monitoring
 //! the Socratic dialogue engine.
 //!
-//! Step 2 (this commit) scaffolds an empty window. Step 3 wires the
-//! session lifecycle commands; step 4 streams chat.
+//! Thin shim around [`primer_gui::run`]. Everything interesting lives
+//! in the library so commands, state, and persistence can be
+//! unit-tested without the Tauri WebView in the loop.
 
 // On Windows, suppress the console-subsystem prompt when running the
 // release build (the Tauri default — kept here so a future cargo run
@@ -10,10 +11,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    // TODO(step 3): initialise tracing-subscriber with EnvFilter (mirroring
-    // primer-cli) once the engine wiring lands — without it, `tracing::warn!`
-    // calls inside the pedagogy/inference stack silently disappear.
-    tauri::Builder::default()
-        .run(tauri::generate_context!())
-        .expect("error while running primer-gui");
+    if let Err(e) = primer_gui::run() {
+        eprintln!("primer-gui exited with error: {e}");
+        std::process::exit(1);
+    }
 }

--- a/src/crates/primer-gui/src/state.rs
+++ b/src/crates/primer-gui/src/state.rs
@@ -75,7 +75,13 @@ impl AppState {
 /// from blocking on each other unnecessarily.
 pub struct ActiveSession {
     /// Identifier of the underlying `Session` row in the session DB.
-    pub session_id: Uuid,
+    ///
+    /// `None` until the first `send_message` opens a `DialogueManager`
+    /// session (step 4). Returning `None` to the frontend is honest —
+    /// a pre-first-turn session has no id yet. An earlier draft used a
+    /// provisional `Uuid::new_v4()` here and overwrote it on first
+    /// turn, which silently invalidated any UUID the frontend cached.
+    pub session_id: Option<Uuid>,
 
     /// The session's locale (matches the learner's stored locale and
     /// the knowledge base's per-locale partition).
@@ -109,4 +115,27 @@ pub struct ActiveSession {
     pub vocab_settings: VocabSettings,
     pub embedder: Option<Arc<dyn Embedder>>,
     pub pedagogy_config: PedagogyConfig,
+}
+
+impl std::fmt::Debug for ActiveSession {
+    /// Print trait-object identities (via `Named::name()` where
+    /// available) instead of the objects themselves — none of them
+    /// implement `Debug`, but tests want `.unwrap_err()` to work and
+    /// printing the wiring summary is more useful than a `<dyn …>`
+    /// placeholder anyway.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ActiveSession")
+            .field("session_id", &self.session_id)
+            .field("locale", &self.locale)
+            .field("backend_name", &self.backend_name)
+            .field("main_model", &self.main_model)
+            .field("classifier", &self.classifier.identifier())
+            .field("extractor", &self.extractor.identifier())
+            .field("comprehension", &self.comprehension.identifier())
+            .field(
+                "embedder",
+                &self.embedder.as_ref().map(|e| e.name().to_string()),
+            )
+            .finish_non_exhaustive()
+    }
 }

--- a/src/crates/primer-gui/src/state.rs
+++ b/src/crates/primer-gui/src/state.rs
@@ -1,0 +1,112 @@
+//! Long-lived Tauri-managed app state.
+//!
+//! `AppState` is the single value registered with `Builder::manage()`;
+//! every Tauri command takes `tauri::State<'_, AppState>` and locks
+//! the appropriate field. The state holds:
+//!
+//! 1. The persisted `GuiConfig` (mutable across "Save" actions).
+//! 2. The home directory path so config save/load are filesystem-pure.
+//! 3. An optional `ActiveSession` carrying the constructed inference /
+//!    knowledge / classifier / extractor / comprehension / embedder /
+//!    store Arcs once `start_session` succeeds.
+//!
+//! Per the implementation plan, the `DialogueManager` itself is *not*
+//! held long-lived — it's constructed lazily on each send-message
+//! command from the Arcs in `ActiveSession`. That choice keeps the
+//! lifetime story of DM's `&'a dyn` borrows compatible with Tauri's
+//! `'static + Send + Sync` state model without refactoring
+//! `primer-pedagogy`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use primer_classifier::{ClassifierSettings, EngagementClassifier};
+use primer_comprehension::{ComprehensionClassifier, ComprehensionSettings};
+use primer_core::config::PedagogyConfig;
+use primer_core::embedder::Embedder;
+use primer_core::i18n::Locale;
+use primer_core::inference::InferenceBackend;
+use primer_core::learner::LearnerModel;
+use primer_core::storage::{LearnerStore, SessionStore};
+use primer_extractor::{ConceptExtractor, ExtractorSettings};
+use primer_knowledge::SqliteKnowledgeBase;
+use primer_pedagogy::vocab::VocabSettings;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::config::GuiConfig;
+
+/// Tauri-managed application state.
+pub struct AppState {
+    /// User's home directory (resolved at startup). Used by config
+    /// load/save and the default session-DB path resolver. Held as
+    /// owned so commands don't need to re-read `$HOME` on every call.
+    pub home: PathBuf,
+
+    /// Persisted settings, kept in memory so `get_settings` doesn't
+    /// hit disk and `update_settings` can stage the new value before
+    /// the JSON save completes.
+    pub config: Mutex<GuiConfig>,
+
+    /// The currently open session, if any. `None` between
+    /// `close_session` and the next `start_session` / `resume_session`.
+    pub session: Mutex<Option<ActiveSession>>,
+}
+
+impl AppState {
+    /// Build a fresh state from a home directory and an initial config.
+    /// The config is taken by value so callers can mutate their own
+    /// `GuiConfig` separately from what gets registered.
+    pub fn new(home: PathBuf, config: GuiConfig) -> Self {
+        Self {
+            home,
+            config: Mutex::new(config),
+            session: Mutex::new(None),
+        }
+    }
+}
+
+/// Everything `DialogueManager::new` needs to be constructed
+/// per-command, plus the live `LearnerModel` that mutates across turns.
+///
+/// All trait objects are `Arc<dyn ...>` so a command can clone them out
+/// of the state guard, drop the guard, and run the (potentially slow)
+/// dialogue turn outside the mutex — preventing concurrent commands
+/// from blocking on each other unnecessarily.
+pub struct ActiveSession {
+    /// Identifier of the underlying `Session` row in the session DB.
+    pub session_id: Uuid,
+
+    /// The session's locale (matches the learner's stored locale and
+    /// the knowledge base's per-locale partition).
+    pub locale: Locale,
+
+    /// The currently-loaded `LearnerModel`. Wrapped in a Mutex because
+    /// the dialogue turn mutates it (engagement state, concept depths,
+    /// vocab box transitions) and may run while other commands inspect
+    /// the snapshot for sidebar updates.
+    pub learner: Mutex<LearnerModel>,
+
+    pub backend: Arc<dyn InferenceBackend>,
+    /// Name string used by `primer-engine::build_*` dispatch. Held
+    /// alongside the Arc because `InferenceBackend::name()` cannot be
+    /// called through a borrow once the Arc is moved into a builder.
+    pub backend_name: String,
+    pub main_model: String,
+
+    pub knowledge: Arc<SqliteKnowledgeBase>,
+
+    pub session_store: Arc<dyn SessionStore>,
+    pub learner_store: Arc<dyn LearnerStore>,
+
+    pub classifier: Arc<dyn EngagementClassifier>,
+    pub classifier_settings: ClassifierSettings,
+    pub extractor: Arc<dyn ConceptExtractor>,
+    pub extractor_settings: ExtractorSettings,
+    pub comprehension: Arc<dyn ComprehensionClassifier>,
+    pub comprehension_settings: ComprehensionSettings,
+
+    pub vocab_settings: VocabSettings,
+    pub embedder: Option<Arc<dyn Embedder>>,
+    pub pedagogy_config: PedagogyConfig,
+}

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -11,7 +11,9 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SessionInfo {
-    pub session_id: Uuid,
+    /// `None` until the first `send_message` opens the underlying
+    /// `Session`. See [`ActiveSession::session_id`](crate::state::ActiveSession::session_id).
+    pub session_id: Option<Uuid>,
     pub learner: LearnerSummary,
     /// Backend kind: "stub" | "cloud" | "ollama".
     pub backend_kind: String,

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -1,0 +1,33 @@
+//! DTOs serialised across the Tauri IPC boundary.
+//!
+//! Step 3 surfaces a single [`SessionInfo`] DTO carrying the bare
+//! minimum the frontend needs to render its header after
+//! `start_session` lands (learner profile + backend identity). Richer
+//! sidebar payloads (`TurnSignals`, `LearnerSnapshot`, etc.) arrive in
+//! steps 5 / 6 alongside the sidebar implementation.
+
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionInfo {
+    pub session_id: Uuid,
+    pub learner: LearnerSummary,
+    /// Backend kind: "stub" | "cloud" | "ollama".
+    pub backend_kind: String,
+    /// Main model id (e.g. "claude-sonnet-4-6", "llama3.2", "stub").
+    pub main_model: String,
+    /// Locale pack id ("en", "de", ...).
+    pub locale: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LearnerSummary {
+    pub id: Uuid,
+    pub name: String,
+    pub age: u8,
+    /// Number of concepts the learner has encountered so far (across
+    /// all sessions). Useful for the header to show "Binti · 9 · 42
+    /// concepts" without pulling the full vocab list.
+    pub concept_count: usize,
+}

--- a/src/crates/primer-gui/src/validation.rs
+++ b/src/crates/primer-gui/src/validation.rs
@@ -1,0 +1,154 @@
+//! Validation of a [`GuiConfig`] before it lands on disk.
+//!
+//! The goal is to surface obviously-bad configs at `update_settings`
+//! time rather than at the next `start_session`, where the same checks
+//! eventually run as part of `build_active_session`. Catching them
+//! early means the settings modal can render the error inline and
+//! never lets a broken config persist.
+//!
+//! This is *cheap, structural* validation only — no I/O, no network.
+//! `start_session` remains the ultimate authority on whether the
+//! config actually produces a working session (model availability,
+//! embedder construction, etc.).
+
+use primer_core::i18n::Locale;
+
+use crate::config::GuiConfig;
+
+/// Run validation and return an inline-friendly error message on the
+/// first failure, or `Ok(())` if the config is structurally sound.
+pub fn validate(cfg: &GuiConfig) -> Result<(), String> {
+    validate_locale(&cfg.learner.locale)?;
+    validate_backend(&cfg.backend.kind)?;
+    // `match_main = true` causes the wiring code to ignore `kind`, so
+    // an invalid `kind` in that branch is dead data — don't fail the
+    // save on it.
+    validate_subsystem_kind("classifier", subsystem_override(&cfg.classifier))?;
+    validate_subsystem_kind("extractor", subsystem_override(&cfg.extractor))?;
+    validate_subsystem_kind("comprehension", subsystem_override(&cfg.comprehension))?;
+    validate_embedder(&cfg.embedder.kind)?;
+    validate_breaks(cfg.breaks.after_mins)?;
+    Ok(())
+}
+
+fn subsystem_override(s: &crate::config::SubsystemConfig) -> Option<&str> {
+    if s.match_main {
+        None
+    } else {
+        s.kind.as_deref()
+    }
+}
+
+fn validate_locale(pack_id: &str) -> Result<(), String> {
+    Locale::from_pack_id(pack_id).map(|_| ()).ok_or_else(|| {
+        let known: Vec<&str> = Locale::ALL.iter().map(|l| l.pack_id()).collect();
+        format!("locale {pack_id:?} is not a supported pack. Known: {known:?}")
+    })
+}
+
+fn validate_backend(kind: &str) -> Result<(), String> {
+    match kind {
+        "stub" | "cloud" | "ollama" => Ok(()),
+        other => Err(format!(
+            "unknown backend kind {other:?}: expected one of stub, cloud, ollama"
+        )),
+    }
+}
+
+/// Subsystem kind is optional — `None` means "match the main backend"
+/// (paired with `match_main = true` in `SubsystemConfig`). Only an
+/// explicit override is validated here.
+fn validate_subsystem_kind(label: &str, kind: Option<&str>) -> Result<(), String> {
+    match kind {
+        None => Ok(()),
+        Some("stub" | "cloud" | "ollama") => Ok(()),
+        Some(other) => Err(format!(
+            "unknown {label} backend {other:?}: expected one of stub, cloud, ollama"
+        )),
+    }
+}
+
+fn validate_embedder(kind: &str) -> Result<(), String> {
+    match kind {
+        "none" | "stub" | "fastembed" | "ollama" => Ok(()),
+        other => Err(format!(
+            "unknown embedder backend {other:?}: expected one of none, stub, fastembed, ollama"
+        )),
+    }
+}
+
+fn validate_breaks(after_mins: u32) -> Result<(), String> {
+    if after_mins == 0 {
+        Err("break-suggestion interval must be at least 1 minute".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_valid() {
+        validate(&GuiConfig::default()).expect("default config must validate");
+    }
+
+    #[test]
+    fn unknown_locale_rejected() {
+        let mut cfg = GuiConfig::default();
+        cfg.learner.locale = "klingon".to_string();
+        let err = validate(&cfg).unwrap_err();
+        assert!(
+            err.contains("klingon"),
+            "error must name the offender: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_backend_rejected() {
+        let mut cfg = GuiConfig::default();
+        cfg.backend.kind = "magic".to_string();
+        let err = validate(&cfg).unwrap_err();
+        assert!(err.contains("magic"));
+    }
+
+    #[test]
+    fn unknown_embedder_rejected() {
+        let mut cfg = GuiConfig::default();
+        cfg.embedder.kind = "secret-sauce".to_string();
+        let err = validate(&cfg).unwrap_err();
+        assert!(err.contains("secret-sauce"));
+    }
+
+    #[test]
+    fn subsystem_kind_override_validates() {
+        let mut cfg = GuiConfig::default();
+        cfg.classifier.match_main = false;
+        cfg.classifier.kind = Some("bogus".to_string());
+        let err = validate(&cfg).unwrap_err();
+        assert!(
+            err.contains("classifier"),
+            "error must name the subsystem: {err}"
+        );
+        assert!(err.contains("bogus"));
+    }
+
+    #[test]
+    fn subsystem_match_main_skips_kind_validation() {
+        // `match_main = true` + bogus kind is OK because the wiring
+        // code ignores `kind` in that case.
+        let mut cfg = GuiConfig::default();
+        cfg.classifier.match_main = true;
+        cfg.classifier.kind = Some("bogus".to_string());
+        validate(&cfg).expect("match_main=true ignores kind");
+    }
+
+    #[test]
+    fn zero_break_interval_rejected() {
+        let mut cfg = GuiConfig::default();
+        cfg.breaks.after_mins = 0;
+        let err = validate(&cfg).unwrap_err();
+        assert!(err.contains("1 minute"));
+    }
+}

--- a/src/crates/primer-gui/src/wiring.rs
+++ b/src/crates/primer-gui/src/wiring.rs
@@ -124,10 +124,7 @@ pub async fn build_active_session(
         if let Some(parent) = session_path.parent() {
             if !parent.as_os_str().is_empty() {
                 std::fs::create_dir_all(parent).map_err(|e| {
-                    format!(
-                        "creating session-db directory {}: {e}",
-                        parent.display()
-                    )
+                    format!("creating session-db directory {}: {e}", parent.display())
                 })?;
             }
         }
@@ -234,18 +231,18 @@ pub async fn build_active_session(
     };
 
     // ─── ActiveSession ───────────────────────────────────────────────
-    // The session_id is provisional — step 4's `send_message` will
-    // call `DialogueManager::open_session` and overwrite it with the
-    // real Session UUID. Stored here so commands have something to
-    // reference before the first turn lands.
-    let provisional_session_id = Uuid::new_v4();
-
+    // No session-id yet — step 4's `send_message` will call
+    // `DialogueManager::open_session` and write the real Session UUID
+    // here. `None` over IPC tells the frontend honestly that no turn
+    // has happened yet, instead of handing out a placeholder that
+    // would invalidate as soon as the first turn lands.
+    // `Arc::clone` can't coerce concrete → trait object; the `as _` cast
+    // does the upcast in one step and is the standard idiom for this.
     let learner_store: Arc<dyn LearnerStore> = Arc::clone(&session_store) as _;
-    let session_store_dyn: Arc<dyn primer_core::storage::SessionStore> =
-        Arc::clone(&session_store) as _;
+    let session_store_dyn: Arc<dyn SessionStore> = Arc::clone(&session_store) as _;
 
     Ok(ActiveSession {
-        session_id: provisional_session_id,
+        session_id: None,
         locale,
         learner: Mutex::new(learner),
         backend,
@@ -277,7 +274,9 @@ fn resolve_main_model(kind: &str, model: Option<&str>) -> Result<String, String>
         "ollama" => model.map(String::from).ok_or_else(|| {
             "ollama backend requires a model name (e.g. \"llama3.2\") in settings".to_string()
         }),
-        "stub" => Ok(model.map(String::from).unwrap_or_else(|| "stub".to_string())),
+        "stub" => Ok(model
+            .map(String::from)
+            .unwrap_or_else(|| "stub".to_string())),
         other => Err(format!(
             "unknown backend kind {other:?}: expected one of stub, cloud, ollama"
         )),
@@ -295,18 +294,20 @@ fn subsystem_kind(s: &crate::config::SubsystemConfig) -> Option<String> {
 /// Embedder construction, mirroring `primer-cli`'s dispatch matrix.
 ///
 /// `fastembed` / `ollama` require their respective cargo features; the
-/// `primer-engine` helpers exit the process with a clear error when the
-/// feature is missing, which is the same behaviour the CLI provides.
+/// `primer-engine` helpers return an `Err(String)` when the feature is
+/// missing so this command path can surface it to the frontend instead
+/// of killing the GUI process (the CLI maps the same Err to a clean
+/// stderr line + exit).
 async fn build_embedder(
     config: &crate::config::EmbedderConfig,
 ) -> Result<Option<Arc<dyn primer_core::embedder::Embedder>>, String> {
     match config.kind.as_str() {
         "none" => Ok(None),
         "stub" => Ok(Some(Arc::new(primer_embedding::StubEmbedder::new()) as _)),
-        "fastembed" => Ok(build_fastembed_embedder(config.model.as_deref())),
-        "ollama" => Ok(
-            build_ollama_embedder(config.ollama_url.as_deref(), config.model.as_deref()).await,
-        ),
+        "fastembed" => build_fastembed_embedder(config.model.as_deref()),
+        "ollama" => {
+            build_ollama_embedder(config.ollama_url.as_deref(), config.model.as_deref()).await
+        }
         other => Err(format!(
             "unknown embedder backend {other:?}: expected one of none, stub, fastembed, ollama"
         )),
@@ -325,17 +326,6 @@ mod tests {
         cfg
     }
 
-    /// Extract the error string from `build_active_session`'s result.
-    /// `ActiveSession` deliberately doesn't implement `Debug` (it holds
-    /// non-Debug trait objects), so the standard `.unwrap_err()` would
-    /// need it to be `Debug` to panic-print the Ok variant.
-    fn expect_err<T>(r: Result<T, String>) -> String {
-        match r {
-            Ok(_) => panic!("expected Err"),
-            Err(e) => e,
-        }
-    }
-
     #[tokio::test]
     async fn builds_active_session_with_stub_backend() {
         let home = TempDir::new().unwrap();
@@ -345,6 +335,10 @@ mod tests {
         assert_eq!(s.backend_name, "stub");
         assert_eq!(s.main_model, "stub");
         assert_eq!(s.locale, Locale::English);
+        assert!(
+            s.session_id.is_none(),
+            "session_id is None until first send_message"
+        );
         // Subsystems all default to stub when the main backend is stub.
         assert_eq!(s.classifier.identifier(), "stub");
         assert_eq!(s.extractor.identifier(), "stub");
@@ -361,7 +355,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let mut cfg = stub_config();
         cfg.learner.locale = "klingon".to_string();
-        let err = expect_err(build_active_session(home.path(), &cfg).await);
+        let err = build_active_session(home.path(), &cfg).await.unwrap_err();
         assert!(
             err.contains("klingon"),
             "error must name the offending locale: {err}"
@@ -374,7 +368,7 @@ mod tests {
         let mut cfg = stub_config();
         cfg.backend.kind = "ollama".to_string();
         cfg.backend.model = None;
-        let err = expect_err(build_active_session(home.path(), &cfg).await);
+        let err = build_active_session(home.path(), &cfg).await.unwrap_err();
         assert!(
             err.to_lowercase().contains("ollama"),
             "error must mention ollama: {err}"
@@ -386,7 +380,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let mut cfg = stub_config();
         cfg.backend.kind = "magic".to_string();
-        let err = expect_err(build_active_session(home.path(), &cfg).await);
+        let err = build_active_session(home.path(), &cfg).await.unwrap_err();
         assert!(
             err.contains("magic"),
             "error must name the offending backend: {err}"
@@ -398,11 +392,26 @@ mod tests {
         let home = TempDir::new().unwrap();
         let mut cfg = stub_config();
         cfg.embedder.kind = "secret-sauce".to_string();
-        let err = expect_err(build_active_session(home.path(), &cfg).await);
+        let err = build_active_session(home.path(), &cfg).await.unwrap_err();
         assert!(
             err.contains("secret-sauce"),
             "error must name the offending embedder: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn cloud_with_inline_api_key_constructs() {
+        // Inline key bypasses the ANTHROPIC_API_KEY env var entirely —
+        // exercise the wiring branch that resolves Inline → Some(key).
+        let home = TempDir::new().unwrap();
+        let mut cfg = stub_config();
+        cfg.backend.kind = "cloud".to_string();
+        cfg.backend.api_key_source = crate::config::ApiKeySource::Inline {
+            key: "sk-test-not-real".to_string(),
+        };
+        let s = build_active_session(home.path(), &cfg).await.unwrap();
+        assert_eq!(s.backend_name, "cloud");
+        assert_eq!(s.main_model, "claude-sonnet-4-6");
     }
 
     #[tokio::test]
@@ -412,6 +421,34 @@ mod tests {
         cfg.embedder.kind = "stub".to_string();
         let s = build_active_session(home.path(), &cfg).await.unwrap();
         assert!(s.embedder.is_some());
+    }
+
+    #[tokio::test]
+    async fn second_build_after_first_drops_persists_learner_growth() {
+        // Models the GUI's start_session → close_session → start_session
+        // round-trip at the wiring layer: each build_active_session
+        // call independently re-opens the on-disk learner. Validates
+        // that the second open sees a stable UUID (no orphaned learner
+        // rows) — the most important invariant of the close+restart
+        // flow.
+        let home = TempDir::new().unwrap();
+        let session_db = home.path().join("roundtrip.db");
+
+        let mut cfg = GuiConfig::default();
+        cfg.learner.name = "Roundtrip".to_string();
+        cfg.persistence.session_db = Some(session_db.clone());
+
+        // First build; the `ActiveSession` drops at the end of the
+        // block, mirroring the session-state-take inside
+        // close_session_inner.
+        let first_id = {
+            let s = build_active_session(home.path(), &cfg).await.unwrap();
+            s.learner.lock().await.profile.id
+        };
+
+        let s2 = build_active_session(home.path(), &cfg).await.unwrap();
+        let id2 = s2.learner.lock().await.profile.id;
+        assert_eq!(id2, first_id, "learner UUID stable across reopens");
     }
 
     #[tokio::test]

--- a/src/crates/primer-gui/src/wiring.rs
+++ b/src/crates/primer-gui/src/wiring.rs
@@ -1,0 +1,442 @@
+//! Build an [`ActiveSession`] from a [`GuiConfig`].
+//!
+//! Mirrors the wiring code in `primer-cli`'s `async_main` — same call
+//! sequence, same defaults, same error semantics — but returns a
+//! constructed `ActiveSession` instead of a `DialogueManager` so the
+//! GUI can manage the lifetime itself (DM is built lazily per command;
+//! see [`crate::state`] for the rationale).
+//!
+//! Errors surface as `String` so the Tauri command can forward them
+//! to the frontend directly. Per-field validation belongs to the
+//! settings modal (step 8); here we fail fast on construction errors.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use primer_classifier::ClassifierSettings;
+use primer_comprehension::ComprehensionSettings;
+use primer_core::config::PedagogyConfig;
+use primer_core::i18n::Locale;
+use primer_core::storage::{LearnerStore, SessionStore};
+use primer_engine::{
+    BackendParams, IN_MEMORY, build_backend, build_classifier, build_comprehension,
+    build_extractor, build_fastembed_embedder, build_ollama_embedder, create_learner_with_id,
+    reconcile_persisted_learner, resolve_session_db_path,
+};
+use primer_extractor::ExtractorSettings;
+use primer_knowledge::SqliteKnowledgeBase;
+use primer_pedagogy::vocab::VocabSettings;
+use primer_storage::SqliteSessionStore;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::config::{ApiKeySource, GuiConfig};
+use crate::state::ActiveSession;
+
+/// Construct everything `DialogueManager::new` would need from a single
+/// `GuiConfig`.
+///
+/// Side effects mirror `primer-cli`:
+/// - Opens or creates the per-locale knowledge DB and auto-seeds it
+///   from the bundled JSONL if empty.
+/// - Opens (or creates the parent dir for) the per-learner session DB
+///   under `<home>/.primer/<slug>.db` unless an explicit path is given.
+/// - Loads or mints a `LearnerModel`; reconciles with the GUI settings
+///   (age refresh + name-mismatch warning) when one is already on disk.
+///
+/// `home` is the user's home directory. Tests can pass a synthetic dir
+/// from `tempfile::TempDir`. The function never reads `$HOME` directly.
+pub async fn build_active_session(
+    home: &Path,
+    config: &GuiConfig,
+) -> Result<ActiveSession, String> {
+    let learner_config = &config.learner;
+    let backend_config = &config.backend;
+
+    // ─── Locale ──────────────────────────────────────────────────────
+    let locale = Locale::from_pack_id(&learner_config.locale).ok_or_else(|| {
+        let known: Vec<&str> = Locale::ALL.iter().map(|l| l.pack_id()).collect();
+        format!(
+            "language {:?} is not a supported locale pack. Known: {:?}",
+            learner_config.locale, known
+        )
+    })?;
+
+    // ─── Main model resolution ───────────────────────────────────────
+    let main_model = resolve_main_model(&backend_config.kind, backend_config.model.as_deref())?;
+
+    // ─── BackendParams ───────────────────────────────────────────────
+    // The cloud `api_key` resolves Env vs Inline here so the wiring
+    // crate doesn't need to touch env vars on every helper call.
+    let api_key = match (&backend_config.api_key_source, backend_config.kind.as_str()) {
+        (ApiKeySource::Inline { key }, _) => Some(key.clone()),
+        (ApiKeySource::Env, "cloud") => std::env::var("ANTHROPIC_API_KEY").ok(),
+        (ApiKeySource::Env, _) => None,
+    };
+
+    let params = BackendParams {
+        api_key,
+        ollama_url: backend_config.ollama_url.clone(),
+        classifier_backend: subsystem_kind(&config.classifier),
+        classifier_model: config.classifier.model.clone(),
+        extractor_backend: subsystem_kind(&config.extractor),
+        extractor_model: config.extractor.model.clone(),
+        comprehension_backend: subsystem_kind(&config.comprehension),
+        comprehension_model: config.comprehension.model.clone(),
+    };
+
+    // ─── Main backend ────────────────────────────────────────────────
+    let backend = build_backend(&backend_config.kind, main_model.clone(), &params)
+        .await
+        .map_err(|e| format!("constructing inference backend: {e}"))?;
+
+    // ─── Knowledge base + auto-seed ──────────────────────────────────
+    let knowledge_path = config
+        .persistence
+        .knowledge_db
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(IN_MEMORY));
+    let knowledge = SqliteKnowledgeBase::open_for_locale(&knowledge_path, locale)
+        .map_err(|e| format!("opening knowledge base {}: {e}", knowledge_path.display()))?;
+    if let Some(stats) = primer_kb_load::auto_seed_if_empty(&knowledge, locale)
+        .await
+        .map_err(|e| format!("auto-seeding knowledge base: {e}"))?
+    {
+        tracing::info!(
+            target = "primer-gui::startup",
+            inserted = stats.inserted,
+            sources = stats.sources_seen,
+            "auto-seeded knowledge base for locale {}",
+            locale.pack_id()
+        );
+    }
+    let knowledge = Arc::new(knowledge);
+
+    // ─── Session store ───────────────────────────────────────────────
+    let session_path = resolve_session_db_path(
+        config.persistence.session_db.clone(),
+        home,
+        &learner_config.name,
+        config.persistence.no_persist,
+    );
+    if !config.persistence.no_persist {
+        if let Some(parent) = session_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    format!(
+                        "creating session-db directory {}: {e}",
+                        parent.display()
+                    )
+                })?;
+            }
+        }
+    }
+    let session_store = Arc::new(
+        SqliteSessionStore::open_for_locale(&session_path, locale)
+            .map_err(|e| format!("opening session-db {}: {e}", session_path.display()))?,
+    );
+
+    // ─── Learner model ───────────────────────────────────────────────
+    let learner = match session_store.load_learner().await {
+        Ok(Some(existing)) => {
+            let reconciled =
+                reconcile_persisted_learner(existing, &learner_config.name, learner_config.age);
+            if let Err(e) = session_store.save_learner(&reconciled).await {
+                tracing::warn!("save_learner on session-start failed: {e}");
+            }
+            reconciled
+        }
+        Ok(None) => {
+            // Truly fresh DB OR v3 DB with sessions but no learners row.
+            // Adopt the most-recent session's learner_id so existing
+            // sessions are not orphaned.
+            let id = match session_store.most_recent_session_learner_id().await {
+                Ok(Some(uuid)) => {
+                    tracing::info!("adopted learner_id {uuid} from existing sessions");
+                    uuid
+                }
+                Ok(None) => Uuid::new_v4(),
+                Err(e) => {
+                    tracing::warn!(
+                        "most_recent_session_learner_id failed: {e}; minting fresh UUID"
+                    );
+                    Uuid::new_v4()
+                }
+            };
+            let fresh =
+                create_learner_with_id(id, &learner_config.name, learner_config.age, locale);
+            if let Err(e) = session_store.save_learner(&fresh).await {
+                tracing::warn!("save_learner on session-start failed: {e}");
+            }
+            fresh
+        }
+        Err(e) => return Err(format!("load_learner failed: {e}")),
+    };
+
+    // ─── Subsystems ──────────────────────────────────────────────────
+    let classifier_settings = ClassifierSettings {
+        blocking_timeout: Duration::from_millis(config.classifier.timeout_ms),
+        ..ClassifierSettings::default()
+    };
+    let classifier = build_classifier(
+        Arc::clone(&backend),
+        &backend_config.kind,
+        &main_model,
+        &params,
+        classifier_settings.clone(),
+    )
+    .await
+    .map_err(|e| format!("constructing engagement classifier: {e}"))?;
+
+    let extractor_settings = ExtractorSettings {
+        blocking_timeout: Duration::from_millis(config.extractor.timeout_ms),
+        ..ExtractorSettings::default()
+    };
+    let extractor = build_extractor(
+        Arc::clone(&backend),
+        &backend_config.kind,
+        &main_model,
+        &params,
+        extractor_settings.clone(),
+    )
+    .await
+    .map_err(|e| format!("constructing concept extractor: {e}"))?;
+
+    let comprehension_settings = ComprehensionSettings {
+        blocking_timeout: Duration::from_millis(config.comprehension.timeout_ms),
+        ..ComprehensionSettings::default()
+    };
+    let comprehension = build_comprehension(
+        Arc::clone(&backend),
+        &backend_config.kind,
+        &main_model,
+        &params,
+        comprehension_settings.clone(),
+    )
+    .await
+    .map_err(|e| format!("constructing comprehension classifier: {e}"))?;
+
+    // ─── Embedder ────────────────────────────────────────────────────
+    let embedder = build_embedder(&config.embedder).await?;
+
+    // ─── Pedagogy + vocab settings ───────────────────────────────────
+    let pedagogy_config = PedagogyConfig {
+        break_suggest_after_minutes: config.breaks.after_mins,
+        ..PedagogyConfig::default()
+    };
+    let vocab_settings = VocabSettings {
+        max_per_prompt: config
+            .vocab
+            .max_per_prompt
+            .map(|n| n as usize)
+            .unwrap_or(primer_core::consts::vocab::DEFAULT_VOCAB_MAX_PER_PROMPT),
+    };
+
+    // ─── ActiveSession ───────────────────────────────────────────────
+    // The session_id is provisional — step 4's `send_message` will
+    // call `DialogueManager::open_session` and overwrite it with the
+    // real Session UUID. Stored here so commands have something to
+    // reference before the first turn lands.
+    let provisional_session_id = Uuid::new_v4();
+
+    let learner_store: Arc<dyn LearnerStore> = Arc::clone(&session_store) as _;
+    let session_store_dyn: Arc<dyn primer_core::storage::SessionStore> =
+        Arc::clone(&session_store) as _;
+
+    Ok(ActiveSession {
+        session_id: provisional_session_id,
+        locale,
+        learner: Mutex::new(learner),
+        backend,
+        backend_name: backend_config.kind.clone(),
+        main_model,
+        knowledge,
+        session_store: session_store_dyn,
+        learner_store,
+        classifier,
+        classifier_settings,
+        extractor,
+        extractor_settings,
+        comprehension,
+        comprehension_settings,
+        vocab_settings,
+        embedder,
+        pedagogy_config,
+    })
+}
+
+/// Resolve the main backend's model id from the GUI's optional override.
+/// Mirrors `primer-cli`: cloud defaults to claude-sonnet-4-6, ollama
+/// requires an explicit value, stub falls back to the literal "stub".
+fn resolve_main_model(kind: &str, model: Option<&str>) -> Result<String, String> {
+    match kind {
+        "cloud" => Ok(model
+            .map(String::from)
+            .unwrap_or_else(|| "claude-sonnet-4-6".to_string())),
+        "ollama" => model.map(String::from).ok_or_else(|| {
+            "ollama backend requires a model name (e.g. \"llama3.2\") in settings".to_string()
+        }),
+        "stub" => Ok(model.map(String::from).unwrap_or_else(|| "stub".to_string())),
+        other => Err(format!(
+            "unknown backend kind {other:?}: expected one of stub, cloud, ollama"
+        )),
+    }
+}
+
+/// For a subsystem set to "match the main backend" we leave the
+/// override fields empty — the wiring helpers in `primer-engine` then
+/// reuse the main backend via `Arc::clone`. Only an explicit override
+/// produces a non-None kind here.
+fn subsystem_kind(s: &crate::config::SubsystemConfig) -> Option<String> {
+    if s.match_main { None } else { s.kind.clone() }
+}
+
+/// Embedder construction, mirroring `primer-cli`'s dispatch matrix.
+///
+/// `fastembed` / `ollama` require their respective cargo features; the
+/// `primer-engine` helpers exit the process with a clear error when the
+/// feature is missing, which is the same behaviour the CLI provides.
+async fn build_embedder(
+    config: &crate::config::EmbedderConfig,
+) -> Result<Option<Arc<dyn primer_core::embedder::Embedder>>, String> {
+    match config.kind.as_str() {
+        "none" => Ok(None),
+        "stub" => Ok(Some(Arc::new(primer_embedding::StubEmbedder::new()) as _)),
+        "fastembed" => Ok(build_fastembed_embedder(config.model.as_deref())),
+        "ollama" => Ok(
+            build_ollama_embedder(config.ollama_url.as_deref(), config.model.as_deref()).await,
+        ),
+        other => Err(format!(
+            "unknown embedder backend {other:?}: expected one of none, stub, fastembed, ollama"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build the smallest config that triggers the full stub pipeline.
+    fn stub_config() -> GuiConfig {
+        let mut cfg = GuiConfig::default();
+        cfg.persistence.no_persist = true;
+        cfg
+    }
+
+    /// Extract the error string from `build_active_session`'s result.
+    /// `ActiveSession` deliberately doesn't implement `Debug` (it holds
+    /// non-Debug trait objects), so the standard `.unwrap_err()` would
+    /// need it to be `Debug` to panic-print the Ok variant.
+    fn expect_err<T>(r: Result<T, String>) -> String {
+        match r {
+            Ok(_) => panic!("expected Err"),
+            Err(e) => e,
+        }
+    }
+
+    #[tokio::test]
+    async fn builds_active_session_with_stub_backend() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config();
+        let s = build_active_session(home.path(), &cfg).await.unwrap();
+
+        assert_eq!(s.backend_name, "stub");
+        assert_eq!(s.main_model, "stub");
+        assert_eq!(s.locale, Locale::English);
+        // Subsystems all default to stub when the main backend is stub.
+        assert_eq!(s.classifier.identifier(), "stub");
+        assert_eq!(s.extractor.identifier(), "stub");
+        assert_eq!(s.comprehension.identifier(), "stub");
+        assert!(s.embedder.is_none(), "default embedder is none");
+        // The learner row is freshly minted; name matches config.
+        let learner = s.learner.lock().await;
+        assert_eq!(learner.profile.name, "Explorer");
+        assert_eq!(learner.profile.age, 8);
+    }
+
+    #[tokio::test]
+    async fn unknown_locale_errors() {
+        let home = TempDir::new().unwrap();
+        let mut cfg = stub_config();
+        cfg.learner.locale = "klingon".to_string();
+        let err = expect_err(build_active_session(home.path(), &cfg).await);
+        assert!(
+            err.contains("klingon"),
+            "error must name the offending locale: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ollama_without_model_errors() {
+        let home = TempDir::new().unwrap();
+        let mut cfg = stub_config();
+        cfg.backend.kind = "ollama".to_string();
+        cfg.backend.model = None;
+        let err = expect_err(build_active_session(home.path(), &cfg).await);
+        assert!(
+            err.to_lowercase().contains("ollama"),
+            "error must mention ollama: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_backend_errors() {
+        let home = TempDir::new().unwrap();
+        let mut cfg = stub_config();
+        cfg.backend.kind = "magic".to_string();
+        let err = expect_err(build_active_session(home.path(), &cfg).await);
+        assert!(
+            err.contains("magic"),
+            "error must name the offending backend: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_embedder_errors() {
+        let home = TempDir::new().unwrap();
+        let mut cfg = stub_config();
+        cfg.embedder.kind = "secret-sauce".to_string();
+        let err = expect_err(build_active_session(home.path(), &cfg).await);
+        assert!(
+            err.contains("secret-sauce"),
+            "error must name the offending embedder: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stub_embedder_kind_succeeds() {
+        let home = TempDir::new().unwrap();
+        let mut cfg = stub_config();
+        cfg.embedder.kind = "stub".to_string();
+        let s = build_active_session(home.path(), &cfg).await.unwrap();
+        assert!(s.embedder.is_some());
+    }
+
+    #[tokio::test]
+    async fn name_reconciles_on_second_open() {
+        // Two start_sessions against the same on-disk file: the persisted
+        // name wins; the GUI's --name flag never overwrites it.
+        let home = TempDir::new().unwrap();
+        let session_db = home.path().join("test.db");
+
+        let mut cfg = GuiConfig::default();
+        cfg.learner.name = "Binti".to_string();
+        cfg.persistence.session_db = Some(session_db.clone());
+
+        let s1 = build_active_session(home.path(), &cfg).await.unwrap();
+        let id1 = s1.learner.lock().await.profile.id;
+
+        // Second open with a different CLI-level name.
+        let mut cfg2 = cfg.clone();
+        cfg2.learner.name = "Other".to_string();
+        let s2 = build_active_session(home.path(), &cfg2).await.unwrap();
+        let learner2 = s2.learner.lock().await;
+        assert_eq!(learner2.profile.id, id1, "UUID stable across opens");
+        assert_eq!(
+            learner2.profile.name, "Binti",
+            "persisted name wins over GUI override"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Step 3 of 10 from the GUI implementation plan. Wires the Tauri backend so the frontend (step 4+) has a working command surface to build against. No streaming yet — that's step 4.

### New modules
- **`config.rs`** — `GuiConfig` struct mirroring every primer-cli flag 1-for-1. `serde(default)` on every section so older configs forward-compatibly grow new fields. Atomic save (`<file>.json.tmp` + rename, mode 0600 on Unix because an inline API key may live there).
- **`wiring.rs::build_active_session`** — takes a `GuiConfig` and produces a fully-wired `ActiveSession`: locale resolution, knowledge base open + auto-seed, session-store open + learner reconcile, classifier / extractor / comprehension / embedder construction. Mirrors `primer-cli`'s `async_main` wiring (using the helpers extracted in PR #68).
- **`state.rs::AppState`** — `Mutex<GuiConfig>`, home dir, `Mutex<Option<ActiveSession>>`. Per the plan, `DialogueManager` is NOT held long-lived; it's reconstructed lazily per command from the held Arcs so `primer-pedagogy` stays untouched.
- **`commands/`** — five Tauri commands:
  - `settings::get_settings`, `settings::update_settings`
  - `session::start_session`, `session::close_session`, `session::current_session_info`

### Behaviour notes
- `start_session` closes any pre-existing session first (no resource leak even if frontend forgets to close).
- `close_session` releases the mutex BEFORE the `save_learner` I/O so other commands aren't blocked on slow disk.
- `main.rs` becomes a thin shim around `primer_gui::run`; tracing-subscriber init mirrors primer-cli so `RUST_LOG=info|debug` works the same way.

## Test plan

- [x] `cargo test -p primer-gui` — 16 new tests (9 config round-trip + 7 wiring construction)
- [x] `cargo clippy -p primer-gui --all-targets` — clean
- [x] `cargo check -p primer-gui --features embedding` — feature forwarding through to primer-engine works
- [x] `cargo test --workspace` — no regressions
- [x] `cargo run --bin primer-gui` boots and runs cleanly (5s background-run smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)