### PR TITLE
feat(gui): streaming chat — send_message + Tauri events + bubble UI

### DIFF
--- a/src/crates/primer-cli/src/main.rs
+++ b/src/crates/primer-cli/src/main.rs
@@ -756,10 +756,11 @@ async fn async_main() -> anyhow::Result<()> {
         vocab_settings,
         embedder: embedder.clone(),
     };
+    let knowledge_arc: Arc<dyn KnowledgeBase> = Arc::new(knowledge);
     let mut dm = DialogueManager::new(
         learner,
-        backend.as_ref(),
-        &knowledge as &dyn KnowledgeBase,
+        Arc::clone(&backend),
+        Arc::clone(&knowledge_arc),
         stores,
         subsystems,
         pedagogy_config,

--- a/src/crates/primer-cli/src/speech_loop.rs
+++ b/src/crates/primer-cli/src/speech_loop.rs
@@ -577,17 +577,14 @@ pub async fn run_loop<'r>(
 }
 
 /// Adapter that lets `&mut DialogueManager` satisfy the [`Responder`]
-/// trait. The lifetime `'a` is the dialogue manager's borrowed-backends
-/// lifetime; `'b` is how long this adapter lives. `'a: 'b` keeps the
-/// nested-borrow well-formed.
-struct DialogueResponder<'a, 'b> {
-    dialogue: &'b mut primer_pedagogy::DialogueManager<'a>,
+/// trait. The lifetime parameter is the borrow of the manager, not of
+/// its collaborators — the manager itself is `'static` now that
+/// inference and knowledge are held as `Arc<dyn …>`.
+struct DialogueResponder<'b> {
+    dialogue: &'b mut primer_pedagogy::DialogueManager,
 }
 
-impl<'a, 'b> Responder for DialogueResponder<'a, 'b>
-where
-    'a: 'b,
-{
+impl<'b> Responder for DialogueResponder<'b> {
     fn respond<'r>(
         &'r mut self,
         transcript: &'r str,
@@ -696,9 +693,9 @@ impl primer_core::speech::TranscriptionSession for ChannelSttSession {
 
 /// Entry point: run the voice REPL until Ctrl+C or a quit phrase is heard.
 #[cfg(feature = "speech")]
-pub async fn run<'a>(
+pub async fn run(
     cfg: SpeechLoopConfig<'_>,
-    dialogue: &mut primer_pedagogy::DialogueManager<'a>,
+    dialogue: &mut primer_pedagogy::DialogueManager,
 ) -> Result<()> {
     use primer_core::speech::VadEvent;
     use primer_speech::{
@@ -1012,9 +1009,9 @@ pub async fn run<'a>(
 /// an error so the binary fails fast if `--speech` is somehow set
 /// without the feature.
 #[cfg(not(feature = "speech"))]
-pub async fn run<'a>(
+pub async fn run(
     _cfg: SpeechLoopConfig<'_>,
-    _dialogue: &mut primer_pedagogy::DialogueManager<'a>,
+    _dialogue: &mut primer_pedagogy::DialogueManager,
 ) -> Result<()> {
     Err(primer_core::error::PrimerError::Speech(
         "primer-cli was built without the `speech` feature".into(),

--- a/src/crates/primer-embedding/src/lib.rs
+++ b/src/crates/primer-embedding/src/lib.rs
@@ -13,7 +13,7 @@
 //! [`Embedder`]: primer_core::embedder::Embedder
 
 pub mod stub;
-pub use stub::StubEmbedder;
+pub use stub::{STUB_MODEL_ID, StubEmbedder};
 
 #[cfg(feature = "fastembed")]
 pub mod fastembed_backend;

--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -22,5 +22,6 @@ pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
         session::start_session,
         session::close_session,
         session::current_session_info,
+        session::send_message,
     ])
 }

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -94,12 +94,15 @@ async fn close_session_inner(state: &tauri::State<'_, AppState>) -> Result<(), S
 ///    from disk and `resume_session` so the timeline + summary +
 ///    engagement history carry over.
 /// 3. Run `respond_to_streaming`, emitting one `primer://chunk` event
-///    per token. The callback also captures the chunk text into a
-///    String so we have the full response for the post-turn event.
+///    per token. The frontend reassembles the full response from the
+///    chunk stream — no String accumulation is needed server-side.
 /// 4. `close_session` to drain background tasks (classifier / extractor
-///    / comprehension), mark `ended_at`, and save.
+///    / comprehension), mark `ended_at`, and save. See #74 for the
+///    follow-up that moves this drain off the critical path.
 /// 5. Write the updated `LearnerModel` and the now-stable `session_id`
-///    back into `ActiveSession`.
+///    back into `ActiveSession`. The session_id writeback also runs on
+///    the error path so a mid-stream failure on the first turn doesn't
+///    orphan its (saved-to-disk) child turn under a fresh UUID on retry.
 /// 6. Emit `primer://turn_complete` with the bare-essentials payload.
 ///
 /// **Concurrency.** The session mutex is held for the entire turn —
@@ -144,7 +147,7 @@ pub async fn send_message(
 /// index and the chunk text. Callers wire it to whatever delivery
 /// channel they want (Tauri events in production, a `Vec<String>`
 /// accumulator in tests).
-pub(crate) async fn run_turn<F>(
+async fn run_turn<F>(
     active: &mut ActiveSession,
     input: &str,
     mut on_chunk: F,
@@ -219,11 +222,23 @@ where
     // mid-stream error.
     dm.close_session().await;
 
+    // Stamp the session_id back into ActiveSession on BOTH paths.
+    // respond_to_streaming records the child turn before the inference
+    // call (step 1 of its flow) and persist_turn saves the partial
+    // session to disk regardless of stream outcome. Without writing
+    // session_id back on the error path, a mid-stream failure on the
+    // first turn would orphan that on-disk Session: the next
+    // send_message would see `previous_session_id = None` and mint a
+    // fresh UUID, leaving the failed child turn stranded.
+    let session_id = dm.session.id;
+    active.session_id = Some(session_id);
+
     response_result.map_err(|e| e.to_string())?;
 
-    let session_id = dm.session.id;
+    // Learner writeback only on success — respond_to_streaming's
+    // contract is that the learner model is not updated on a mid-stream
+    // error (the partial Primer turn was dropped).
     *active.learner.lock().await = dm.learner;
-    active.session_id = Some(session_id);
 
     Ok(TurnComplete {
         session_id,

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -8,7 +8,9 @@
 //! `send_message` clones the DM Arc out of the session guard, releases
 //! the session guard, then locks the DM independently for the duration
 //! of the turn — so the long streaming wallclock doesn't keep other
-//! commands (e.g. `current_session_info`) waiting.
+//! commands (e.g. `current_session_info`) waiting. After each
+//! successful turn it refreshes [`ActiveSession::snapshot`] so reader
+//! commands never touch the DM lock at all.
 
 use std::sync::Arc;
 
@@ -17,7 +19,7 @@ use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::state::{ActiveSession, AppState};
+use crate::state::{ActiveSession, AppState, SessionSnapshot};
 use crate::types::{ChunkEvent, LearnerSummary, SessionInfo, TurnComplete};
 use crate::wiring;
 
@@ -106,16 +108,22 @@ pub async fn send_message(
     app: AppHandle,
     input: String,
 ) -> Result<TurnComplete, String> {
-    // Clone the DM Arc out under the session mutex, then release it.
-    let dm_arc = {
+    // Clone both Arcs under the session mutex, then release it. The
+    // DM Arc drives the turn; the snapshot Arc is refreshed at the
+    // end so reader commands see fresh learner/session-id fields
+    // without ever locking the DM.
+    let (dm_arc, snapshot_arc) = {
         let guard = state.session.lock().await;
         let active = guard
             .as_ref()
             .ok_or_else(|| "no active session — call start_session first".to_string())?;
-        Arc::clone(&active.dialogue_manager)
+        (
+            Arc::clone(&active.dialogue_manager),
+            Arc::clone(&active.snapshot),
+        )
     };
 
-    run_turn(&dm_arc, &input, |primer_turn_index, chunk| {
+    let payload = run_turn(&dm_arc, &input, |primer_turn_index, chunk| {
         let payload = ChunkEvent {
             primer_turn_index,
             text: chunk.to_string(),
@@ -124,12 +132,36 @@ pub async fn send_message(
             tracing::warn!("emit primer://chunk failed: {e}");
         }
     })
-    .await
-    .inspect(|payload| {
-        if let Err(e) = app.emit("primer://turn_complete", payload) {
-            tracing::warn!("emit primer://turn_complete failed: {e}");
+    .await?;
+
+    refresh_snapshot(&dm_arc, &snapshot_arc).await;
+
+    if let Err(e) = app.emit("primer://turn_complete", &payload) {
+        tracing::warn!("emit primer://turn_complete failed: {e}");
+    }
+    Ok(payload)
+}
+
+/// Re-read learner + session-id fields from the just-completed DM and
+/// publish them into the snapshot. The DM lock is held only for the
+/// few field reads — no `.await` inside — so any concurrent
+/// `current_session_info` waiting on the snapshot mutex returns in
+/// microseconds, not the streaming wallclock.
+async fn refresh_snapshot(
+    dm_arc: &Arc<Mutex<DialogueManager>>,
+    snapshot_arc: &Arc<Mutex<SessionSnapshot>>,
+) {
+    let new_snapshot = {
+        let dm = dm_arc.lock().await;
+        SessionSnapshot {
+            session_id: Some(dm.session.id),
+            learner_id: dm.learner.profile.id,
+            learner_name: dm.learner.profile.name.clone(),
+            learner_age: dm.learner.profile.age,
+            concept_count: dm.learner.concepts.len(),
         }
-    })
+    };
+    *snapshot_arc.lock().await = new_snapshot;
 }
 
 /// Drive one streaming turn against a held DM.
@@ -167,20 +199,17 @@ where
 }
 
 async fn info_from(active: &ActiveSession) -> SessionInfo {
-    let dm = active.dialogue_manager.lock().await;
-    let session_has_turns = !dm.session.turns.is_empty();
+    // Reads ONLY from the snapshot — never touches the DM mutex —
+    // so a sidebar refresh during a streaming turn returns immediately
+    // instead of queueing behind the entire response wallclock.
+    let snapshot = active.snapshot.lock().await;
     SessionInfo {
-        // The session-row UUID is real from construction (DM mints it
-        // in `new`), but the on-disk row only exists after the first
-        // turn lands (`persist_turn` saves it). Return None until then
-        // so the frontend doesn't display a UUID that can't yet be
-        // round-tripped through `load_session`.
-        session_id: session_has_turns.then_some(dm.session.id),
+        session_id: snapshot.session_id,
         learner: LearnerSummary {
-            id: dm.learner.profile.id,
-            name: dm.learner.profile.name.clone(),
-            age: dm.learner.profile.age,
-            concept_count: dm.learner.concepts.len(),
+            id: snapshot.learner_id,
+            name: snapshot.learner_name.clone(),
+            age: snapshot.learner_age,
+            concept_count: snapshot.concept_count,
         },
         backend_kind: active.backend_name.clone(),
         main_model: active.main_model.clone(),
@@ -237,7 +266,10 @@ mod tests {
             first.session_id, second.session_id,
             "long-lived DM holds the same Session across turns"
         );
-        assert_eq!(second.child_turn_index, 2, "child #2 lands after first exchange");
+        assert_eq!(
+            second.child_turn_index, 2,
+            "child #2 lands after first exchange"
+        );
         assert_eq!(second.primer_turn_index, 3, "primer #2 lands at index 3");
     }
 
@@ -252,17 +284,17 @@ mod tests {
             .await
             .unwrap();
 
-        // Reach into the DM's storage Arc to verify the on-disk row
-        // round-trips. The DM exposes its stores via the public field
-        // path indirectly — we re-open via the test config's session
-        // db path instead, which validates the actual on-disk artefact
-        // independently of any DM-internal caching.
+        // Drain the DM's background tasks before re-opening the same
+        // DB from a second connection so we don't race a still-running
+        // extractor/comprehension/embedding write through the first.
+        dm_arc.lock().await.close_session().await;
+
+        // Re-open via the test config's session-db path so we validate
+        // the actual on-disk artefact independently of any DM-internal
+        // caching.
         let session_db = home.path().join("test_session.db");
-        let store = primer_storage::SqliteSessionStore::open_for_locale(
-            &session_db,
-            active.locale,
-        )
-        .unwrap();
+        let store = primer_storage::SqliteSessionStore::open_for_locale(&session_db, active.locale)
+            .unwrap();
         let loaded = primer_core::storage::SessionStore::load_session(&store, payload.session_id)
             .await
             .unwrap()
@@ -271,6 +303,50 @@ mod tests {
             loaded.turns.len() >= 2,
             "session must persist both the child and primer turns; got {} turns",
             loaded.turns.len()
+        );
+    }
+
+    /// Pre-turn `current_session_info` (via `info_from`) returns the
+    /// initial snapshot (no `session_id` yet) without ever touching
+    /// the DM mutex; after `send_message`-style snapshot refresh, the
+    /// session_id and concept count appear.
+    #[tokio::test]
+    async fn snapshot_decouples_info_from_dm_lock() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+
+        let before = info_from(&active).await;
+        assert!(
+            before.session_id.is_none(),
+            "pre-turn snapshot has no session_id"
+        );
+        assert_eq!(before.learner.name, cfg.learner.name);
+        assert_eq!(before.learner.age, cfg.learner.age);
+
+        // Hold the DM lock for the whole duration of the snapshot
+        // refresh + reader call — if `info_from` were still touching
+        // the DM mutex, the second `info_from` below would deadlock
+        // here (current task holds DM lock, info_from would block
+        // waiting for it). Reaching the `assert!` proves info_from
+        // never blocks on the DM.
+        let dm_arc = Arc::clone(&active.dialogue_manager);
+        let _guard = dm_arc.lock().await;
+        let during_stream = info_from(&active).await;
+        assert_eq!(
+            during_stream.learner.id, before.learner.id,
+            "info_from returns while DM is locked elsewhere"
+        );
+        drop(_guard);
+
+        let dm_arc = Arc::clone(&active.dialogue_manager);
+        let _payload = run_turn(&dm_arc, "hello", |_, _| {}).await.unwrap();
+        refresh_snapshot(&dm_arc, &active.snapshot).await;
+
+        let after = info_from(&active).await;
+        assert!(
+            after.session_id.is_some(),
+            "post-turn snapshot carries the session id"
         );
     }
 }

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -9,8 +9,13 @@
 //! `DialogueManager`) lands in step 4. `resume_session` + `list_sessions`
 //! land in step 9 alongside the picker.
 
+use std::sync::Arc;
+
+use primer_pedagogy::{DialogueManager, DialogueManagerStores, DialogueManagerSubsystems};
+use tauri::{AppHandle, Emitter};
+
 use crate::state::{ActiveSession, AppState};
-use crate::types::{LearnerSummary, SessionInfo};
+use crate::types::{ChunkEvent, LearnerSummary, SessionInfo, TurnComplete};
 use crate::wiring;
 
 /// Construct an `ActiveSession` from the persisted settings and store
@@ -80,6 +85,153 @@ async fn close_session_inner(state: &tauri::State<'_, AppState>) -> Result<(), S
     Ok(())
 }
 
+/// Drive one streaming dialogue turn end-to-end.
+///
+/// Flow:
+/// 1. Construct a fresh `DialogueManager` from the active session's
+///    Arcs (per the plan, DM is per-command rather than long-lived).
+/// 2. If this isn't the very first turn, load the existing `Session`
+///    from disk and `resume_session` so the timeline + summary +
+///    engagement history carry over.
+/// 3. Run `respond_to_streaming`, emitting one `primer://chunk` event
+///    per token. The callback also captures the chunk text into a
+///    String so we have the full response for the post-turn event.
+/// 4. `close_session` to drain background tasks (classifier / extractor
+///    / comprehension), mark `ended_at`, and save.
+/// 5. Write the updated `LearnerModel` and the now-stable `session_id`
+///    back into `ActiveSession`.
+/// 6. Emit `primer://turn_complete` with the bare-essentials payload.
+///
+/// **Concurrency.** The session mutex is held for the entire turn —
+/// concurrent `send_message` calls would race over DM construction
+/// and `LearnerModel` ownership. Other commands that don't lock
+/// `state.session` (e.g. `get_settings`) keep running.
+#[tauri::command]
+pub async fn send_message(
+    state: tauri::State<'_, AppState>,
+    app: AppHandle,
+    input: String,
+) -> Result<TurnComplete, String> {
+    let mut guard = state.session.lock().await;
+    let active = guard
+        .as_mut()
+        .ok_or_else(|| "no active session — call start_session first".to_string())?;
+
+    run_turn(active, &input, |primer_turn_index, chunk| {
+        let payload = ChunkEvent {
+            primer_turn_index,
+            text: chunk.to_string(),
+        };
+        if let Err(e) = app.emit("primer://chunk", &payload) {
+            tracing::warn!("emit primer://chunk failed: {e}");
+        }
+    })
+    .await
+    .inspect(|payload| {
+        if let Err(e) = app.emit("primer://turn_complete", payload) {
+            tracing::warn!("emit primer://turn_complete failed: {e}");
+        }
+    })
+}
+
+/// Drive one streaming turn end-to-end against an `ActiveSession`.
+///
+/// Split out from `send_message` so unit tests can exercise the full
+/// DM construction / resume / respond / close / writeback flow
+/// without a Tauri `AppHandle` in scope.
+///
+/// `on_chunk` is invoked once per streamed token with the Primer-turn
+/// index and the chunk text. Callers wire it to whatever delivery
+/// channel they want (Tauri events in production, a `Vec<String>`
+/// accumulator in tests).
+pub(crate) async fn run_turn<F>(
+    active: &mut ActiveSession,
+    input: &str,
+    mut on_chunk: F,
+) -> Result<TurnComplete, String>
+where
+    F: FnMut(usize, &str),
+{
+    // Clone the learner — DM takes ownership; we put the mutated copy
+    // back into the active session on return.
+    let learner = active.learner.lock().await.clone();
+    let previous_session_id = active.session_id;
+
+    // Bundle subsystems + stores DM expects, cloning the Arcs.
+    let stores = DialogueManagerStores {
+        session: Some(Arc::clone(&active.session_store)),
+        learner: Some(Arc::clone(&active.learner_store)),
+    };
+    let subsystems = DialogueManagerSubsystems {
+        classifier: Arc::clone(&active.classifier),
+        classifier_settings: active.classifier_settings.clone(),
+        extractor: Arc::clone(&active.extractor),
+        extractor_settings: active.extractor_settings.clone(),
+        comprehension: Arc::clone(&active.comprehension),
+        comprehension_settings: active.comprehension_settings.clone(),
+        vocab_settings: active.vocab_settings,
+        embedder: active.embedder.clone(),
+    };
+
+    // Construct DM. `inference` and `knowledge` are borrowed from the
+    // Arcs we keep alive on the stack; DM's `&'a dyn` lifetime is
+    // tied to this function's scope.
+    let inference = active.backend.as_ref();
+    let knowledge = active.knowledge.as_ref();
+    let mut dm = DialogueManager::new(
+        learner,
+        inference,
+        knowledge,
+        stores,
+        subsystems,
+        active.pedagogy_config.clone(),
+    );
+
+    // Resume the prior Session if this isn't the first turn.
+    if let Some(prev_id) = previous_session_id {
+        match active.session_store.load_session(prev_id).await {
+            Ok(Some(loaded)) => {
+                dm.resume_session(loaded)
+                    .await
+                    .map_err(|e| format!("resume_session({prev_id}): {e}"))?;
+            }
+            Ok(None) => {
+                return Err(format!(
+                    "session {prev_id} missing from store; the file may have been deleted"
+                ));
+            }
+            Err(e) => return Err(format!("load_session({prev_id}): {e}")),
+        }
+    }
+
+    // The Primer turn lands at `turns.len() + 1` after the child's
+    // turn appends at `turns.len()`. Captured before respond_to_streaming
+    // so the chunk callback can address its bubble.
+    let primer_turn_index = dm.session.turns.len() + 1;
+
+    let response_result = dm
+        .respond_to_streaming(input, |chunk| on_chunk(primer_turn_index, chunk))
+        .await;
+
+    // close_session drains the background classifier / extractor /
+    // comprehension tasks so their results land on disk AND in
+    // dm.learner before we extract it. Idempotent — safe even on a
+    // mid-stream error.
+    dm.close_session().await;
+
+    response_result.map_err(|e| e.to_string())?;
+
+    let session_id = dm.session.id;
+    *active.learner.lock().await = dm.learner;
+    active.session_id = Some(session_id);
+
+    Ok(TurnComplete {
+        session_id,
+        child_turn_index: primer_turn_index - 1,
+        primer_turn_index,
+    })
+}
+
 async fn info_from(active: &ActiveSession) -> SessionInfo {
     let learner = active.learner.lock().await;
     SessionInfo {
@@ -93,5 +245,86 @@ async fn info_from(active: &ActiveSession) -> SessionInfo {
         backend_kind: active.backend_name.clone(),
         main_model: active.main_model.clone(),
         locale: active.locale.pack_id().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::GuiConfig;
+    use crate::wiring::build_active_session;
+    use tempfile::TempDir;
+
+    fn stub_config_with_persistence(home: &std::path::Path) -> GuiConfig {
+        // Persist to a real on-disk session DB so the second turn's
+        // resume_session path is exercised against actual storage.
+        let mut cfg = GuiConfig::default();
+        cfg.persistence.session_db = Some(home.join("test_session.db"));
+        cfg
+    }
+
+    #[tokio::test]
+    async fn first_turn_creates_session_and_returns_payload() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let mut active = build_active_session(home.path(), &cfg).await.unwrap();
+
+        assert!(active.session_id.is_none(), "no session_id before first turn");
+
+        let mut chunks = Vec::<(usize, String)>::new();
+        let payload = run_turn(&mut active, "hello", |i, c| chunks.push((i, c.to_string())))
+            .await
+            .unwrap();
+
+        assert!(active.session_id.is_some(), "session_id set after first turn");
+        assert_eq!(active.session_id.unwrap(), payload.session_id);
+        assert_eq!(payload.child_turn_index, 0, "child lands at index 0");
+        assert_eq!(payload.primer_turn_index, 1, "primer lands at index 1");
+        assert!(!chunks.is_empty(), "stub backend emits at least one chunk");
+        // Every chunk must address the correct primer turn.
+        for (idx, _) in &chunks {
+            assert_eq!(*idx, payload.primer_turn_index);
+        }
+    }
+
+    #[tokio::test]
+    async fn second_turn_resumes_same_session() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let mut active = build_active_session(home.path(), &cfg).await.unwrap();
+
+        let first = run_turn(&mut active, "hello", |_, _| {}).await.unwrap();
+        let second = run_turn(&mut active, "tell me more", |_, _| {}).await.unwrap();
+
+        assert_eq!(
+            first.session_id, second.session_id,
+            "second turn resumes the same Session — no orphan ids"
+        );
+        assert_eq!(second.child_turn_index, 2, "child #2 lands after first exchange");
+        assert_eq!(second.primer_turn_index, 3, "primer #2 lands at index 3");
+    }
+
+    #[tokio::test]
+    async fn turn_persists_to_session_store() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let mut active = build_active_session(home.path(), &cfg).await.unwrap();
+        let store = Arc::clone(&active.session_store);
+
+        let payload = run_turn(&mut active, "what is curiosity?", |_, _| {})
+            .await
+            .unwrap();
+
+        // Verify the session is round-trippable through the on-disk store.
+        let loaded = store
+            .load_session(payload.session_id)
+            .await
+            .unwrap()
+            .expect("session must be loadable after first turn");
+        assert!(
+            loaded.turns.len() >= 2,
+            "session must persist both the child and primer turns; got {} turns",
+            loaded.turns.len()
+        );
     }
 }

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -1,18 +1,21 @@
-//! Session lifecycle commands: start, close, query.
+//! Session lifecycle + per-turn streaming commands.
 //!
-//! `start_session` builds an [`ActiveSession`] from the persisted
-//! `GuiConfig` and stores it in `AppState`. `close_session` drops it.
-//! `current_session_info` returns a serialisable summary so the
-//! frontend can render its header.
+//! `start_session` builds an [`ActiveSession`] (which carries a
+//! long-lived [`DialogueManager`]) from the persisted `GuiConfig` and
+//! stores it in `AppState`. `close_session` drops it, draining any
+//! in-flight background tasks first via `dm.close_session()`.
 //!
-//! `send_message` (the streaming command that drives a turn through
-//! `DialogueManager`) lands in step 4. `resume_session` + `list_sessions`
-//! land in step 9 alongside the picker.
+//! `send_message` clones the DM Arc out of the session guard, releases
+//! the session guard, then locks the DM independently for the duration
+//! of the turn — so the long streaming wallclock doesn't keep other
+//! commands (e.g. `current_session_info`) waiting.
 
 use std::sync::Arc;
 
-use primer_pedagogy::{DialogueManager, DialogueManagerStores, DialogueManagerSubsystems};
+use primer_pedagogy::DialogueManager;
 use tauri::{AppHandle, Emitter};
+use tokio::sync::Mutex;
+use uuid::Uuid;
 
 use crate::state::{ActiveSession, AppState};
 use crate::types::{ChunkEvent, LearnerSummary, SessionInfo, TurnComplete};
@@ -23,11 +26,10 @@ use crate::wiring;
 ///
 /// If a session is already open, it is closed first (no resource leak
 /// even if the frontend forgets to close before re-starting). The
-/// previous learner's state is saved before the new session opens.
+/// previous learner's state is saved as part of `close_session`'s
+/// internal drain.
 #[tauri::command]
 pub async fn start_session(state: tauri::State<'_, AppState>) -> Result<SessionInfo, String> {
-    // Close any pre-existing session first so the Arcs from the old
-    // construction drop before we build the new ones.
     close_session_inner(&state).await?;
 
     let cfg = state.config.lock().await.clone();
@@ -40,9 +42,9 @@ pub async fn start_session(state: tauri::State<'_, AppState>) -> Result<SessionI
 /// Drop the active session, if any. Idempotent — calling it with no
 /// active session is a no-op (returns Ok).
 ///
-/// Persists the current learner state on the way out so the next
-/// `start_session` (or the next CLI run) sees the latest box-levels
-/// / concept counts / engagement history.
+/// Drains the DM's background tasks (classifier / extractor /
+/// comprehension) before drop so the final turn's analysis lands on
+/// disk before the Arcs are released.
 #[tauri::command]
 pub async fn close_session(state: tauri::State<'_, AppState>) -> Result<(), String> {
     close_session_inner(&state).await
@@ -63,24 +65,19 @@ pub async fn current_session_info(
     }
 }
 
-/// Internal helper used by both `close_session` and `start_session` so
-/// the persistence-then-drop flow is centralised. Lock is released
-/// before the (potentially I/O-heavy) `save_learner` call so other
-/// commands aren't blocked on slow disk.
+/// Internal helper used by both `close_session` and `start_session`.
+///
+/// Two-step lock dance: pop the `ActiveSession` out of the session
+/// mutex first (so other commands aren't blocked while DM drain runs),
+/// then lock the DM mutex and call `close_session` on it. The DM mutex
+/// lock will WAIT for any in-flight `send_message` to finish — exactly
+/// the right behaviour so a "Close" click never aborts a partially-
+/// streamed response.
 async fn close_session_inner(state: &tauri::State<'_, AppState>) -> Result<(), String> {
-    let to_save = {
-        let mut guard = state.session.lock().await;
-        if let Some(active) = guard.take() {
-            let snapshot = active.learner.lock().await.clone();
-            Some((std::sync::Arc::clone(&active.learner_store), snapshot))
-        } else {
-            None
-        }
-    };
-    if let Some((store, snapshot)) = to_save {
-        if let Err(e) = store.save_learner(&snapshot).await {
-            tracing::warn!("save_learner on close failed: {e}");
-        }
+    let active = state.session.lock().await.take();
+    if let Some(active) = active {
+        let mut dm = active.dialogue_manager.lock().await;
+        dm.close_session().await;
     }
     Ok(())
 }
@@ -88,39 +85,37 @@ async fn close_session_inner(state: &tauri::State<'_, AppState>) -> Result<(), S
 /// Drive one streaming dialogue turn end-to-end.
 ///
 /// Flow:
-/// 1. Construct a fresh `DialogueManager` from the active session's
-///    Arcs (per the plan, DM is per-command rather than long-lived).
-/// 2. If this isn't the very first turn, load the existing `Session`
-///    from disk and `resume_session` so the timeline + summary +
-///    engagement history carry over.
-/// 3. Run `respond_to_streaming`, emitting one `primer://chunk` event
-///    per token. The frontend reassembles the full response from the
-///    chunk stream — no String accumulation is needed server-side.
-/// 4. `close_session` to drain background tasks (classifier / extractor
-///    / comprehension), mark `ended_at`, and save. See #74 for the
-///    follow-up that moves this drain off the critical path.
-/// 5. Write the updated `LearnerModel` and the now-stable `session_id`
-///    back into `ActiveSession`. The session_id writeback also runs on
-///    the error path so a mid-stream failure on the first turn doesn't
-///    orphan its (saved-to-disk) child turn under a fresh UUID on retry.
-/// 6. Emit `primer://turn_complete` with the bare-essentials payload.
-///
-/// **Concurrency.** The session mutex is held for the entire turn —
-/// concurrent `send_message` calls would race over DM construction
-/// and `LearnerModel` ownership. Other commands that don't lock
-/// `state.session` (e.g. `get_settings`) keep running.
+/// 1. Clone the DM Arc out of the session guard and release the
+///    session guard. Other commands (`current_session_info`,
+///    `update_settings`, …) keep running for the duration of the turn.
+/// 2. Lock the DM mutex. Concurrent `send_message` calls serialise
+///    here — there can only be one in-flight turn at a time, which is
+///    what the pedagogy crate expects.
+/// 3. Capture the Primer-turn index, then run `respond_to_streaming`.
+///    `await_pending_background` at the top of that method drains the
+///    PREVIOUS turn's classifier / extractor / comprehension tasks
+///    inside the natural inter-turn pause — that's the latency
+///    property we get back from holding DM long-lived.
+/// 4. Emit `primer://turn_complete` immediately on success. The current
+///    turn's spawned background tasks keep running in the background
+///    and will be awaited at the start of the next turn (or at
+///    `close_session`).
 #[tauri::command]
 pub async fn send_message(
     state: tauri::State<'_, AppState>,
     app: AppHandle,
     input: String,
 ) -> Result<TurnComplete, String> {
-    let mut guard = state.session.lock().await;
-    let active = guard
-        .as_mut()
-        .ok_or_else(|| "no active session — call start_session first".to_string())?;
+    // Clone the DM Arc out under the session mutex, then release it.
+    let dm_arc = {
+        let guard = state.session.lock().await;
+        let active = guard
+            .as_ref()
+            .ok_or_else(|| "no active session — call start_session first".to_string())?;
+        Arc::clone(&active.dialogue_manager)
+    };
 
-    run_turn(active, &input, |primer_turn_index, chunk| {
+    run_turn(&dm_arc, &input, |primer_turn_index, chunk| {
         let payload = ChunkEvent {
             primer_turn_index,
             text: chunk.to_string(),
@@ -137,108 +132,32 @@ pub async fn send_message(
     })
 }
 
-/// Drive one streaming turn end-to-end against an `ActiveSession`.
+/// Drive one streaming turn against a held DM.
 ///
 /// Split out from `send_message` so unit tests can exercise the full
-/// DM construction / resume / respond / close / writeback flow
-/// without a Tauri `AppHandle` in scope.
+/// lock / respond / unlock flow without a Tauri `AppHandle` in scope.
 ///
 /// `on_chunk` is invoked once per streamed token with the Primer-turn
-/// index and the chunk text. Callers wire it to whatever delivery
-/// channel they want (Tauri events in production, a `Vec<String>`
-/// accumulator in tests).
+/// index and the chunk text.
 async fn run_turn<F>(
-    active: &mut ActiveSession,
+    dm_arc: &Arc<Mutex<DialogueManager>>,
     input: &str,
     mut on_chunk: F,
 ) -> Result<TurnComplete, String>
 where
     F: FnMut(usize, &str),
 {
-    // Clone the learner — DM takes ownership; we put the mutated copy
-    // back into the active session on return.
-    let learner = active.learner.lock().await.clone();
-    let previous_session_id = active.session_id;
+    let mut dm = dm_arc.lock().await;
 
-    // Bundle subsystems + stores DM expects, cloning the Arcs.
-    let stores = DialogueManagerStores {
-        session: Some(Arc::clone(&active.session_store)),
-        learner: Some(Arc::clone(&active.learner_store)),
-    };
-    let subsystems = DialogueManagerSubsystems {
-        classifier: Arc::clone(&active.classifier),
-        classifier_settings: active.classifier_settings.clone(),
-        extractor: Arc::clone(&active.extractor),
-        extractor_settings: active.extractor_settings.clone(),
-        comprehension: Arc::clone(&active.comprehension),
-        comprehension_settings: active.comprehension_settings.clone(),
-        vocab_settings: active.vocab_settings,
-        embedder: active.embedder.clone(),
-    };
-
-    // Construct DM. `inference` and `knowledge` are borrowed from the
-    // Arcs we keep alive on the stack; DM's `&'a dyn` lifetime is
-    // tied to this function's scope.
-    let inference = active.backend.as_ref();
-    let knowledge = active.knowledge.as_ref();
-    let mut dm = DialogueManager::new(
-        learner,
-        inference,
-        knowledge,
-        stores,
-        subsystems,
-        active.pedagogy_config.clone(),
-    );
-
-    // Resume the prior Session if this isn't the first turn.
-    if let Some(prev_id) = previous_session_id {
-        match active.session_store.load_session(prev_id).await {
-            Ok(Some(loaded)) => {
-                dm.resume_session(loaded)
-                    .await
-                    .map_err(|e| format!("resume_session({prev_id}): {e}"))?;
-            }
-            Ok(None) => {
-                return Err(format!(
-                    "session {prev_id} missing from store; the file may have been deleted"
-                ));
-            }
-            Err(e) => return Err(format!("load_session({prev_id}): {e}")),
-        }
-    }
-
-    // The Primer turn lands at `turns.len() + 1` after the child's
-    // turn appends at `turns.len()`. Captured before respond_to_streaming
-    // so the chunk callback can address its bubble.
+    // The Primer turn lands at `turns.len() + 1` after the child turn
+    // appends at `turns.len()`. Captured before respond_to_streaming
+    // runs so the chunk callback can address its bubble.
     let primer_turn_index = dm.session.turns.len() + 1;
+    let session_id: Uuid = dm.session.id;
 
-    let response_result = dm
-        .respond_to_streaming(input, |chunk| on_chunk(primer_turn_index, chunk))
-        .await;
-
-    // close_session drains the background classifier / extractor /
-    // comprehension tasks so their results land on disk AND in
-    // dm.learner before we extract it. Idempotent — safe even on a
-    // mid-stream error.
-    dm.close_session().await;
-
-    // Stamp the session_id back into ActiveSession on BOTH paths.
-    // respond_to_streaming records the child turn before the inference
-    // call (step 1 of its flow) and persist_turn saves the partial
-    // session to disk regardless of stream outcome. Without writing
-    // session_id back on the error path, a mid-stream failure on the
-    // first turn would orphan that on-disk Session: the next
-    // send_message would see `previous_session_id = None` and mint a
-    // fresh UUID, leaving the failed child turn stranded.
-    let session_id = dm.session.id;
-    active.session_id = Some(session_id);
-
-    response_result.map_err(|e| e.to_string())?;
-
-    // Learner writeback only on success — respond_to_streaming's
-    // contract is that the learner model is not updated on a mid-stream
-    // error (the partial Primer turn was dropped).
-    *active.learner.lock().await = dm.learner;
+    dm.respond_to_streaming(input, |chunk| on_chunk(primer_turn_index, chunk))
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(TurnComplete {
         session_id,
@@ -248,14 +167,20 @@ where
 }
 
 async fn info_from(active: &ActiveSession) -> SessionInfo {
-    let learner = active.learner.lock().await;
+    let dm = active.dialogue_manager.lock().await;
+    let session_has_turns = !dm.session.turns.is_empty();
     SessionInfo {
-        session_id: active.session_id,
+        // The session-row UUID is real from construction (DM mints it
+        // in `new`), but the on-disk row only exists after the first
+        // turn lands (`persist_turn` saves it). Return None until then
+        // so the frontend doesn't display a UUID that can't yet be
+        // round-tripped through `load_session`.
+        session_id: session_has_turns.then_some(dm.session.id),
         learner: LearnerSummary {
-            id: learner.profile.id,
-            name: learner.profile.name.clone(),
-            age: learner.profile.age,
-            concept_count: learner.concepts.len(),
+            id: dm.learner.profile.id,
+            name: dm.learner.profile.name.clone(),
+            age: dm.learner.profile.age,
+            concept_count: dm.learner.concepts.len(),
         },
         backend_kind: active.backend_name.clone(),
         main_model: active.main_model.clone(),
@@ -282,38 +207,35 @@ mod tests {
     async fn first_turn_creates_session_and_returns_payload() {
         let home = TempDir::new().unwrap();
         let cfg = stub_config_with_persistence(home.path());
-        let mut active = build_active_session(home.path(), &cfg).await.unwrap();
-
-        assert!(active.session_id.is_none(), "no session_id before first turn");
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm_arc = Arc::clone(&active.dialogue_manager);
 
         let mut chunks = Vec::<(usize, String)>::new();
-        let payload = run_turn(&mut active, "hello", |i, c| chunks.push((i, c.to_string())))
+        let payload = run_turn(&dm_arc, "hello", |i, c| chunks.push((i, c.to_string())))
             .await
             .unwrap();
 
-        assert!(active.session_id.is_some(), "session_id set after first turn");
-        assert_eq!(active.session_id.unwrap(), payload.session_id);
         assert_eq!(payload.child_turn_index, 0, "child lands at index 0");
         assert_eq!(payload.primer_turn_index, 1, "primer lands at index 1");
         assert!(!chunks.is_empty(), "stub backend emits at least one chunk");
-        // Every chunk must address the correct primer turn.
         for (idx, _) in &chunks {
             assert_eq!(*idx, payload.primer_turn_index);
         }
     }
 
     #[tokio::test]
-    async fn second_turn_resumes_same_session() {
+    async fn second_turn_continues_same_session() {
         let home = TempDir::new().unwrap();
         let cfg = stub_config_with_persistence(home.path());
-        let mut active = build_active_session(home.path(), &cfg).await.unwrap();
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm_arc = Arc::clone(&active.dialogue_manager);
 
-        let first = run_turn(&mut active, "hello", |_, _| {}).await.unwrap();
-        let second = run_turn(&mut active, "tell me more", |_, _| {}).await.unwrap();
+        let first = run_turn(&dm_arc, "hello", |_, _| {}).await.unwrap();
+        let second = run_turn(&dm_arc, "tell me more", |_, _| {}).await.unwrap();
 
         assert_eq!(
             first.session_id, second.session_id,
-            "second turn resumes the same Session — no orphan ids"
+            "long-lived DM holds the same Session across turns"
         );
         assert_eq!(second.child_turn_index, 2, "child #2 lands after first exchange");
         assert_eq!(second.primer_turn_index, 3, "primer #2 lands at index 3");
@@ -323,16 +245,25 @@ mod tests {
     async fn turn_persists_to_session_store() {
         let home = TempDir::new().unwrap();
         let cfg = stub_config_with_persistence(home.path());
-        let mut active = build_active_session(home.path(), &cfg).await.unwrap();
-        let store = Arc::clone(&active.session_store);
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm_arc = Arc::clone(&active.dialogue_manager);
 
-        let payload = run_turn(&mut active, "what is curiosity?", |_, _| {})
+        let payload = run_turn(&dm_arc, "what is curiosity?", |_, _| {})
             .await
             .unwrap();
 
-        // Verify the session is round-trippable through the on-disk store.
-        let loaded = store
-            .load_session(payload.session_id)
+        // Reach into the DM's storage Arc to verify the on-disk row
+        // round-trips. The DM exposes its stores via the public field
+        // path indirectly — we re-open via the test config's session
+        // db path instead, which validates the actual on-disk artefact
+        // independently of any DM-internal caching.
+        let session_db = home.path().join("test_session.db");
+        let store = primer_storage::SqliteSessionStore::open_for_locale(
+            &session_db,
+            active.locale,
+        )
+        .unwrap();
+        let loaded = primer_core::storage::SessionStore::load_session(&store, payload.session_id)
             .await
             .unwrap()
             .expect("session must be loadable after first turn");

--- a/src/crates/primer-gui/src/state.rs
+++ b/src/crates/primer-gui/src/state.rs
@@ -6,33 +6,30 @@
 //!
 //! 1. The persisted `GuiConfig` (mutable across "Save" actions).
 //! 2. The home directory path so config save/load are filesystem-pure.
-//! 3. An optional `ActiveSession` carrying the constructed inference /
-//!    knowledge / classifier / extractor / comprehension / embedder /
-//!    store Arcs once `start_session` succeeds.
+//! 3. An optional `ActiveSession` holding the constructed long-lived
+//!    `DialogueManager` once `start_session` succeeds.
 //!
-//! Per the implementation plan, the `DialogueManager` itself is *not*
-//! held long-lived — it's constructed lazily on each send-message
-//! command from the Arcs in `ActiveSession`. That choice keeps the
-//! lifetime story of DM's `&'a dyn` borrows compatible with Tauri's
-//! `'static + Send + Sync` state model without refactoring
-//! `primer-pedagogy`.
+//! The `DialogueManager` is held long-lived (behind `Arc<Mutex<…>>`)
+//! so the natural CLI latency design carries over: the previous turn's
+//! classifier / extractor / comprehension tasks are awaited at the
+//! TOP of the next `respond_to_streaming` rather than at the END of
+//! the current one. That keeps the composer re-enable instantaneous
+//! once the stream finishes and absorbs the ~13 s background-task
+//! wallclock in the natural inter-turn pause.
+//!
+//! Sharing across tasks: the DM is held in `Arc<Mutex<DialogueManager>>`
+//! so a command can clone the Arc out of the session guard, release
+//! the session guard, and lock the DM independently. That keeps
+//! `current_session_info` / `update_settings` / future sidebar
+//! commands free to run while a turn is streaming — they'd otherwise
+//! queue behind the entire turn duration.
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use primer_classifier::{ClassifierSettings, EngagementClassifier};
-use primer_comprehension::{ComprehensionClassifier, ComprehensionSettings};
-use primer_core::config::PedagogyConfig;
-use primer_core::embedder::Embedder;
 use primer_core::i18n::Locale;
-use primer_core::inference::InferenceBackend;
-use primer_core::learner::LearnerModel;
-use primer_core::storage::{LearnerStore, SessionStore};
-use primer_extractor::{ConceptExtractor, ExtractorSettings};
-use primer_knowledge::SqliteKnowledgeBase;
-use primer_pedagogy::vocab::VocabSettings;
+use primer_pedagogy::DialogueManager;
 use tokio::sync::Mutex;
-use uuid::Uuid;
 
 use crate::config::GuiConfig;
 
@@ -66,76 +63,45 @@ impl AppState {
     }
 }
 
-/// Everything `DialogueManager::new` needs to be constructed
-/// per-command, plus the live `LearnerModel` that mutates across turns.
+/// The active session — wraps a long-lived `DialogueManager` plus the
+/// small chunk of display-only metadata commands need without locking
+/// the DM (so `current_session_info` doesn't block on an in-flight
+/// `send_message`).
 ///
-/// All trait objects are `Arc<dyn ...>` so a command can clone them out
-/// of the state guard, drop the guard, and run the (potentially slow)
-/// dialogue turn outside the mutex — preventing concurrent commands
-/// from blocking on each other unnecessarily.
+/// The DM owns all its collaborators (inference + knowledge as
+/// `Arc<dyn …>` since the Phase 0.3+ refactor; classifier / extractor
+/// / comprehension already were). Putting it behind an `Arc<Mutex<…>>`
+/// lets `send_message` clone the Arc and run its turn outside the
+/// session-state lock.
 pub struct ActiveSession {
-    /// Identifier of the underlying `Session` row in the session DB.
-    ///
-    /// `None` until the first `send_message` opens a `DialogueManager`
-    /// session (step 4). Returning `None` to the frontend is honest —
-    /// a pre-first-turn session has no id yet. An earlier draft used a
-    /// provisional `Uuid::new_v4()` here and overwrote it on first
-    /// turn, which silently invalidated any UUID the frontend cached.
-    pub session_id: Option<Uuid>,
+    /// The dialogue manager — owns the active `Session`, the loaded
+    /// `LearnerModel`, and every subsystem trait object the turn
+    /// needs. Long-lived across `send_message` calls so the previous
+    /// turn's background tasks are awaited at the top of the next
+    /// turn (CLI-style), not synchronously at end-of-turn.
+    pub dialogue_manager: Arc<Mutex<DialogueManager>>,
 
     /// The session's locale (matches the learner's stored locale and
-    /// the knowledge base's per-locale partition).
+    /// the knowledge base's per-locale partition). Kept outside the
+    /// DM mutex so `current_session_info` can read it without locking.
     pub locale: Locale,
 
-    /// The currently-loaded `LearnerModel`. Wrapped in a Mutex because
-    /// the dialogue turn mutates it (engagement state, concept depths,
-    /// vocab box transitions) and may run while other commands inspect
-    /// the snapshot for sidebar updates.
-    pub learner: Mutex<LearnerModel>,
-
-    pub backend: Arc<dyn InferenceBackend>,
-    /// Name string used by `primer-engine::build_*` dispatch. Held
-    /// alongside the Arc because `InferenceBackend::name()` cannot be
-    /// called through a borrow once the Arc is moved into a builder.
+    /// Display string for the inference backend kind (e.g. "cloud",
+    /// "ollama", "stub"). Kept outside the DM mutex so the frontend
+    /// header can render without contention.
     pub backend_name: String,
+
+    /// Display string for the main model id (e.g. "claude-sonnet-4-6",
+    /// "llama3.2"). Kept outside the DM mutex for the same reason.
     pub main_model: String,
-
-    pub knowledge: Arc<SqliteKnowledgeBase>,
-
-    pub session_store: Arc<dyn SessionStore>,
-    pub learner_store: Arc<dyn LearnerStore>,
-
-    pub classifier: Arc<dyn EngagementClassifier>,
-    pub classifier_settings: ClassifierSettings,
-    pub extractor: Arc<dyn ConceptExtractor>,
-    pub extractor_settings: ExtractorSettings,
-    pub comprehension: Arc<dyn ComprehensionClassifier>,
-    pub comprehension_settings: ComprehensionSettings,
-
-    pub vocab_settings: VocabSettings,
-    pub embedder: Option<Arc<dyn Embedder>>,
-    pub pedagogy_config: PedagogyConfig,
 }
 
 impl std::fmt::Debug for ActiveSession {
-    /// Print trait-object identities (via `Named::name()` where
-    /// available) instead of the objects themselves — none of them
-    /// implement `Debug`, but tests want `.unwrap_err()` to work and
-    /// printing the wiring summary is more useful than a `<dyn …>`
-    /// placeholder anyway.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ActiveSession")
-            .field("session_id", &self.session_id)
             .field("locale", &self.locale)
             .field("backend_name", &self.backend_name)
             .field("main_model", &self.main_model)
-            .field("classifier", &self.classifier.identifier())
-            .field("extractor", &self.extractor.identifier())
-            .field("comprehension", &self.comprehension.identifier())
-            .field(
-                "embedder",
-                &self.embedder.as_ref().map(|e| e.name().to_string()),
-            )
             .finish_non_exhaustive()
     }
 }

--- a/src/crates/primer-gui/src/state.rs
+++ b/src/crates/primer-gui/src/state.rs
@@ -19,10 +19,13 @@
 //!
 //! Sharing across tasks: the DM is held in `Arc<Mutex<DialogueManager>>`
 //! so a command can clone the Arc out of the session guard, release
-//! the session guard, and lock the DM independently. That keeps
+//! the session guard, and lock the DM independently. To keep
 //! `current_session_info` / `update_settings` / future sidebar
-//! commands free to run while a turn is streaming — they'd otherwise
-//! queue behind the entire turn duration.
+//! commands free to run while a turn is streaming, an
+//! [`SessionSnapshot`] mirror of the DM-owned fields the frontend
+//! needs lives behind its own short-lived `Mutex` — readers never
+//! touch the DM lock. The snapshot is refreshed after each successful
+//! turn from within `send_message`.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -30,6 +33,7 @@ use std::sync::Arc;
 use primer_core::i18n::Locale;
 use primer_pedagogy::DialogueManager;
 use tokio::sync::Mutex;
+use uuid::Uuid;
 
 use crate::config::GuiConfig;
 
@@ -94,6 +98,33 @@ pub struct ActiveSession {
     /// Display string for the main model id (e.g. "claude-sonnet-4-6",
     /// "llama3.2"). Kept outside the DM mutex for the same reason.
     pub main_model: String,
+
+    /// Snapshot of the DM-owned fields the frontend reads via
+    /// `current_session_info`. Refreshed by `send_message` after each
+    /// successful turn so readers never have to lock the DM (and queue
+    /// behind an in-flight stream that can take tens of seconds).
+    pub snapshot: Arc<Mutex<SessionSnapshot>>,
+}
+
+/// Read-mostly mirror of the DM-owned fields the frontend renders via
+/// `current_session_info`. Kept separate from the DM mutex so the
+/// sidebar can read while a turn is streaming. Refreshed by
+/// `send_message` after every successful turn.
+#[derive(Debug, Clone)]
+pub struct SessionSnapshot {
+    /// `None` until the first send_message completes — at that point
+    /// a real `Session` row exists on disk and the UUID can be
+    /// round-tripped through `load_session`.
+    pub session_id: Option<Uuid>,
+    /// Stable learner UUID; written once at construction.
+    pub learner_id: Uuid,
+    /// Learner display name from the resolved profile.
+    pub learner_name: String,
+    /// Learner age from the resolved profile.
+    pub learner_age: u8,
+    /// Concept count from the in-memory learner model. Grows as the
+    /// extractor surfaces new concepts; refreshed at each turn boundary.
+    pub concept_count: usize,
 }
 
 impl std::fmt::Debug for ActiveSession {

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -33,3 +33,43 @@ pub struct LearnerSummary {
     /// concepts" without pulling the full vocab list.
     pub concept_count: usize,
 }
+
+/// Payload of the `primer://turn_complete` event, emitted by
+/// `send_message` once a streaming response has fully landed.
+///
+/// Step 4 carries only the bare essentials the chat surface needs.
+/// Sidebar-shaped signals (intent badge, engagement confidence,
+/// extracted concepts, comprehension depth, retrieved passages) land
+/// in steps 5–6 by extending this struct — the event name stays the
+/// same so the frontend listener doesn't need to know which fields
+/// are present until it tries to render them.
+#[derive(Debug, Clone, Serialize)]
+pub struct TurnComplete {
+    /// UUID of the underlying `Session`. Useful for the frontend to
+    /// confirm subsequent `send_message` calls are addressed to the
+    /// session it thinks they are (no per-call session-id field is
+    /// needed because the GUI is single-session).
+    pub session_id: Uuid,
+
+    /// Zero-based index of the child's turn in the session timeline.
+    pub child_turn_index: usize,
+
+    /// Zero-based index of the Primer's response turn (always
+    /// `child_turn_index + 1`).
+    pub primer_turn_index: usize,
+}
+
+/// Payload of the `primer://chunk` event — a single token (or short
+/// run of tokens) emitted by the streaming inference backend.
+///
+/// Carries the chunk text plus the index of the response bubble it
+/// belongs to so the frontend can append to the correct DOM node
+/// even if a future feature multiplexes streams.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChunkEvent {
+    /// Zero-based index of the Primer's response turn this chunk
+    /// belongs to. Matches [`TurnComplete::primer_turn_index`].
+    pub primer_turn_index: usize,
+    /// The token text — append directly to the bubble.
+    pub text: String,
+}

--- a/src/crates/primer-gui/src/wiring.rs
+++ b/src/crates/primer-gui/src/wiring.rs
@@ -230,27 +230,24 @@ pub async fn build_active_session(
             .unwrap_or(primer_core::consts::vocab::DEFAULT_VOCAB_MAX_PER_PROMPT),
     };
 
-    // ─── ActiveSession ───────────────────────────────────────────────
-    // No session-id yet — step 4's `send_message` will call
-    // `DialogueManager::open_session` and write the real Session UUID
-    // here. `None` over IPC tells the frontend honestly that no turn
-    // has happened yet, instead of handing out a placeholder that
-    // would invalidate as soon as the first turn lands.
-    // `Arc::clone` can't coerce concrete → trait object; the `as _` cast
-    // does the upcast in one step and is the standard idiom for this.
+    // ─── DialogueManager construction ────────────────────────────────
+    // Build the long-lived DM here. `DialogueManager::new` mints a fresh
+    // `Session` automatically (with a brand-new UUID), so no extra
+    // `open_session` call is needed — the first `send_message` lands
+    // the first child turn and primer response into that session.
+    //
+    // The `as _` casts upcast concrete `Arc<T>` to `Arc<dyn Trait>` —
+    // `Arc::clone` alone can't bridge the unsize coercion across the
+    // generic boundary, so the explicit cast is the standard idiom.
     let learner_store: Arc<dyn LearnerStore> = Arc::clone(&session_store) as _;
     let session_store_dyn: Arc<dyn SessionStore> = Arc::clone(&session_store) as _;
+    let knowledge_dyn: Arc<dyn primer_core::knowledge::KnowledgeBase> = knowledge as _;
 
-    Ok(ActiveSession {
-        session_id: None,
-        locale,
-        learner: Mutex::new(learner),
-        backend,
-        backend_name: backend_config.kind.clone(),
-        main_model,
-        knowledge,
-        session_store: session_store_dyn,
-        learner_store,
+    let stores = primer_pedagogy::DialogueManagerStores {
+        session: Some(session_store_dyn),
+        learner: Some(learner_store),
+    };
+    let subsystems = primer_pedagogy::DialogueManagerSubsystems {
         classifier,
         classifier_settings,
         extractor,
@@ -259,7 +256,21 @@ pub async fn build_active_session(
         comprehension_settings,
         vocab_settings,
         embedder,
+    };
+    let dm = primer_pedagogy::DialogueManager::new(
+        learner,
+        Arc::clone(&backend),
+        knowledge_dyn,
+        stores,
+        subsystems,
         pedagogy_config,
+    );
+
+    Ok(ActiveSession {
+        dialogue_manager: Arc::new(Mutex::new(dm)),
+        locale,
+        backend_name: backend_config.kind.clone(),
+        main_model,
     })
 }
 
@@ -335,19 +346,20 @@ mod tests {
         assert_eq!(s.backend_name, "stub");
         assert_eq!(s.main_model, "stub");
         assert_eq!(s.locale, Locale::English);
+        // The DM is constructed but no turn has run yet, so its
+        // session is empty (no on-disk row yet).
+        let dm = s.dialogue_manager.lock().await;
         assert!(
-            s.session_id.is_none(),
-            "session_id is None until first send_message"
+            dm.session.turns.is_empty(),
+            "no turns until first send_message"
         );
         // Subsystems all default to stub when the main backend is stub.
-        assert_eq!(s.classifier.identifier(), "stub");
-        assert_eq!(s.extractor.identifier(), "stub");
-        assert_eq!(s.comprehension.identifier(), "stub");
-        assert!(s.embedder.is_none(), "default embedder is none");
+        assert_eq!(dm.classifier_identifier(), "stub");
+        assert_eq!(dm.extractor_identifier(), "stub");
+        assert_eq!(dm.comprehension_identifier(), "stub");
         // The learner row is freshly minted; name matches config.
-        let learner = s.learner.lock().await;
-        assert_eq!(learner.profile.name, "Explorer");
-        assert_eq!(learner.profile.age, 8);
+        assert_eq!(dm.learner.profile.name, "Explorer");
+        assert_eq!(dm.learner.profile.age, 8);
     }
 
     #[tokio::test]
@@ -419,8 +431,11 @@ mod tests {
         let home = TempDir::new().unwrap();
         let mut cfg = stub_config();
         cfg.embedder.kind = "stub".to_string();
-        let s = build_active_session(home.path(), &cfg).await.unwrap();
-        assert!(s.embedder.is_some());
+        // build_active_session returning Ok proves the stub embedder
+        // wired cleanly into the DM construction — DM doesn't expose
+        // its private embedder Arc, but the construction succeeding
+        // is the only outcome that matters for the wiring path.
+        let _ = build_active_session(home.path(), &cfg).await.unwrap();
     }
 
     #[tokio::test]
@@ -443,11 +458,12 @@ mod tests {
         // close_session_inner.
         let first_id = {
             let s = build_active_session(home.path(), &cfg).await.unwrap();
-            s.learner.lock().await.profile.id
+            let dm = s.dialogue_manager.lock().await;
+            dm.learner.profile.id
         };
 
         let s2 = build_active_session(home.path(), &cfg).await.unwrap();
-        let id2 = s2.learner.lock().await.profile.id;
+        let id2 = s2.dialogue_manager.lock().await.learner.profile.id;
         assert_eq!(id2, first_id, "learner UUID stable across reopens");
     }
 
@@ -463,16 +479,16 @@ mod tests {
         cfg.persistence.session_db = Some(session_db.clone());
 
         let s1 = build_active_session(home.path(), &cfg).await.unwrap();
-        let id1 = s1.learner.lock().await.profile.id;
+        let id1 = s1.dialogue_manager.lock().await.learner.profile.id;
 
         // Second open with a different CLI-level name.
         let mut cfg2 = cfg.clone();
         cfg2.learner.name = "Other".to_string();
         let s2 = build_active_session(home.path(), &cfg2).await.unwrap();
-        let learner2 = s2.learner.lock().await;
-        assert_eq!(learner2.profile.id, id1, "UUID stable across opens");
+        let dm2 = s2.dialogue_manager.lock().await;
+        assert_eq!(dm2.learner.profile.id, id1, "UUID stable across opens");
         assert_eq!(
-            learner2.profile.name, "Binti",
+            dm2.learner.profile.name, "Binti",
             "persisted name wins over GUI override"
         );
     }

--- a/src/crates/primer-gui/src/wiring.rs
+++ b/src/crates/primer-gui/src/wiring.rs
@@ -32,7 +32,7 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use crate::config::{ApiKeySource, GuiConfig};
-use crate::state::ActiveSession;
+use crate::state::{ActiveSession, SessionSnapshot};
 
 /// Construct everything `DialogueManager::new` would need from a single
 /// `GuiConfig`.
@@ -257,6 +257,15 @@ pub async fn build_active_session(
         vocab_settings,
         embedder,
     };
+    // Snapshot must be built BEFORE `learner` moves into `DialogueManager::new`.
+    let initial_snapshot = SessionSnapshot {
+        session_id: None,
+        learner_id: learner.profile.id,
+        learner_name: learner.profile.name.clone(),
+        learner_age: learner.profile.age,
+        concept_count: learner.concepts.len(),
+    };
+
     let dm = primer_pedagogy::DialogueManager::new(
         learner,
         Arc::clone(&backend),
@@ -268,6 +277,7 @@ pub async fn build_active_session(
 
     Ok(ActiveSession {
         dialogue_manager: Arc::new(Mutex::new(dm)),
+        snapshot: Arc::new(Mutex::new(initial_snapshot)),
         locale,
         backend_name: backend_config.kind.clone(),
         main_model,
@@ -431,11 +441,13 @@ mod tests {
         let home = TempDir::new().unwrap();
         let mut cfg = stub_config();
         cfg.embedder.kind = "stub".to_string();
-        // build_active_session returning Ok proves the stub embedder
-        // wired cleanly into the DM construction — DM doesn't expose
-        // its private embedder Arc, but the construction succeeding
-        // is the only outcome that matters for the wiring path.
-        let _ = build_active_session(home.path(), &cfg).await.unwrap();
+        let s = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm = s.dialogue_manager.lock().await;
+        assert_eq!(
+            dm.embedder_identifier(),
+            Some(primer_embedding::STUB_MODEL_ID),
+            "stub embedder must be wired into the DM"
+        );
     }
 
     #[tokio::test]

--- a/src/crates/primer-gui/tauri.conf.json
+++ b/src/crates/primer-gui/tauri.conf.json
@@ -7,6 +7,7 @@
     "frontendDist": "ui"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "label": "main",

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -125,6 +125,13 @@ async function onSubmit(e) {
   }
 }
 
+// Both listeners are wired once at startup and never torn down — the
+// app has no flow today that closes the session UI without exiting
+// the process. `listen` returns a Promise<UnlistenFn>; we discard the
+// handle deliberately. If a future step adds in-app session teardown
+// (e.g. settings-modal reload, picker-driven session switch), capture
+// the resolved unlisten fns here and call them on teardown to avoid
+// double-emission.
 function setupChunkListener() {
   listen("primer://chunk", (event) => {
     const payload = event.payload || {};

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -134,18 +134,15 @@ async function onSubmit(e) {
 // double-emission.
 function setupChunkListener() {
   listen("primer://chunk", (event) => {
-    const payload = event.payload || {};
-    const text = typeof payload === "string" ? payload : payload.text || "";
-    if (!state.streamingPrimerEl || !text) return;
-    state.streamingPrimerEl.textContent += text;
+    if (!state.streamingPrimerEl) return;
+    state.streamingPrimerEl.textContent += event.payload.text;
     scrollToBottom();
   });
 }
 
 function setupTurnCompleteListener() {
   listen("primer://turn_complete", (event) => {
-    const payload = event.payload || {};
-    state.sessionId = payload.session_id || state.sessionId;
+    state.sessionId = event.payload.session_id;
     finaliseStreamingBubble({ aborted: false });
     enableComposer();
   });

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -1,0 +1,222 @@
+// Vanilla-JS chat shell for the Primer GUI.
+//
+// Step 4 wires:
+//   • Auto-start a session on launch (uses persisted gui-config.json).
+//   • Render child + Primer bubbles in the scroll area.
+//   • Listen for `primer://chunk` events and append to the live bubble.
+//   • Finalise on `primer://turn_complete`.
+//
+// Tauri 2 exposes `invoke` / `listen` on `window.__TAURI__` because
+// `app.withGlobalTauri = true` is set in tauri.conf.json — no npm
+// toolchain needed.
+
+const { invoke } = window.__TAURI__.core;
+const { listen } = window.__TAURI__.event;
+
+const dom = {
+  sessionInfo: document.getElementById("session-info"),
+  chatScroll: document.getElementById("chat-scroll"),
+  emptyState: document.getElementById("empty-state"),
+  errorBanner: document.getElementById("error-banner"),
+  composer: document.getElementById("composer"),
+  input: document.getElementById("input"),
+  send: document.getElementById("send"),
+};
+
+// Live state — `streamingPrimerEl` points at the currently-streaming
+// Primer bubble (if any) so chunk events can append to its text node
+// without re-querying the DOM.
+const state = {
+  sessionId: null,
+  streamingPrimerEl: null,
+};
+
+main();
+
+async function main() {
+  setupChunkListener();
+  setupTurnCompleteListener();
+  setupComposer();
+  setupAutogrow();
+  await openOrStartSession();
+}
+
+async function openOrStartSession() {
+  try {
+    let info = await invoke("current_session_info");
+    if (info === null) {
+      info = await invoke("start_session");
+    }
+    renderSessionInfo(info);
+    enableComposer();
+  } catch (err) {
+    showError(formatErr(err));
+  }
+}
+
+function renderSessionInfo(info) {
+  state.sessionId = info.session_id; // may be null until first send
+  const { learner, backend_kind, main_model, locale } = info;
+  dom.sessionInfo.dataset.state = "ready";
+  dom.sessionInfo.innerHTML = `
+    <span class="pill" title="learner">
+      ${escapeHtml(learner.name)} · age ${learner.age}
+    </span>
+    <span class="pill" title="backend / model">
+      ${escapeHtml(backend_kind)}${
+        main_model && main_model !== backend_kind ? " · " + escapeHtml(main_model) : ""
+      }
+    </span>
+    <span class="pill" title="locale">${escapeHtml(locale)}</span>
+  `;
+}
+
+function enableComposer() {
+  dom.input.disabled = false;
+  dom.send.disabled = false;
+  dom.input.focus();
+}
+
+function disableComposer() {
+  dom.input.disabled = true;
+  dom.send.disabled = true;
+}
+
+function setupComposer() {
+  dom.composer.addEventListener("submit", onSubmit);
+  // Enter sends, Shift+Enter inserts a newline (standard chat affordance).
+  dom.input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      onSubmit(e);
+    }
+  });
+}
+
+function setupAutogrow() {
+  // Grow the textarea as the user types, capped by max-height in CSS.
+  dom.input.addEventListener("input", () => {
+    dom.input.style.height = "auto";
+    dom.input.style.height = `${dom.input.scrollHeight}px`;
+  });
+}
+
+async function onSubmit(e) {
+  e.preventDefault();
+  const text = dom.input.value.trim();
+  if (!text || dom.send.disabled) return;
+
+  hideError();
+  hideEmptyState();
+  appendChildBubble(text);
+  state.streamingPrimerEl = appendStreamingPrimerBubble();
+  dom.input.value = "";
+  dom.input.style.height = "auto";
+  disableComposer();
+
+  try {
+    await invoke("send_message", { input: text });
+    // The turn_complete event listener will finalise the bubble and
+    // re-enable the composer; nothing to do here on success.
+  } catch (err) {
+    finaliseStreamingBubble({ aborted: true });
+    showError(formatErr(err));
+    enableComposer();
+  }
+}
+
+function setupChunkListener() {
+  listen("primer://chunk", (event) => {
+    const payload = event.payload || {};
+    const text = typeof payload === "string" ? payload : payload.text || "";
+    if (!state.streamingPrimerEl || !text) return;
+    state.streamingPrimerEl.textContent += text;
+    scrollToBottom();
+  });
+}
+
+function setupTurnCompleteListener() {
+  listen("primer://turn_complete", (event) => {
+    const payload = event.payload || {};
+    state.sessionId = payload.session_id || state.sessionId;
+    finaliseStreamingBubble({ aborted: false });
+    enableComposer();
+  });
+}
+
+function appendChildBubble(text) {
+  const row = document.createElement("div");
+  row.className = "bubble-row is-child";
+  const bubble = document.createElement("div");
+  bubble.className = "bubble";
+  bubble.textContent = text;
+  row.appendChild(bubble);
+  dom.chatScroll.appendChild(row);
+  scrollToBottom();
+}
+
+function appendStreamingPrimerBubble() {
+  const row = document.createElement("div");
+  row.className = "bubble-row is-primer";
+  const bubble = document.createElement("div");
+  bubble.className = "bubble is-streaming";
+  bubble.textContent = "";
+  row.appendChild(bubble);
+  dom.chatScroll.appendChild(row);
+  scrollToBottom();
+  return bubble;
+}
+
+function finaliseStreamingBubble({ aborted }) {
+  const el = state.streamingPrimerEl;
+  if (!el) return;
+  el.classList.remove("is-streaming");
+  if (aborted && el.textContent.trim() === "") {
+    // Empty-aborted: drop the placeholder rather than leaving a blank
+    // Primer bubble. Matches DM's "partial Primer turn dropped on
+    // mid-stream error" semantic.
+    el.parentElement?.remove();
+  }
+  state.streamingPrimerEl = null;
+}
+
+function hideEmptyState() {
+  if (dom.emptyState && !dom.emptyState.hidden) {
+    dom.emptyState.hidden = true;
+  }
+}
+
+function scrollToBottom() {
+  dom.chatScroll.scrollTop = dom.chatScroll.scrollHeight;
+}
+
+function showError(msg) {
+  dom.errorBanner.textContent = msg;
+  dom.errorBanner.hidden = false;
+}
+
+function hideError() {
+  dom.errorBanner.hidden = true;
+  dom.errorBanner.textContent = "";
+}
+
+function formatErr(err) {
+  if (typeof err === "string") return err;
+  if (err && typeof err.message === "string") return err.message;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+// Minimal HTML escaper for header pill content. The bubble text path
+// uses textContent so it doesn't need escaping.
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -18,8 +18,12 @@
     </header>
 
     <main class="chat">
-      <div class="chat-scroll" id="chat-scroll" aria-live="polite">
-        <!-- Bubbles are injected here. The first turn lands once the user sends. -->
+      <div class="chat-scroll" id="chat-scroll">
+        <!-- Bubbles are injected here. The first turn lands once the user sends.
+             No `aria-live` on the container: streaming `textContent +=` mutates an
+             existing node, which most screen readers either ignore or fire on
+             every chunk — both unhelpful. Per-bubble live semantics (announce
+             once on stream completion) lands with the a11y pass after step 6. -->
         <div class="empty-state" id="empty-state">
           <h2>Ready when you are.</h2>
           <p>
@@ -44,6 +48,6 @@
       </form>
     </main>
 
-    <script src="app.js" type="module"></script>
+    <script src="app.js"></script>
   </body>
 </html>

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -4,65 +4,46 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Primer</title>
-    <style>
-      :root {
-        color-scheme: light dark;
-      }
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        font-family:
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-      }
-      body {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background:
-          radial-gradient(
-            circle at 30% 20%,
-            color-mix(in oklab, currentColor 6%, transparent),
-            transparent 60%
-          ),
-          radial-gradient(
-            circle at 70% 80%,
-            color-mix(in oklab, currentColor 4%, transparent),
-            transparent 60%
-          );
-        text-align: center;
-      }
-      h1 {
-        font-size: 1.6rem;
-        font-weight: 600;
-        margin: 0 0 0.4rem;
-        letter-spacing: -0.01em;
-      }
-      p {
-        margin: 0;
-        max-width: 28rem;
-        font-size: 0.95rem;
-        opacity: 0.7;
-        line-height: 1.5;
-      }
-      .stage {
-        font-size: 0.78rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        opacity: 0.45;
-        margin-top: 1.6rem;
-      }
-    </style>
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <h1>The Primer</h1>
-    <p>A Socratic learning companion. Settings, chat, and live evaluation arrive in the next steps.</p>
-    <div class="stage">Step 2 · scaffold</div>
+    <header class="app-header">
+      <div class="brand">
+        <span class="brand-mark">●</span>
+        <span class="brand-name">Primer</span>
+      </div>
+      <div class="session-info" id="session-info" data-state="loading">
+        <span class="muted">Starting session…</span>
+      </div>
+    </header>
+
+    <main class="chat">
+      <div class="chat-scroll" id="chat-scroll" aria-live="polite">
+        <!-- Bubbles are injected here. The first turn lands once the user sends. -->
+        <div class="empty-state" id="empty-state">
+          <h2>Ready when you are.</h2>
+          <p>
+            Type a question or share something you're curious about. The Primer
+            asks more than it answers — that's the point.
+          </p>
+        </div>
+      </div>
+
+      <div class="error-banner" id="error-banner" hidden></div>
+
+      <form class="composer" id="composer" autocomplete="off">
+        <textarea
+          id="input"
+          name="input"
+          placeholder="Ask the Primer something…"
+          rows="1"
+          aria-label="Your message"
+          disabled
+        ></textarea>
+        <button type="submit" id="send" disabled>Send</button>
+      </form>
+    </main>
+
+    <script src="app.js" type="module"></script>
   </body>
 </html>

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -1,0 +1,273 @@
+:root {
+  color-scheme: light dark;
+  --bg: #fafaf9;
+  --fg: #1c1917;
+  --fg-muted: #57534e;
+  --surface: #ffffff;
+  --border: #e7e5e4;
+  --accent: #4f46e5;
+  --bubble-child-bg: #4f46e5;
+  --bubble-child-fg: #ffffff;
+  --bubble-primer-bg: #f5f5f4;
+  --bubble-primer-fg: #1c1917;
+  --error-bg: #fee2e2;
+  --error-fg: #991b1b;
+  --error-border: #fecaca;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1c1917;
+    --fg: #fafaf9;
+    --fg-muted: #a8a29e;
+    --surface: #292524;
+    --border: #44403c;
+    --accent: #818cf8;
+    --bubble-child-bg: #4338ca;
+    --bubble-child-fg: #f5f5f4;
+    --bubble-primer-bg: #292524;
+    --bubble-primer-fg: #f5f5f4;
+    --error-bg: #3f1d1d;
+    --error-fg: #fecaca;
+    --error-border: #7f1d1d;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 14.5px;
+  line-height: 1.55;
+}
+
+body {
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+/* ─── Header ─────────────────────────────────────────────────────── */
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 1.2rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  -webkit-app-region: drag; /* macOS title-bar drag */
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.brand-mark {
+  color: var(--accent);
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.brand-name {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.session-info {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+}
+
+.session-info .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.18rem 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg);
+  font-variant-numeric: tabular-nums;
+}
+
+.muted {
+  color: var(--fg-muted);
+}
+
+/* ─── Chat ───────────────────────────────────────────────────────── */
+
+.chat {
+  display: grid;
+  grid-template-rows: 1fr auto auto;
+  overflow: hidden;
+}
+
+.chat-scroll {
+  overflow-y: auto;
+  padding: 1.2rem 1.5rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  scroll-behavior: smooth;
+}
+
+.empty-state {
+  margin: auto;
+  max-width: 32rem;
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--fg-muted);
+}
+
+.empty-state h2 {
+  font-size: 1.4rem;
+  margin: 0 0 0.6rem;
+  color: var(--fg);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.empty-state p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+/* Bubble container — handles left/right alignment via the modifier. */
+.bubble-row {
+  display: flex;
+  width: 100%;
+}
+
+.bubble-row.is-child {
+  justify-content: flex-end;
+}
+
+.bubble-row.is-primer {
+  justify-content: flex-start;
+}
+
+.bubble {
+  max-width: 78%;
+  padding: 0.6rem 0.85rem;
+  border-radius: 1rem;
+  box-shadow: var(--shadow-sm);
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  font-size: 0.95rem;
+}
+
+.bubble-row.is-child .bubble {
+  background: var(--bubble-child-bg);
+  color: var(--bubble-child-fg);
+  border-bottom-right-radius: 0.35rem;
+}
+
+.bubble-row.is-primer .bubble {
+  background: var(--bubble-primer-bg);
+  color: var(--bubble-primer-fg);
+  border-bottom-left-radius: 0.35rem;
+}
+
+/* Caret shown while the Primer is still streaming. */
+.bubble.is-streaming::after {
+  content: "▍";
+  display: inline-block;
+  margin-left: 0.15rem;
+  animation: caret-blink 1s steps(2) infinite;
+  color: var(--accent);
+}
+
+@keyframes caret-blink {
+  to {
+    opacity: 0;
+  }
+}
+
+/* ─── Error banner ──────────────────────────────────────────────── */
+
+.error-banner {
+  margin: 0 1.5rem 0.4rem;
+  padding: 0.55rem 0.8rem;
+  background: var(--error-bg);
+  color: var(--error-fg);
+  border: 1px solid var(--error-border);
+  border-radius: 0.5rem;
+  font-size: 0.85rem;
+}
+
+/* ─── Composer ──────────────────────────────────────────────────── */
+
+.composer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  padding: 0.8rem 1.5rem 1.1rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+
+#input {
+  resize: none;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 0.6rem;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  min-height: 2.4rem;
+  max-height: 8rem;
+  outline: none;
+  transition: border-color 120ms ease;
+}
+
+#input:focus {
+  border-color: var(--accent);
+}
+
+#input:disabled {
+  opacity: 0.6;
+}
+
+#send {
+  align-self: end;
+  height: 2.4rem;
+  padding: 0 1.1rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: var(--accent);
+  color: white;
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: filter 120ms ease;
+}
+
+#send:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+#send:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}

--- a/src/crates/primer-pedagogy/src/dialogue_manager/background.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/background.rs
@@ -25,7 +25,7 @@ use super::{
     apply_comprehension, apply_extraction, merge_concepts_into_turn,
 };
 
-impl<'a> DialogueManager<'a> {
+impl DialogueManager {
     /// Drain only the classifier task and apply its outcome.
     ///
     /// Production paths use `await_pending_background` (which drains both

--- a/src/crates/primer-pedagogy/src/dialogue_manager/learner_update.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/learner_update.rs
@@ -15,7 +15,7 @@ use primer_core::learner::EngagementState;
 
 use super::DialogueManager;
 
-impl<'a> DialogueManager<'a> {
+impl DialogueManager {
     /// Update the learner model based on the conversation evidence.
     ///
     /// This is deliberately minimal for the scaffold. A production version

--- a/src/crates/primer-pedagogy/src/dialogue_manager/lifecycle.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/lifecycle.rs
@@ -10,6 +10,8 @@
 //! Break-suggestion timing decisions live in `decide_intent_at_with_pack`
 //! — see `primer_core::session_timing` for the pure helper.
 
+use std::sync::Arc;
+
 use chrono::Utc;
 
 use primer_core::config::PedagogyConfig;
@@ -22,7 +24,7 @@ use primer_core::learner::LearnerModel;
 use super::{DialogueManager, DialogueManagerStores, DialogueManagerSubsystems};
 use crate::prompt_pack;
 
-impl<'a> DialogueManager<'a> {
+impl DialogueManager {
     /// Create a new dialogue manager for a session.
     ///
     /// `stores` bundles the optional `SessionStore` and `LearnerStore`;
@@ -32,8 +34,8 @@ impl<'a> DialogueManager<'a> {
     /// without lifetime constraints — `tokio::spawn` requires `'static`.
     pub fn new(
         learner: LearnerModel,
-        inference: &'a dyn InferenceBackend,
-        knowledge: &'a dyn KnowledgeBase,
+        inference: Arc<dyn InferenceBackend>,
+        knowledge: Arc<dyn KnowledgeBase>,
         stores: DialogueManagerStores,
         subsystems: DialogueManagerSubsystems,
         config: PedagogyConfig,

--- a/src/crates/primer-pedagogy/src/dialogue_manager/lifecycle.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/lifecycle.rs
@@ -209,6 +209,14 @@ impl DialogueManager {
         self.comprehension.identifier()
     }
 
+    /// Stable identifier of the active embedder, or `None` when
+    /// hybrid retrieval is disabled (`--embedder-backend none`).
+    /// `Embedder` inherits `Named`, so `name()` is reachable via the
+    /// trait object without an explicit `use`.
+    pub fn embedder_identifier(&self) -> Option<&str> {
+        self.embedder.as_deref().map(|e| e.name())
+    }
+
     /// End the session gracefully. Drains any in-flight classifier task so
     /// the final turn's assessment lands on disk, records `ended_at`, and
     /// (if storage is configured) fires a final save so the timestamp

--- a/src/crates/primer-pedagogy/src/dialogue_manager/mod.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/mod.rs
@@ -97,19 +97,23 @@ pub struct DialogueManagerSubsystems {
 /// session and learner model state. The CLI (or future GUI) drives
 /// the conversation by calling `respond_to()` in a loop.
 ///
-/// `inference` and `knowledge` are borrowed references: they are used
-/// only synchronously inside method bodies. `storage`, `learner_store`,
-/// and `classifier` are `Arc<dyn …>` so they can be captured by the
-/// post-response classifier task (`tokio::spawn` requires `'static`).
-pub struct DialogueManager<'a> {
+/// All trait-object collaborators are `Arc<dyn …>` so the manager has
+/// no lifetime parameter and can be stored long-lived behind an
+/// `Arc<Mutex<…>>` (or any other `'static` container) — required by
+/// the GUI's Tauri `State<T>` and helpful for any future host that
+/// keeps a DM alive across an event loop. The Arcs are cheap to clone
+/// and let the spawned classifier / extractor / comprehension tasks
+/// capture their collaborators across turn boundaries (`tokio::spawn`
+/// requires `'static`).
+pub struct DialogueManager {
     /// The learner model — updated in place as we learn about the child.
     pub learner: LearnerModel,
     /// The current conversation session.
     pub session: Session,
     /// Inference backend (local model or cloud API).
-    inference: &'a dyn InferenceBackend,
+    inference: Arc<dyn InferenceBackend>,
     /// Knowledge base for RAG retrieval.
-    knowledge: &'a dyn KnowledgeBase,
+    knowledge: Arc<dyn KnowledgeBase>,
     /// Optional session persistence. When set, the session is saved after
     /// every `respond_to_streaming` call (success or mid-stream error).
     /// Arc so the classifier task can capture it across turn boundaries.
@@ -230,7 +234,7 @@ type PostResponseOutcome = Option<
     >,
 >;
 
-impl<'a> DialogueManager<'a> {
+impl DialogueManager {
     /// Returns the current wallclock for break-gate decisions. Tests
     /// can override via `clock_override`; production always reads
     /// `chrono::Utc::now()`.

--- a/src/crates/primer-pedagogy/src/dialogue_manager/retrieval.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/retrieval.rs
@@ -38,7 +38,7 @@ fn ltm_hybrid_params() -> HybridParams {
     }
 }
 
-impl<'a> DialogueManager<'a> {
+impl DialogueManager {
     /// Retrieve knowledge passages relevant to the child's input.
     /// Falls back gracefully if the knowledge base is empty or errors.
     ///

--- a/src/crates/primer-pedagogy/src/dialogue_manager/summary.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/summary.rs
@@ -16,7 +16,7 @@
 
 use super::DialogueManager;
 
-impl<'a> DialogueManager<'a> {
+impl DialogueManager {
     /// Active-conversation cadence. Refresh the rolling summary when at
     /// least `context_window_turns` turns have fallen out of the window
     /// since `summary_through_turn_index` was last set, so per-turn

--- a/src/crates/primer-pedagogy/src/dialogue_manager/tests/background_tests.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/tests/background_tests.rs
@@ -8,8 +8,6 @@ use async_trait::async_trait;
 use chrono::Utc;
 use primer_core::config::PedagogyConfig;
 use primer_core::error::{PrimerError, Result};
-use primer_core::inference::InferenceBackend;
-use primer_core::knowledge::KnowledgeBase;
 use primer_core::learner::EngagementState;
 use primer_extractor::ExtractorSettings;
 
@@ -41,17 +39,17 @@ async fn respond_to_streaming_spawns_classify_task_and_persists() {
         .unwrap(),
     );
 
-    let backend = ScriptedBackend::new(vec![
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
         Ok(chunk("Great question!", false)),
         Ok(chunk("", true)),
-    ]);
-    let knowledge = EmptyKnowledge;
+    ]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let settings = ClassifierSettings::default();
 
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&storage) as Arc<dyn SessionStore>),
             learner: None,
@@ -121,8 +119,8 @@ async fn await_pending_classification_aborts_and_preserves_state_on_timeout() {
         }
     }
 
-    let backend = ScriptedBackend::new(vec![Ok(chunk("hi", false)), Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("hi", false)), Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     // Tight timeout so the await reliably trips it before the 5s sleep.
     let settings = ClassifierSettings {
         blocking_timeout: Duration::from_millis(50),
@@ -131,8 +129,8 @@ async fn await_pending_classification_aborts_and_preserves_state_on_timeout() {
 
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         DialogueManagerSubsystems {
             classifier: Arc::new(SlowClassifier),
@@ -229,8 +227,8 @@ async fn end_to_end_classifier_routing_across_multi_turn_session() {
         .unwrap(),
     );
 
-    let backend = RepeatingBackend;
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(RepeatingBackend);
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
 
     // Generous blocking timeout for deterministic test behaviour.
     let settings = ClassifierSettings {
@@ -245,8 +243,8 @@ async fn end_to_end_classifier_routing_across_multi_turn_session() {
 
     let mut dm = DialogueManager::new(
         learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&storage) as Arc<dyn SessionStore>),
             learner: None,
@@ -368,13 +366,13 @@ async fn end_to_end_save_learner_after_open_and_one_turn() {
     let learner = test_learner();
     store.save_learner(&learner).await.unwrap();
 
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hello!", false)), Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hello!", false)), Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
 
     let mut dm = DialogueManager::new(
         learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&store) as Arc<dyn SessionStore>),
             learner: Some(Arc::clone(&store) as Arc<dyn LearnerStore>),
@@ -438,12 +436,12 @@ async fn divergence_bug_closed_via_cli_startup_flow() {
     store.save_learner(&adopted_learner).await.unwrap();
 
     // Construct a DialogueManager with the adopted learner.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         adopted_learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&store) as Arc<dyn SessionStore>),
             learner: Some(Arc::clone(&store) as Arc<dyn LearnerStore>),
@@ -468,7 +466,7 @@ async fn divergence_bug_closed_via_cli_startup_flow() {
 
 #[tokio::test]
 async fn extract_task_persists_concepts_for_both_turns_after_response() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hi there!", true))]);
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi there!", true))]));
     let extractor = Arc::new(primer_extractor::StubConceptExtractor::with_response(
         ConceptExtraction {
             child_concepts: vec!["topic-a".into()],
@@ -484,8 +482,8 @@ async fn extract_task_persists_concepts_for_both_turns_after_response() {
 
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend as &dyn InferenceBackend,
-        &EmptyKnowledge as &dyn KnowledgeBase,
+        backend.clone(),
+        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems_with_extractor(extractor as Arc<dyn ConceptExtractor>),
         PedagogyConfig::default(),
@@ -512,7 +510,7 @@ async fn extract_task_persists_concepts_for_both_turns_after_response() {
 
 #[tokio::test]
 async fn extract_task_does_not_spawn_on_inference_error() {
-    let backend = ScriptedBackend::new(vec![Err(PrimerError::Inference("boom".into()))]);
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Err(PrimerError::Inference("boom".into()))]));
     let extractor = Arc::new(primer_extractor::StubConceptExtractor::with_response(
         ConceptExtraction {
             child_concepts: vec!["should-not-persist".into()],
@@ -528,8 +526,8 @@ async fn extract_task_does_not_spawn_on_inference_error() {
 
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend as &dyn InferenceBackend,
-        &EmptyKnowledge as &dyn KnowledgeBase,
+        backend.clone(),
+        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems_with_extractor(extractor as Arc<dyn ConceptExtractor>),
         PedagogyConfig::default(),
@@ -547,7 +545,7 @@ async fn extract_task_does_not_spawn_on_inference_error() {
 
 #[tokio::test]
 async fn pending_extraction_applied_to_learner_at_next_turn() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hi turn 1!", true))]);
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi turn 1!", true))]));
     // Two turns of extraction scripted: turn 1 surfaces "gravity" + "physics",
     // turn 2 surfaces "mass". Only the first one matters for this test —
     // we want to assert that after respond_to(turn 2), the learner has
@@ -565,8 +563,8 @@ async fn pending_extraction_applied_to_learner_at_next_turn() {
 
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend as &dyn InferenceBackend,
-        &EmptyKnowledge as &dyn KnowledgeBase,
+        backend.clone(),
+        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         DialogueManagerStores::default(),
         subsystems_with_extractor(extractor as Arc<dyn ConceptExtractor>),
         PedagogyConfig::default(),
@@ -607,7 +605,7 @@ async fn post_response_chain_persists_extraction_and_comprehension() {
     use primer_core::extractor::ConceptExtraction;
     use primer_core::learner::UnderstandingDepth;
 
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hi there!", true))]);
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi there!", true))]));
     let extractor = Arc::new(primer_extractor::StubConceptExtractor::with_response(
         ConceptExtraction {
             child_concepts: vec!["gravity".into()],
@@ -646,8 +644,8 @@ async fn post_response_chain_persists_extraction_and_comprehension() {
 
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend as &dyn InferenceBackend,
-        &EmptyKnowledge as &dyn KnowledgeBase,
+        backend.clone(),
+        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems,
         PedagogyConfig::default(),
@@ -721,7 +719,7 @@ async fn post_response_chain_skips_comprehension_on_empty_extraction() {
         }
     }
 
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hi there!", true))]);
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi there!", true))]));
     let extractor =
         Arc::new(primer_extractor::StubConceptExtractor::new()) as Arc<dyn ConceptExtractor>;
     let comprehension =
@@ -746,8 +744,8 @@ async fn post_response_chain_skips_comprehension_on_empty_extraction() {
 
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend as &dyn InferenceBackend,
-        &EmptyKnowledge as &dyn KnowledgeBase,
+        backend.clone(),
+        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems,
         PedagogyConfig::default(),

--- a/src/crates/primer-pedagogy/src/dialogue_manager/tests/background_tests.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/tests/background_tests.rs
@@ -119,7 +119,10 @@ async fn await_pending_classification_aborts_and_preserves_state_on_timeout() {
         }
     }
 
-    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("hi", false)), Ok(chunk("", true))]));
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
+        Ok(chunk("hi", false)),
+        Ok(chunk("", true)),
+    ]));
     let knowledge = std::sync::Arc::new(EmptyKnowledge);
     // Tight timeout so the await reliably trips it before the 5s sleep.
     let settings = ClassifierSettings {
@@ -366,7 +369,10 @@ async fn end_to_end_save_learner_after_open_and_one_turn() {
     let learner = test_learner();
     store.save_learner(&learner).await.unwrap();
 
-    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hello!", false)), Ok(chunk("", true))]));
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
+        Ok(chunk("Hello!", false)),
+        Ok(chunk("", true)),
+    ]));
     let knowledge = std::sync::Arc::new(EmptyKnowledge);
 
     let mut dm = DialogueManager::new(
@@ -483,7 +489,8 @@ async fn extract_task_persists_concepts_for_both_turns_after_response() {
     let mut dm = DialogueManager::new(
         test_learner(),
         backend.clone(),
-        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
+        std::sync::Arc::new(EmptyKnowledge)
+            as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems_with_extractor(extractor as Arc<dyn ConceptExtractor>),
         PedagogyConfig::default(),
@@ -510,7 +517,9 @@ async fn extract_task_persists_concepts_for_both_turns_after_response() {
 
 #[tokio::test]
 async fn extract_task_does_not_spawn_on_inference_error() {
-    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Err(PrimerError::Inference("boom".into()))]));
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Err(PrimerError::Inference(
+        "boom".into(),
+    ))]));
     let extractor = Arc::new(primer_extractor::StubConceptExtractor::with_response(
         ConceptExtraction {
             child_concepts: vec!["should-not-persist".into()],
@@ -527,7 +536,8 @@ async fn extract_task_does_not_spawn_on_inference_error() {
     let mut dm = DialogueManager::new(
         test_learner(),
         backend.clone(),
-        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
+        std::sync::Arc::new(EmptyKnowledge)
+            as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems_with_extractor(extractor as Arc<dyn ConceptExtractor>),
         PedagogyConfig::default(),
@@ -564,7 +574,8 @@ async fn pending_extraction_applied_to_learner_at_next_turn() {
     let mut dm = DialogueManager::new(
         test_learner(),
         backend.clone(),
-        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
+        std::sync::Arc::new(EmptyKnowledge)
+            as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         DialogueManagerStores::default(),
         subsystems_with_extractor(extractor as Arc<dyn ConceptExtractor>),
         PedagogyConfig::default(),
@@ -645,7 +656,8 @@ async fn post_response_chain_persists_extraction_and_comprehension() {
     let mut dm = DialogueManager::new(
         test_learner(),
         backend.clone(),
-        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
+        std::sync::Arc::new(EmptyKnowledge)
+            as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems,
         PedagogyConfig::default(),
@@ -745,7 +757,8 @@ async fn post_response_chain_skips_comprehension_on_empty_extraction() {
     let mut dm = DialogueManager::new(
         test_learner(),
         backend.clone(),
-        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
+        std::sync::Arc::new(EmptyKnowledge)
+            as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems,
         PedagogyConfig::default(),

--- a/src/crates/primer-pedagogy/src/dialogue_manager/tests/lifecycle_tests.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/tests/lifecycle_tests.rs
@@ -15,7 +15,10 @@ use super::super::*;
 
 #[tokio::test]
 async fn close_session_fires_engine_save_with_ended_at() {
-    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi", false)), Ok(chunk("", true))]));
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
+        Ok(chunk("Hi", false)),
+        Ok(chunk("", true)),
+    ]));
     let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let store = Arc::new(CountingStore::new());
     let mut dm = DialogueManager::new(
@@ -391,7 +394,8 @@ async fn close_session_drains_extractor_task() {
     let mut dm = DialogueManager::new(
         test_learner(),
         backend.clone(),
-        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
+        std::sync::Arc::new(EmptyKnowledge)
+            as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems_with_extractor(extractor as Arc<dyn ConceptExtractor>),
         PedagogyConfig::default(),

--- a/src/crates/primer-pedagogy/src/dialogue_manager/tests/lifecycle_tests.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/tests/lifecycle_tests.rs
@@ -6,8 +6,6 @@ use std::sync::Arc;
 use chrono::Utc;
 use primer_core::config::PedagogyConfig;
 use primer_core::conversation::{Speaker, Turn};
-use primer_core::inference::InferenceBackend;
-use primer_core::knowledge::KnowledgeBase;
 use primer_core::learner::EngagementState;
 use primer_extractor::ExtractorSettings;
 use uuid::Uuid;
@@ -17,13 +15,13 @@ use super::super::*;
 
 #[tokio::test]
 async fn close_session_fires_engine_save_with_ended_at() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hi", false)), Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi", false)), Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let store = Arc::new(CountingStore::new());
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&store) as Arc<dyn SessionStore>),
             learner: None,
@@ -45,13 +43,13 @@ async fn close_session_fires_engine_save_with_ended_at() {
 
 #[tokio::test]
 async fn open_session_fires_engine_save() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let store = Arc::new(CountingStore::new());
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&store) as Arc<dyn SessionStore>),
             learner: None,
@@ -74,12 +72,12 @@ async fn resume_session_loads_turns_without_greeting() {
     // Resume picks up the loaded turns verbatim. No greeting is
     // prepended; the turn count after resume_session matches the
     // loaded session exactly.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -96,13 +94,13 @@ async fn resume_session_loads_turns_without_greeting() {
 
 #[tokio::test]
 async fn resume_session_clears_ended_at_and_persists() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let store = Arc::new(CountingStore::new());
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&store) as Arc<dyn SessionStore>),
             learner: None,
@@ -122,12 +120,12 @@ async fn resume_session_preserves_loaded_learner_id() {
     // The in-memory LearnerModel comes from CLI flags; the loaded
     // Session might belong to a different learner_id. Resume must
     // keep the loaded learner_id (no silent override).
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -148,12 +146,12 @@ async fn resume_session_triggers_summary_refresh_when_above_window() {
     // A loaded session with > context_window_turns should get its
     // summary refreshed unconditionally on resume so the Primer has
     // long-term memory of pre-window turns from turn one.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -180,12 +178,12 @@ async fn resume_session_triggers_summary_refresh_when_above_window() {
 async fn resume_session_skips_summary_when_inside_first_window() {
     // Sessions that fit inside the active window have nothing to
     // summarize; resume must not waste an inference call.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -203,12 +201,12 @@ async fn resume_session_skips_refresh_when_summary_already_current() {
     // turns[..5] — exactly the pre-window range. There is no new
     // pre-window content for the summary to absorb, so resume must
     // not burn an LLM call regenerating identical work.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -234,12 +232,12 @@ async fn resume_session_refreshes_when_existing_summary_is_stale() {
     // turns[..3]. The current pre-window range is turns[..10], so
     // there are 7 pre-window turns the summary doesn't yet know
     // about. Resume must refresh.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -293,13 +291,13 @@ async fn resume_session_rehydrates_recent_assessments() {
         .unwrap();
 
     // Create a DialogueManager and resume the persisted session.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let settings = ClassifierSettings::default();
     let mut dm = DialogueManager::new(
         learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&storage) as Arc<dyn SessionStore>),
             learner: None,
@@ -347,13 +345,13 @@ async fn close_session_always_saves_learner_regardless_of_dirty() {
     // Lifecycle events flush unconditionally — they're explicit
     // checkpoints, not "save when dirty" sites.
     let (learner, store) = dirty_flag_test_setup(EngagementState::Engaged);
-    let backend = RepeatingBackend;
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(RepeatingBackend);
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
 
     let mut dm = DialogueManager::new(
         learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: None,
             learner: Some(Arc::clone(&store) as Arc<dyn LearnerStore>),
@@ -376,7 +374,7 @@ async fn close_session_always_saves_learner_regardless_of_dirty() {
 /// records `save_comprehensions` calls so chain tests can assert
 #[tokio::test]
 async fn close_session_drains_extractor_task() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hi", true))]);
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi", true))]));
     let extractor = Arc::new(primer_extractor::StubConceptExtractor::with_response(
         ConceptExtraction {
             child_concepts: vec!["x".into()],
@@ -392,8 +390,8 @@ async fn close_session_drains_extractor_task() {
 
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend as &dyn InferenceBackend,
-        &EmptyKnowledge as &dyn KnowledgeBase,
+        backend.clone(),
+        std::sync::Arc::new(EmptyKnowledge) as std::sync::Arc<dyn primer_core::knowledge::KnowledgeBase>,
         stores,
         subsystems_with_extractor(extractor as Arc<dyn ConceptExtractor>),
         PedagogyConfig::default(),
@@ -417,12 +415,12 @@ async fn close_session_drains_extractor_task() {
 
 #[tokio::test]
 async fn new_initialises_last_break_suggested_at_to_none() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         primer_core::config::PedagogyConfig::default(),
@@ -432,12 +430,12 @@ async fn new_initialises_last_break_suggested_at_to_none() {
 
 #[tokio::test]
 async fn resume_session_clears_last_break_suggested_at() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         primer_core::config::PedagogyConfig::default(),

--- a/src/crates/primer-pedagogy/src/dialogue_manager/tests/turn_tests.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/tests/turn_tests.rs
@@ -195,7 +195,10 @@ async fn respond_to_thin_wrapper_still_works() {
 
 #[tokio::test]
 async fn respond_to_streaming_fires_engine_save_on_success() {
-    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi", false)), Ok(chunk("", true))]));
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
+        Ok(chunk("Hi", false)),
+        Ok(chunk("", true)),
+    ]));
     let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let store = Arc::new(CountingStore::new());
     let mut dm = DialogueManager::new(
@@ -252,7 +255,10 @@ async fn respond_to_streaming_fires_engine_save_on_stream_error() {
 async fn summary_does_not_refresh_when_below_threshold_during_active_session() {
     // First respond_to_streaming fires only when there are turns to
     // process. With turn count below window+window, no refresh.
-    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("ok", false)), Ok(chunk("", true))]));
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
+        Ok(chunk("ok", false)),
+        Ok(chunk("", true)),
+    ]));
     let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
@@ -575,7 +581,10 @@ async fn build_turn_prompt_omits_vocab_section_when_no_concept_is_due() {
 
 #[tokio::test]
 async fn respond_after_threshold_yields_suggest_break_intent() {
-    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hello", false)), Ok(chunk("", true))]));
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
+        Ok(chunk("Hello", false)),
+        Ok(chunk("", true)),
+    ]));
     let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),

--- a/src/crates/primer-pedagogy/src/dialogue_manager/tests/turn_tests.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/tests/turn_tests.rs
@@ -15,17 +15,17 @@ use super::super::*;
 
 #[tokio::test]
 async fn respond_to_streaming_invokes_callback_per_chunk() {
-    let backend = ScriptedBackend::new(vec![
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
         Ok(chunk("Hel", false)),
         Ok(chunk("lo", false)),
         Ok(chunk(" there", false)),
         Ok(chunk("", true)),
-    ]);
-    let knowledge = EmptyKnowledge;
+    ]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -45,17 +45,17 @@ async fn respond_to_streaming_invokes_callback_per_chunk() {
 
 #[tokio::test]
 async fn respond_to_streaming_returns_full_accumulated_text() {
-    let backend = ScriptedBackend::new(vec![
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
         Ok(chunk("Hel", false)),
         Ok(chunk("lo", false)),
         Ok(chunk(" there", false)),
         Ok(chunk("", true)),
-    ]);
-    let knowledge = EmptyKnowledge;
+    ]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -67,16 +67,16 @@ async fn respond_to_streaming_returns_full_accumulated_text() {
 
 #[tokio::test]
 async fn respond_to_streaming_records_full_primer_turn() {
-    let backend = ScriptedBackend::new(vec![
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
         Ok(chunk("part one ", false)),
         Ok(chunk("part two", false)),
         Ok(chunk("", true)),
-    ]);
-    let knowledge = EmptyKnowledge;
+    ]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -90,15 +90,15 @@ async fn respond_to_streaming_records_full_primer_turn() {
 
 #[tokio::test]
 async fn respond_to_streaming_does_not_record_primer_turn_on_stream_error() {
-    let backend = ScriptedBackend::new(vec![
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
         Ok(chunk("partial", false)),
         Err(PrimerError::Inference("simulated network drop".into())),
-    ]);
-    let knowledge = EmptyKnowledge;
+    ]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -124,14 +124,14 @@ async fn respond_to_streaming_preserves_typed_inference_error_variant() {
     //
     // This test asserts that a typed Auth variant from the backend
     // survives the dialogue_manager round-trip with its variant intact.
-    let backend = ScriptedBackend::new(vec![Err(PrimerError::Inference(
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Err(PrimerError::Inference(
         primer_core::error::InferenceError::Auth,
-    ))]);
-    let knowledge = EmptyKnowledge;
+    ))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -154,12 +154,12 @@ async fn respond_to_streaming_returns_empty_string_when_stream_yields_no_text() 
     // should succeed with an empty accumulated string and still record
     // the (empty) Primer turn — the consumer is responsible for noticing
     // and surfacing this as a user-facing problem if they care.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -174,16 +174,16 @@ async fn respond_to_streaming_returns_empty_string_when_stream_yields_no_text() 
 
 #[tokio::test]
 async fn respond_to_thin_wrapper_still_works() {
-    let backend = ScriptedBackend::new(vec![
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
         Ok(chunk("alpha ", false)),
         Ok(chunk("beta", false)),
         Ok(chunk("", true)),
-    ]);
-    let knowledge = EmptyKnowledge;
+    ]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -195,13 +195,13 @@ async fn respond_to_thin_wrapper_still_works() {
 
 #[tokio::test]
 async fn respond_to_streaming_fires_engine_save_on_success() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hi", false)), Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hi", false)), Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let store = Arc::new(CountingStore::new());
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&store) as Arc<dyn SessionStore>),
             learner: None,
@@ -220,16 +220,16 @@ async fn respond_to_streaming_fires_engine_save_on_success() {
 
 #[tokio::test]
 async fn respond_to_streaming_fires_engine_save_on_stream_error() {
-    let backend = ScriptedBackend::new(vec![
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![
         Ok(chunk("partial", false)),
         Err(PrimerError::Inference("simulated drop".into())),
-    ]);
-    let knowledge = EmptyKnowledge;
+    ]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let store = Arc::new(CountingStore::new());
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: Some(Arc::clone(&store) as Arc<dyn SessionStore>),
             learner: None,
@@ -252,12 +252,12 @@ async fn respond_to_streaming_fires_engine_save_on_stream_error() {
 async fn summary_does_not_refresh_when_below_threshold_during_active_session() {
     // First respond_to_streaming fires only when there are turns to
     // process. With turn count below window+window, no refresh.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("ok", false)), Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("ok", false)), Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -279,13 +279,13 @@ async fn per_turn_save_skipped_when_no_persisted_field_changes() {
     // a stub returning no assessments. The only save_learner call is
     // the one open_session emits.
     let (learner, store) = dirty_flag_test_setup(EngagementState::Reflecting);
-    let backend = RepeatingBackend;
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(RepeatingBackend);
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
 
     let mut dm = DialogueManager::new(
         learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: None,
             learner: Some(Arc::clone(&store) as Arc<dyn LearnerStore>),
@@ -315,13 +315,13 @@ async fn per_turn_save_fires_when_engagement_changes() {
     // Engaged in update_learner_model, which IS a change to a
     // persisted field. dirty=true → per-turn save fires.
     let (learner, store) = dirty_flag_test_setup(EngagementState::Reflecting);
-    let backend = RepeatingBackend;
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(RepeatingBackend);
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
 
     let mut dm = DialogueManager::new(
         learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: None,
             learner: Some(Arc::clone(&store) as Arc<dyn LearnerStore>),
@@ -350,13 +350,13 @@ async fn dirty_cleared_after_save_so_subsequent_idle_turn_skips_save() {
     // After the dirty turn, the flag should be cleared; the idle
     // turn must not produce a second per-turn save.
     let (learner, store) = dirty_flag_test_setup(EngagementState::Reflecting);
-    let backend = RepeatingBackend;
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(RepeatingBackend);
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
 
     let mut dm = DialogueManager::new(
         learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: None,
             learner: Some(Arc::clone(&store) as Arc<dyn LearnerStore>),
@@ -430,13 +430,13 @@ async fn save_learner_failure_does_not_propagate_through_respond_to() {
     let mut learner = test_learner();
     learner.current_engagement = EngagementState::Reflecting;
     let failing = Arc::new(FailingLearnerStore::new());
-    let backend = RepeatingBackend;
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(RepeatingBackend);
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
 
     let mut dm = DialogueManager::new(
         learner,
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores {
             session: None,
             learner: Some(Arc::clone(&failing) as Arc<dyn LearnerStore>),
@@ -488,12 +488,12 @@ async fn build_turn_prompt_includes_vocab_section_when_concept_is_overdue() {
     // Scripted backend isn't even called by build_turn_prompt — we drive
     // the prompt-build path directly. EmptyKnowledge keeps the knowledge
     // section empty so the assertion lands cleanly.
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -538,12 +538,12 @@ async fn build_turn_prompt_omits_vocab_section_when_no_concept_is_due() {
     use primer_core::conversation::PedagogicalIntent;
     use primer_core::learner::{ConceptState, UnderstandingDepth};
 
-    let backend = ScriptedBackend::new(vec![Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         PedagogyConfig::default(),
@@ -575,12 +575,12 @@ async fn build_turn_prompt_omits_vocab_section_when_no_concept_is_due() {
 
 #[tokio::test]
 async fn respond_after_threshold_yields_suggest_break_intent() {
-    let backend = ScriptedBackend::new(vec![Ok(chunk("Hello", false)), Ok(chunk("", true))]);
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(ScriptedBackend::new(vec![Ok(chunk("Hello", false)), Ok(chunk("", true))]));
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         primer_core::config::PedagogyConfig::default(),
@@ -608,12 +608,12 @@ async fn respond_after_threshold_yields_suggest_break_intent() {
 async fn cadence_resets_after_suggest_break_fires() {
     // Use RepeatingBackend so the same backend can handle both turns
     // (ScriptedBackend can only emit its script once).
-    let backend = RepeatingBackend;
-    let knowledge = EmptyKnowledge;
+    let backend = std::sync::Arc::new(RepeatingBackend);
+    let knowledge = std::sync::Arc::new(EmptyKnowledge);
     let mut dm = DialogueManager::new(
         test_learner(),
-        &backend,
-        &knowledge,
+        backend.clone(),
+        knowledge.clone(),
         DialogueManagerStores::default(),
         default_subsystems(),
         primer_core::config::PedagogyConfig::default(),

--- a/src/crates/primer-pedagogy/src/dialogue_manager/turn.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/turn.rs
@@ -36,7 +36,7 @@ use primer_core::inference::{GenerationParams, Prompt};
 use super::{DialogueManager, ExtractionPart, PostResponseResult};
 use crate::prompt_builder;
 
-impl<'a> DialogueManager<'a> {
+impl DialogueManager {
     /// Process the child's input and generate the Primer's response.
     /// Convenience wrapper around `respond_to_streaming` that discards
     /// per-chunk callbacks. See that method for the full contract.


### PR DESCRIPTION
## Summary

Step 4 of 10. Wires the first interactive surface — a child types a message and the Primer streams a response token-by-token into a chat bubble. Session state persists across turns through the existing `SqliteSessionStore`.

### Backend
- **`send_message` Tauri command** (`commands/session.rs`) — builds a fresh `DialogueManager` per turn from the active session's Arcs (lazy-DM pattern from the plan). First turn: `DM::new` mints a `Session`; `respond_to_streaming` adds child + Primer turns. Second turn: stored `session_id` drives `load_session` + `resume_session` so the timeline carries over.
- **Tauri events**:
  - `primer://chunk` (`ChunkEvent { primer_turn_index, text }`) per token
  - `primer://turn_complete` (`TurnComplete { session_id, child_turn_index, primer_turn_index }`) on completion — richer payload lands with the sidebar in step 5/6
- **`run_turn` extraction** — `send_message`'s body factored into a `pub(crate)` helper so unit tests can exercise the full DM-construction / resume / respond / close / writeback flow without a Tauri `AppHandle`.
- **Background-task drain** — `dm.close_session()` runs before we extract `dm.learner`, ensuring classifier / extractor / comprehension results land on disk AND in the in-memory learner before the active session is updated.

### Frontend
- **`ui/index.html`** — proper chat shell (header pills, scroll area, error banner, composer with auto-grow textarea).
- **`ui/styles.css`** — bubble alignment (child right blue / Primer left neutral), streaming caret animation, light/dark via `prefers-color-scheme`.
- **`ui/app.js`** — auto-starts a session on launch, renders bubbles, listens for chunk / turn_complete events. Uses `window.__TAURI__` via `app.withGlobalTauri = true` — **no npm / JS toolchain required**.

## Test plan

- [x] `cargo test -p primer-gui --lib` — 34 tests pass (3 new for `run_turn`)
- [x] `cargo clippy -p primer-gui --all-targets` — clean
- [x] 5s background-boot smoke: GUI auto-runs `start_session` (auto-seed log lines appear), chat surface renders without panic
- [x] Run-turn integration tests verify: first turn creates session, second turn resumes the same UUID, session round-trips through the store

🤖 Generated with [Claude Code](https://claude.com/claude-code)