### PR TITLE
feat(gui): sidebar — Current turn section

### DIFF
--- a/src/crates/primer-core/src/conversation.rs
+++ b/src/crates/primer-core/src/conversation.rs
@@ -80,6 +80,30 @@ impl PedagogicalIntent {
         Self::SessionClose,
         Self::SuggestBreak,
     ];
+
+    /// Canonical machine-readable name. Stable identifier exposed across
+    /// the FFI surface (Tauri `TurnSignals`, future verbose-CLI tracing).
+    /// Don't rename — frontends key behaviour (e.g. badge colour, log
+    /// filters) on these exact strings.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::SocraticQuestion => "SocraticQuestion",
+            Self::ComprehensionCheck => "ComprehensionCheck",
+            Self::Scaffolding => "Scaffolding",
+            Self::Encouragement => "Encouragement",
+            Self::Extension => "Extension",
+            Self::DirectAnswer => "DirectAnswer",
+            Self::AnswerThenPivot => "AnswerThenPivot",
+            Self::SessionClose => "SessionClose",
+            Self::SuggestBreak => "SuggestBreak",
+        }
+    }
+}
+
+impl std::fmt::Display for PedagogicalIntent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
 }
 
 /// A complete conversation session.
@@ -148,5 +172,32 @@ mod tests {
         assert!(PedagogicalIntent::ALL.contains(&PedagogicalIntent::SocraticQuestion));
         assert!(PedagogicalIntent::ALL.contains(&PedagogicalIntent::SessionClose));
         assert!(PedagogicalIntent::ALL.contains(&PedagogicalIntent::SuggestBreak));
+    }
+
+    #[test]
+    fn pedagogical_intent_name_matches_canonical_strings() {
+        assert_eq!(
+            PedagogicalIntent::SocraticQuestion.name(),
+            "SocraticQuestion"
+        );
+        assert_eq!(
+            PedagogicalIntent::ComprehensionCheck.name(),
+            "ComprehensionCheck"
+        );
+        assert_eq!(PedagogicalIntent::Scaffolding.name(), "Scaffolding");
+        assert_eq!(PedagogicalIntent::Encouragement.name(), "Encouragement");
+        assert_eq!(PedagogicalIntent::Extension.name(), "Extension");
+        assert_eq!(PedagogicalIntent::DirectAnswer.name(), "DirectAnswer");
+        assert_eq!(PedagogicalIntent::AnswerThenPivot.name(), "AnswerThenPivot");
+        assert_eq!(PedagogicalIntent::SessionClose.name(), "SessionClose");
+        assert_eq!(PedagogicalIntent::SuggestBreak.name(), "SuggestBreak");
+    }
+
+    #[test]
+    fn pedagogical_intent_display_uses_name() {
+        assert_eq!(
+            format!("{}", PedagogicalIntent::SuggestBreak),
+            "SuggestBreak"
+        );
     }
 }

--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -23,5 +23,6 @@ pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
         session::close_session,
         session::current_session_info,
         session::send_message,
+        session::get_turn_signals,
     ])
 }

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -82,6 +82,16 @@ pub async fn current_session_info(
 /// refresh until the response finishes streaming, which is the
 /// correct UX (the signals don't change until then anyway).
 ///
+/// **Why not via `SessionSnapshot` like `current_session_info`?** That
+/// snapshot exists so reader commands NEVER touch the DM mutex, since
+/// they may fire during a streaming turn. Signals don't have that
+/// constraint: the frontend refreshes them on `primer://turn_complete`
+/// (post-stream, DM free) and on launch — never during a turn. A brief
+/// post-stream DM lock costs less than the per-turn snapshot-write
+/// fan-out we'd otherwise add to `refresh_snapshot`. If a future
+/// caller ever needs live mid-stream signals, fold them into
+/// `SessionSnapshot` instead of relaxing this invariant.
+///
 /// Returns `Ok(None)` when no session is active.
 #[tauri::command]
 pub async fn get_turn_signals(
@@ -104,9 +114,13 @@ pub async fn get_turn_signals(
 /// pattern (one DM lock per sidebar refresh) without duplicating the
 /// shape mapping. No `.await` — caller must already hold the DM lock.
 pub(crate) fn read_signals(dm: &DialogueManager) -> TurnSignals {
-    let intent = dm.last_intent().map(|i| format!("{i:?}"));
+    // Wire strings come from each enum's `name()` — the same canonical
+    // identifiers the storage lookup tables use. Don't switch back to
+    // `format!("{:?}", ...)`: Debug output is not a stable contract and
+    // frontend CSS/keys depend on these exact strings.
+    let intent = dm.last_intent().map(|i| i.name().to_string());
     let engagement = dm.last_assessment().map(|a| EngagementSummary {
-        state: format!("{:?}", a.state),
+        state: a.state.name().to_string(),
         confidence: a.confidence,
         reasoning: a.reasoning.clone(),
     });
@@ -124,7 +138,7 @@ pub(crate) fn read_signals(dm: &DialogueManager) -> TurnSignals {
                 .iter()
                 .map(|a| ComprehensionSummary {
                     concept: a.concept.clone(),
-                    depth: format!("{:?}", a.depth),
+                    depth: a.depth.name().to_string(),
                     confidence: a.confidence,
                     evidence: a.evidence.clone(),
                 })
@@ -297,6 +311,8 @@ mod tests {
     use super::*;
     use crate::config::GuiConfig;
     use crate::wiring::build_active_session;
+    use primer_core::conversation::PedagogicalIntent;
+    use primer_core::learner::EngagementState;
     use tempfile::TempDir;
 
     fn stub_config_with_persistence(home: &std::path::Path) -> GuiConfig {
@@ -389,7 +405,10 @@ mod tests {
         let dm = active.dialogue_manager.lock().await;
         let signals = read_signals(&dm);
         assert!(signals.intent.is_none(), "no intent before any turn");
-        assert!(signals.engagement.is_none(), "no engagement before any turn");
+        assert!(
+            signals.engagement.is_none(),
+            "no engagement before any turn"
+        );
         assert!(signals.concepts.child.is_empty());
         assert!(signals.concepts.primer.is_empty());
         assert!(signals.comprehension.is_empty());
@@ -397,6 +416,40 @@ mod tests {
         assert_eq!(signals.classifier_identifier, "stub");
         assert_eq!(signals.extractor_identifier, "stub");
         assert_eq!(signals.comprehension_identifier, "stub");
+    }
+
+    #[tokio::test]
+    async fn read_signals_after_first_turn_has_intent_only() {
+        // After exactly one respond_to_streaming, intent is current
+        // (decided in-turn) but the classifier / extractor /
+        // comprehension tasks for that turn haven't been drained —
+        // that drain happens at the TOP of turn 2's respond_to_streaming.
+        // This is the lag boundary the UI banner promises; pin it.
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm_arc = Arc::clone(&active.dialogue_manager);
+
+        run_turn(&dm_arc, "hello", |_, _| {}).await.unwrap();
+
+        let dm = dm_arc.lock().await;
+        let signals = read_signals(&dm);
+        assert!(
+            signals.intent.is_some(),
+            "intent is decided in-turn — populated after first respond_to_streaming"
+        );
+        assert!(
+            signals.engagement.is_none(),
+            "engagement task is still pending — drain happens at top of turn 2"
+        );
+        assert!(
+            signals.concepts.child.is_empty() && signals.concepts.primer.is_empty(),
+            "extractor task is still pending — drain happens at top of turn 2"
+        );
+        assert!(
+            signals.comprehension.is_empty(),
+            "comprehension task is still pending — drain happens at top of turn 2"
+        );
     }
 
     #[tokio::test]
@@ -417,15 +470,30 @@ mod tests {
         let signals = read_signals(&dm);
         // Intent is current (decided during turn 2); always populated
         // after at least one respond_to_streaming has run.
-        assert!(signals.intent.is_some(), "intent is current — set during turn 2");
+        let intent = signals
+            .intent
+            .as_deref()
+            .expect("intent is current — set during turn 2");
+        // Stable wire format from PedagogicalIntent::name() — must
+        // match one of the canonical variant names. If this assertion
+        // ever fires, either a variant was added/renamed in primer-core
+        // (update the list below + the CSS) or somebody put the
+        // `format!("{:?}", ...)` back. Both need to be caught.
+        assert!(
+            PedagogicalIntent::ALL.iter().any(|v| v.name() == intent),
+            "intent {intent:?} must be a canonical PedagogicalIntent::name()"
+        );
         // Stub classifier produces a deterministic Engaged-default
         // assessment — populated after the turn-1 task drain at top
         // of turn 2.
+        let eng = signals
+            .engagement
+            .expect("engagement populated after second turn drains turn-1 classifier task");
         assert!(
-            signals.engagement.is_some(),
-            "engagement populated after second turn drains turn-1 classifier task"
+            EngagementState::ALL.iter().any(|v| v.name() == eng.state),
+            "engagement state {:?} must be a canonical EngagementState::name()",
+            eng.state
         );
-        let eng = signals.engagement.unwrap();
         assert!(
             (0.0..=1.0).contains(&eng.confidence),
             "confidence in valid range"

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -20,7 +20,10 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use crate::state::{ActiveSession, AppState, SessionSnapshot};
-use crate::types::{ChunkEvent, LearnerSummary, SessionInfo, TurnComplete};
+use crate::types::{
+    ChunkEvent, ComprehensionSummary, ConceptBreakdown, EngagementSummary, LearnerSummary,
+    SessionInfo, TurnComplete, TurnSignals,
+};
 use crate::wiring;
 
 /// Construct an `ActiveSession` from the persisted settings and store
@@ -64,6 +67,78 @@ pub async fn current_session_info(
         Ok(Some(info_from(active).await))
     } else {
         Ok(None)
+    }
+}
+
+/// Return the pedagogical signals for the most-recently completed
+/// exchange (intent, engagement, concepts, comprehension).
+///
+/// **DM-lock duration: brief.** Locks the DM mutex only long enough to
+/// clone a handful of `last_*` accessor outputs; no `.await` inside
+/// the locked region. A `current_session_info` request issued in
+/// parallel with this one therefore queues for microseconds, not the
+/// streaming wallclock. Holding the lock for an in-flight
+/// `send_message` is fine — the lock-wait just defers the signal
+/// refresh until the response finishes streaming, which is the
+/// correct UX (the signals don't change until then anyway).
+///
+/// Returns `Ok(None)` when no session is active.
+#[tauri::command]
+pub async fn get_turn_signals(
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<TurnSignals>, String> {
+    let session_guard = state.session.lock().await;
+    let active = match session_guard.as_ref() {
+        Some(a) => a,
+        None => return Ok(None),
+    };
+    let dm_arc = Arc::clone(&active.dialogue_manager);
+    drop(session_guard);
+
+    let dm = dm_arc.lock().await;
+    Ok(Some(read_signals(&dm)))
+}
+
+/// Pure-ish read of the DM's `last_*` accessors. Split out from
+/// `get_turn_signals` so step 6's learner snapshot can reuse the same
+/// pattern (one DM lock per sidebar refresh) without duplicating the
+/// shape mapping. No `.await` — caller must already hold the DM lock.
+pub(crate) fn read_signals(dm: &DialogueManager) -> TurnSignals {
+    let intent = dm.last_intent().map(|i| format!("{i:?}"));
+    let engagement = dm.last_assessment().map(|a| EngagementSummary {
+        state: format!("{:?}", a.state),
+        confidence: a.confidence,
+        reasoning: a.reasoning.clone(),
+    });
+    let concepts = dm
+        .last_extraction()
+        .map(|e| ConceptBreakdown {
+            child: e.child_concepts.clone(),
+            primer: e.primer_concepts.clone(),
+        })
+        .unwrap_or_default();
+    let comprehension = dm
+        .last_comprehension()
+        .map(|r| {
+            r.assessments
+                .iter()
+                .map(|a| ComprehensionSummary {
+                    concept: a.concept.clone(),
+                    depth: format!("{:?}", a.depth),
+                    confidence: a.confidence,
+                    evidence: a.evidence.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    TurnSignals {
+        intent,
+        engagement,
+        concepts,
+        comprehension,
+        classifier_identifier: dm.classifier_identifier().to_string(),
+        extractor_identifier: dm.extractor_identifier().to_string(),
+        comprehension_identifier: dm.comprehension_identifier().to_string(),
     }
 }
 
@@ -303,6 +378,57 @@ mod tests {
             loaded.turns.len() >= 2,
             "session must persist both the child and primer turns; got {} turns",
             loaded.turns.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_signals_empty_before_any_turn() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm = active.dialogue_manager.lock().await;
+        let signals = read_signals(&dm);
+        assert!(signals.intent.is_none(), "no intent before any turn");
+        assert!(signals.engagement.is_none(), "no engagement before any turn");
+        assert!(signals.concepts.child.is_empty());
+        assert!(signals.concepts.primer.is_empty());
+        assert!(signals.comprehension.is_empty());
+        // Identifiers are populated at construction (subsystems always exist).
+        assert_eq!(signals.classifier_identifier, "stub");
+        assert_eq!(signals.extractor_identifier, "stub");
+        assert_eq!(signals.comprehension_identifier, "stub");
+    }
+
+    #[tokio::test]
+    async fn read_signals_populates_after_second_turn() {
+        // The DM drains the previous turn's background tasks at the
+        // TOP of the next respond_to_streaming. So after turn 2,
+        // last_* reflects turn 1's analysis — a populated path the
+        // stub classifier/extractor/comprehension all exercise.
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm_arc = Arc::clone(&active.dialogue_manager);
+
+        run_turn(&dm_arc, "hello", |_, _| {}).await.unwrap();
+        run_turn(&dm_arc, "tell me more", |_, _| {}).await.unwrap();
+
+        let dm = dm_arc.lock().await;
+        let signals = read_signals(&dm);
+        // Intent is current (decided during turn 2); always populated
+        // after at least one respond_to_streaming has run.
+        assert!(signals.intent.is_some(), "intent is current — set during turn 2");
+        // Stub classifier produces a deterministic Engaged-default
+        // assessment — populated after the turn-1 task drain at top
+        // of turn 2.
+        assert!(
+            signals.engagement.is_some(),
+            "engagement populated after second turn drains turn-1 classifier task"
+        );
+        let eng = signals.engagement.unwrap();
+        assert!(
+            (0.0..=1.0).contains(&eng.confidence),
+            "confidence in valid range"
         );
     }
 

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -73,3 +73,83 @@ pub struct ChunkEvent {
     /// The token text — append directly to the bubble.
     pub text: String,
 }
+
+/// Snapshot of the pedagogical signals attached to the most-recently
+/// completed exchange. Returned by `get_turn_signals` and rendered in
+/// the right-hand sidebar's "Current turn" section.
+///
+/// **One-turn lag, by design.** The classifier / extractor /
+/// comprehension subsystems spawn background tasks at the END of each
+/// turn and the dialogue manager drains them at the TOP of the NEXT
+/// `respond_to_streaming`. So after turn N's stream completes,
+/// `engagement` / `concepts` / `comprehension` reflect what the
+/// background tasks produced for turn **N−1** (turn N's haven't been
+/// awaited yet). `intent` is current — it's decided synchronously
+/// during respond_to_streaming. This mirrors what the CLI's `--verbose`
+/// flag shows and is the right trade-off for the natural inter-turn
+/// pause to absorb the 3–10 s analysis wallclock.
+///
+/// On the very first turn of a session, every Optional field except
+/// `intent` is `None`.
+#[derive(Debug, Clone, Serialize)]
+pub struct TurnSignals {
+    /// The pedagogical intent the Primer adopted on its most recent
+    /// response (e.g. `"SocraticQuestion"`, `"Encouragement"`,
+    /// `"SuggestBreak"`). Current — not lagged.
+    pub intent: Option<String>,
+
+    /// The engagement assessment applied to the in-memory `LearnerModel`
+    /// for the previous turn's child input. Lagged by one turn.
+    pub engagement: Option<EngagementSummary>,
+
+    /// Concepts the extractor surfaced from the previous exchange.
+    /// Lagged by one turn.
+    pub concepts: ConceptBreakdown,
+
+    /// Per-concept comprehension assessments for the previous exchange.
+    /// Lagged by one turn.
+    pub comprehension: Vec<ComprehensionSummary>,
+
+    /// Stable identifier of the active classifier (e.g. `"stub"`,
+    /// `"llm:claude-sonnet-4-6"`). Renders as a small subtitle under
+    /// the engagement section so a parent can see which model produced
+    /// the rating.
+    pub classifier_identifier: String,
+    /// Stable identifier of the active extractor.
+    pub extractor_identifier: String,
+    /// Stable identifier of the active comprehension classifier.
+    pub comprehension_identifier: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EngagementSummary {
+    /// The `EngagementState` variant name, e.g. `"Curious"`, `"Frustrated"`.
+    pub state: String,
+    /// In `[0.0, 1.0]`.
+    pub confidence: f32,
+    /// Optional one-sentence rationale. LLM classifiers populate this;
+    /// the stub does not.
+    pub reasoning: Option<String>,
+}
+
+/// Two-column extractor breakdown of who introduced what.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ConceptBreakdown {
+    /// Concepts the child surfaced.
+    pub child: Vec<String>,
+    /// Concepts the Primer introduced.
+    pub primer: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ComprehensionSummary {
+    pub concept: String,
+    /// `UnderstandingDepth` variant name: `"Aware"`, `"Familiar"`,
+    /// `"Solid"`, or `"Fluent"`. The frontend renders this as a pill
+    /// with depth-graded colour.
+    pub depth: String,
+    /// In `[0.0, 1.0]`.
+    pub confidence: f32,
+    /// Optional short rationale — usually a phrase the child said.
+    pub evidence: Option<String>,
+}

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -95,7 +95,9 @@ pub struct ChunkEvent {
 pub struct TurnSignals {
     /// The pedagogical intent the Primer adopted on its most recent
     /// response (e.g. `"SocraticQuestion"`, `"Encouragement"`,
-    /// `"SuggestBreak"`). Current — not lagged.
+    /// `"SuggestBreak"`). Current — not lagged. Value comes from
+    /// `PedagogicalIntent::name()` — canonical, stable across releases;
+    /// frontends key behaviour on these exact strings.
     pub intent: Option<String>,
 
     /// The engagement assessment applied to the in-memory `LearnerModel`
@@ -123,7 +125,9 @@ pub struct TurnSignals {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct EngagementSummary {
-    /// The `EngagementState` variant name, e.g. `"Curious"`, `"Frustrated"`.
+    /// The `EngagementState` variant name from `EngagementState::name()`,
+    /// e.g. `"Engaged"`, `"Reflecting"`, `"FrustratedStuck"`,
+    /// `"FrustratedTrying"`, `"Disengaging"`, `"Unknown"`.
     pub state: String,
     /// In `[0.0, 1.0]`.
     pub confidence: f32,
@@ -144,9 +148,11 @@ pub struct ConceptBreakdown {
 #[derive(Debug, Clone, Serialize)]
 pub struct ComprehensionSummary {
     pub concept: String,
-    /// `UnderstandingDepth` variant name: `"Aware"`, `"Familiar"`,
-    /// `"Solid"`, or `"Fluent"`. The frontend renders this as a pill
-    /// with depth-graded colour.
+    /// `UnderstandingDepth` variant name from `UnderstandingDepth::name()`:
+    /// `"Unknown"`, `"Aware"`, `"Recall"`, `"Comprehension"`,
+    /// `"Application"`, or `"Analysis"`. The frontend lowercases this for
+    /// the depth-pill `data-depth` selector — keep the lowercased forms
+    /// in sync with [`styles.css`](../../ui/styles.css).
     pub depth: String,
     /// In `[0.0, 1.0]`.
     pub confidence: f32,

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -14,6 +14,7 @@ const { invoke } = window.__TAURI__.core;
 const { listen } = window.__TAURI__.event;
 
 const dom = {
+  body: document.body,
   sessionInfo: document.getElementById("session-info"),
   chatScroll: document.getElementById("chat-scroll"),
   emptyState: document.getElementById("empty-state"),
@@ -21,6 +22,26 @@ const dom = {
   composer: document.getElementById("composer"),
   input: document.getElementById("input"),
   send: document.getElementById("send"),
+  sidebarToggle: document.getElementById("sidebar-toggle"),
+  signals: {
+    empty: document.getElementById("sidebar-empty"),
+    lagHint: document.getElementById("signals-lag-hint"),
+    intentCard: document.getElementById("signals-intent-card"),
+    intentBadge: document.getElementById("signals-intent-badge"),
+    engagementCard: document.getElementById("signals-engagement-card"),
+    engagementState: document.getElementById("signals-engagement-state"),
+    engagementFill: document.getElementById("signals-engagement-fill"),
+    engagementValue: document.getElementById("signals-engagement-value"),
+    engagementReasoning: document.getElementById("signals-engagement-reasoning"),
+    engagementModel: document.getElementById("signals-engagement-model"),
+    conceptsCard: document.getElementById("signals-concepts-card"),
+    conceptsChild: document.getElementById("signals-concepts-child"),
+    conceptsPrimer: document.getElementById("signals-concepts-primer"),
+    extractorModel: document.getElementById("signals-extractor-model"),
+    comprehensionCard: document.getElementById("signals-comprehension-card"),
+    comprehensionList: document.getElementById("signals-comprehension-list"),
+    comprehensionModel: document.getElementById("signals-comprehension-model"),
+  },
 };
 
 // Live state — `streamingPrimerEl` points at the currently-streaming
@@ -38,7 +59,11 @@ async function main() {
   setupTurnCompleteListener();
   setupComposer();
   setupAutogrow();
+  setupSidebarToggle();
   await openOrStartSession();
+  // Render whatever's already on the DM (resumed sessions land here
+  // with populated last_* accessors); first-launch shows the empty state.
+  refreshSignals();
 }
 
 async function openOrStartSession() {
@@ -145,7 +170,147 @@ function setupTurnCompleteListener() {
     state.sessionId = event.payload.session_id;
     finaliseStreamingBubble({ aborted: false });
     enableComposer();
+    // Fire-and-forget — sidebar updates are non-critical; a failure
+    // here shouldn't deny the user the chat surface.
+    refreshSignals();
   });
+}
+
+function setupSidebarToggle() {
+  dom.sidebarToggle.addEventListener("click", () => {
+    const collapsed = dom.body.classList.toggle("sidebar-collapsed");
+    dom.sidebarToggle.setAttribute("aria-pressed", String(!collapsed));
+  });
+}
+
+async function refreshSignals() {
+  try {
+    const signals = await invoke("get_turn_signals");
+    renderSignals(signals);
+  } catch (err) {
+    // Sidebar errors are non-critical — log but don't surface.
+    console.warn("get_turn_signals failed:", err);
+  }
+}
+
+function renderSignals(signals) {
+  if (!signals) {
+    showSignalsEmpty();
+    return;
+  }
+  const s = dom.signals;
+
+  // The sidebar has SOMETHING to render once any field is populated.
+  // Even on turn 1 we get intent + identifier strings; the lag-hint
+  // appears once the engagement/concepts/comprehension cards do.
+  const anyLagged =
+    signals.engagement ||
+    (signals.concepts && (signals.concepts.child?.length || signals.concepts.primer?.length)) ||
+    (signals.comprehension && signals.comprehension.length > 0);
+  s.empty.hidden = !!(signals.intent || anyLagged);
+  s.lagHint.hidden = !anyLagged;
+
+  // Intent
+  if (signals.intent) {
+    s.intentCard.hidden = false;
+    s.intentBadge.textContent = signals.intent;
+  } else {
+    s.intentCard.hidden = true;
+  }
+
+  // Engagement
+  if (signals.engagement) {
+    s.engagementCard.hidden = false;
+    s.engagementState.textContent = signals.engagement.state;
+    const pct = Math.round((signals.engagement.confidence ?? 0) * 100);
+    s.engagementFill.style.width = `${pct}%`;
+    s.engagementValue.textContent = `${pct}%`;
+    if (signals.engagement.reasoning) {
+      s.engagementReasoning.hidden = false;
+      s.engagementReasoning.textContent = `“${signals.engagement.reasoning}”`;
+    } else {
+      s.engagementReasoning.hidden = true;
+      s.engagementReasoning.textContent = "";
+    }
+    s.engagementModel.textContent = signals.classifier_identifier
+      ? `via ${signals.classifier_identifier}`
+      : "";
+  } else {
+    s.engagementCard.hidden = true;
+  }
+
+  // Concepts
+  const child = signals.concepts?.child ?? [];
+  const primer = signals.concepts?.primer ?? [];
+  if (child.length || primer.length) {
+    s.conceptsCard.hidden = false;
+    renderChips(s.conceptsChild, child);
+    renderChips(s.conceptsPrimer, primer);
+    s.extractorModel.textContent = signals.extractor_identifier
+      ? `via ${signals.extractor_identifier}`
+      : "";
+  } else {
+    s.conceptsCard.hidden = true;
+  }
+
+  // Comprehension
+  const assessments = signals.comprehension ?? [];
+  if (assessments.length) {
+    s.comprehensionCard.hidden = false;
+    s.comprehensionList.replaceChildren(
+      ...assessments.map(renderComprehensionItem),
+    );
+    s.comprehensionModel.textContent = signals.comprehension_identifier
+      ? `via ${signals.comprehension_identifier}`
+      : "";
+  } else {
+    s.comprehensionCard.hidden = true;
+  }
+}
+
+function showSignalsEmpty() {
+  const s = dom.signals;
+  s.empty.hidden = false;
+  s.lagHint.hidden = true;
+  s.intentCard.hidden = true;
+  s.engagementCard.hidden = true;
+  s.conceptsCard.hidden = true;
+  s.comprehensionCard.hidden = true;
+}
+
+function renderChips(ulEl, items) {
+  ulEl.replaceChildren();
+  if (!items.length) {
+    const li = document.createElement("li");
+    li.className = "placeholder";
+    li.textContent = "—";
+    ulEl.appendChild(li);
+    return;
+  }
+  for (const item of items) {
+    const li = document.createElement("li");
+    li.textContent = item;
+    ulEl.appendChild(li);
+  }
+}
+
+function renderComprehensionItem(a) {
+  const li = document.createElement("li");
+  const concept = document.createElement("span");
+  concept.textContent = a.concept;
+  const pill = document.createElement("span");
+  pill.className = "depth-pill";
+  pill.dataset.depth = String(a.depth || "").toLowerCase();
+  pill.textContent = a.depth;
+  const pct = Math.round((a.confidence ?? 0) * 100);
+  const conf = document.createElement("span");
+  conf.className = "muted";
+  conf.textContent = `${pct}%`;
+  conf.title = a.evidence ? `“${a.evidence}”` : "";
+  li.appendChild(concept);
+  li.appendChild(pill);
+  li.appendChild(conf);
+  return li;
 }
 
 function appendChildBubble(text) {

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -180,6 +180,10 @@ function setupSidebarToggle() {
   dom.sidebarToggle.addEventListener("click", () => {
     const collapsed = dom.body.classList.toggle("sidebar-collapsed");
     dom.sidebarToggle.setAttribute("aria-pressed", String(!collapsed));
+    // Flip the label too: a screen reader user gets the state from
+    // aria-pressed, but sighted users only see the button text. Keep
+    // both surfaces in sync.
+    dom.sidebarToggle.textContent = collapsed ? "Show Sidebar" : "Hide Sidebar";
   });
 }
 
@@ -300,7 +304,11 @@ function renderComprehensionItem(a) {
   concept.textContent = a.concept;
   const pill = document.createElement("span");
   pill.className = "depth-pill";
-  pill.dataset.depth = String(a.depth || "").toLowerCase();
+  // a.depth is always a canonical `UnderstandingDepth::name()` from
+  // the Rust side (Unknown / Aware / Recall / Comprehension /
+  // Application / Analysis). Lowercase it to match the CSS
+  // `data-depth=` selectors in styles.css.
+  pill.dataset.depth = a.depth.toLowerCase();
   pill.textContent = a.depth;
   const pct = Math.round((a.confidence ?? 0) * 100);
   const conf = document.createElement("span");

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -15,6 +15,15 @@
       <div class="session-info" id="session-info" data-state="loading">
         <span class="muted">Starting session…</span>
       </div>
+      <button
+        type="button"
+        class="sidebar-toggle"
+        id="sidebar-toggle"
+        aria-pressed="true"
+        title="Show or hide the evaluation sidebar"
+      >
+        Sidebar
+      </button>
     </header>
 
     <main class="chat">
@@ -47,6 +56,78 @@
         <button type="submit" id="send" disabled>Send</button>
       </form>
     </main>
+
+    <aside class="sidebar" id="sidebar" aria-label="Evaluation sidebar">
+      <section class="sidebar-section" data-section="current-turn">
+        <header class="sidebar-section-header">
+          <h2>Current turn</h2>
+          <span class="sidebar-section-hint muted" id="signals-lag-hint" hidden>
+            Engagement, concepts, and comprehension show the previous exchange
+            — the dialogue manager analyses each turn in the background and
+            applies the results at the top of the next turn.
+          </span>
+        </header>
+
+        <div class="sidebar-empty" id="sidebar-empty">
+          <p>Signals appear here once the first exchange completes.</p>
+        </div>
+
+        <div class="sidebar-card" id="signals-intent-card" hidden>
+          <div class="sidebar-card-label">Intent</div>
+          <div class="sidebar-card-body">
+            <span class="badge" id="signals-intent-badge">—</span>
+          </div>
+        </div>
+
+        <div class="sidebar-card" id="signals-engagement-card" hidden>
+          <div class="sidebar-card-label">Engagement</div>
+          <div class="sidebar-card-body">
+            <div class="row">
+              <span class="badge" id="signals-engagement-state">—</span>
+              <span class="confidence-bar" aria-hidden="true">
+                <span class="confidence-fill" id="signals-engagement-fill"></span>
+              </span>
+              <span class="confidence-value" id="signals-engagement-value">—</span>
+            </div>
+            <div
+              class="sidebar-card-rationale muted"
+              id="signals-engagement-reasoning"
+              hidden
+            ></div>
+            <div
+              class="sidebar-card-meta muted"
+              id="signals-engagement-model"
+            ></div>
+          </div>
+        </div>
+
+        <div class="sidebar-card" id="signals-concepts-card" hidden>
+          <div class="sidebar-card-label">Concepts</div>
+          <div class="sidebar-card-body two-col">
+            <div>
+              <div class="col-label muted">Child</div>
+              <ul class="chips" id="signals-concepts-child"></ul>
+            </div>
+            <div>
+              <div class="col-label muted">Primer</div>
+              <ul class="chips" id="signals-concepts-primer"></ul>
+            </div>
+          </div>
+          <div class="sidebar-card-meta muted" id="signals-extractor-model"></div>
+        </div>
+
+        <div class="sidebar-card" id="signals-comprehension-card" hidden>
+          <div class="sidebar-card-label">Comprehension</div>
+          <div class="sidebar-card-body">
+            <ul class="comprehension-list" id="signals-comprehension-list"></ul>
+          </div>
+          <div
+            class="sidebar-card-meta muted"
+            id="signals-comprehension-model"
+          ></div>
+        </div>
+      </section>
+    </aside>
 
     <script src="app.js"></script>
   </body>

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -20,9 +20,10 @@
         class="sidebar-toggle"
         id="sidebar-toggle"
         aria-pressed="true"
+        aria-controls="sidebar"
         title="Show or hide the evaluation sidebar"
       >
-        Sidebar
+        Hide Sidebar
       </button>
     </header>
 

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -14,6 +14,23 @@
   --error-fg: #991b1b;
   --error-border: #fecaca;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+
+  /* Depth-pill palette — one stop per UnderstandingDepth variant.
+     Light-mode foreground is the saturated end so the pill text stays
+     legible on a 18%-mixed background. Keep variant names in sync with
+     primer-core's UnderstandingDepth::name(). */
+  --depth-unknown: #6b7280;
+  --depth-aware: #ca8a04;
+  --depth-recall: #2563eb;
+  --depth-comprehension: #16a34a;
+  --depth-application: #9333ea;
+  --depth-analysis: #db2777;
+  --depth-unknown-fg: #4b5563;
+  --depth-aware-fg: #a16207;
+  --depth-recall-fg: #1d4ed8;
+  --depth-comprehension-fg: #15803d;
+  --depth-application-fg: #7e22ce;
+  --depth-analysis-fg: #be185d;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -31,6 +48,15 @@
     --error-bg: #3f1d1d;
     --error-fg: #fecaca;
     --error-border: #7f1d1d;
+
+    /* In dark mode the depth-pill background is the same mix, but the
+       text needs to lift to a pastel for contrast. */
+    --depth-unknown-fg: #d1d5db;
+    --depth-aware-fg: #fde68a;
+    --depth-recall-fg: #bfdbfe;
+    --depth-comprehension-fg: #bbf7d0;
+    --depth-application-fg: #e9d5ff;
+    --depth-analysis-fg: #fbcfe8;
   }
 }
 
@@ -523,34 +549,30 @@ body.sidebar-collapsed .sidebar {
   letter-spacing: 0.02em;
 }
 
+/* Variant names mirror UnderstandingDepth::name() lowercased. The JS
+   sets `data-depth` from the canonical `.name()` value from
+   primer-core. If a variant is ever renamed there, update both ends. */
+.depth-pill[data-depth="unknown"] {
+  background: color-mix(in oklab, var(--depth-unknown) 18%, transparent);
+  color: var(--depth-unknown-fg);
+}
 .depth-pill[data-depth="aware"] {
-  background: color-mix(in oklab, #ca8a04 18%, transparent);
-  color: #a16207;
+  background: color-mix(in oklab, var(--depth-aware) 18%, transparent);
+  color: var(--depth-aware-fg);
 }
-.depth-pill[data-depth="familiar"] {
-  background: color-mix(in oklab, #2563eb 18%, transparent);
-  color: #1d4ed8;
+.depth-pill[data-depth="recall"] {
+  background: color-mix(in oklab, var(--depth-recall) 18%, transparent);
+  color: var(--depth-recall-fg);
 }
-.depth-pill[data-depth="solid"] {
-  background: color-mix(in oklab, #16a34a 18%, transparent);
-  color: #15803d;
+.depth-pill[data-depth="comprehension"] {
+  background: color-mix(in oklab, var(--depth-comprehension) 18%, transparent);
+  color: var(--depth-comprehension-fg);
 }
-.depth-pill[data-depth="fluent"] {
-  background: color-mix(in oklab, #9333ea 18%, transparent);
-  color: #7e22ce;
+.depth-pill[data-depth="application"] {
+  background: color-mix(in oklab, var(--depth-application) 18%, transparent);
+  color: var(--depth-application-fg);
 }
-
-@media (prefers-color-scheme: dark) {
-  .depth-pill[data-depth="aware"] {
-    color: #fde68a;
-  }
-  .depth-pill[data-depth="familiar"] {
-    color: #bfdbfe;
-  }
-  .depth-pill[data-depth="solid"] {
-    color: #bbf7d0;
-  }
-  .depth-pill[data-depth="fluent"] {
-    color: #e9d5ff;
-  }
+.depth-pill[data-depth="analysis"] {
+  background: color-mix(in oklab, var(--depth-analysis) 18%, transparent);
+  color: var(--depth-analysis-fg);
 }

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -58,6 +58,30 @@ body {
 body {
   display: grid;
   grid-template-rows: auto 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+  grid-template-areas:
+    "header header"
+    "chat sidebar";
+  transition: grid-template-columns 180ms ease;
+}
+
+body.sidebar-collapsed {
+  grid-template-columns: minmax(0, 1fr) 0;
+}
+
+.app-header {
+  grid-area: header;
+}
+
+.chat {
+  grid-area: chat;
+}
+
+.sidebar {
+  grid-area: sidebar;
+  overflow: hidden;
+  border-left: 1px solid var(--border);
+  background: var(--surface);
 }
 
 /* ─── Header ─────────────────────────────────────────────────────── */
@@ -270,4 +294,263 @@ body {
 #send:disabled {
   cursor: not-allowed;
   opacity: 0.55;
+}
+
+/* ─── Sidebar toggle button ─────────────────────────────────────── */
+
+.sidebar-toggle {
+  -webkit-app-region: no-drag;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.sidebar-toggle:hover {
+  background: color-mix(in oklab, var(--accent) 8%, var(--bg));
+}
+
+.sidebar-toggle[aria-pressed="false"] {
+  opacity: 0.65;
+}
+
+/* ─── Sidebar ───────────────────────────────────────────────────── */
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow-y: auto;
+}
+
+body.sidebar-collapsed .sidebar {
+  display: none;
+}
+
+.sidebar-section {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.sidebar-section:last-child {
+  border-bottom: none;
+}
+
+.sidebar-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.sidebar-section-header h2 {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.sidebar-section-hint {
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.sidebar-empty {
+  padding: 0.6rem 0.7rem;
+  border: 1px dashed var(--border);
+  border-radius: 0.5rem;
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+}
+
+.sidebar-empty p {
+  margin: 0;
+}
+
+.sidebar-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.55rem;
+  background: var(--bg);
+}
+
+.sidebar-card-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.sidebar-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.88rem;
+}
+
+.sidebar-card-body.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.col-label {
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.sidebar-card-meta {
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.sidebar-card-rationale {
+  font-size: 0.82rem;
+  font-style: italic;
+  line-height: 1.5;
+}
+
+/* Inline row used by the engagement card (badge + bar + value). */
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.12rem 0.55rem;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 14%, transparent);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.confidence-bar {
+  position: relative;
+  flex: 1 1 6rem;
+  min-width: 4rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--fg) 8%, transparent);
+  overflow: hidden;
+}
+
+.confidence-fill {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: var(--accent);
+  border-radius: inherit;
+  transition: width 220ms ease;
+}
+
+.confidence-value {
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+  min-width: 2.4rem;
+  text-align: right;
+}
+
+.chips {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.chips li {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  background: color-mix(in oklab, var(--fg) 6%, transparent);
+  color: var(--fg);
+  border-radius: 0.35rem;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.chips .placeholder {
+  color: var(--fg-muted);
+  font-style: italic;
+  background: transparent;
+  padding: 0;
+}
+
+.comprehension-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.comprehension-list li {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.depth-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.08rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.depth-pill[data-depth="aware"] {
+  background: color-mix(in oklab, #ca8a04 18%, transparent);
+  color: #a16207;
+}
+.depth-pill[data-depth="familiar"] {
+  background: color-mix(in oklab, #2563eb 18%, transparent);
+  color: #1d4ed8;
+}
+.depth-pill[data-depth="solid"] {
+  background: color-mix(in oklab, #16a34a 18%, transparent);
+  color: #15803d;
+}
+.depth-pill[data-depth="fluent"] {
+  background: color-mix(in oklab, #9333ea 18%, transparent);
+  color: #7e22ce;
+}
+
+@media (prefers-color-scheme: dark) {
+  .depth-pill[data-depth="aware"] {
+    color: #fde68a;
+  }
+  .depth-pill[data-depth="familiar"] {
+    color: #bfdbfe;
+  }
+  .depth-pill[data-depth="solid"] {
+    color: #bbf7d0;
+  }
+  .depth-pill[data-depth="fluent"] {
+    color: #e9d5ff;
+  }
 }


### PR DESCRIPTION
## Summary

Step 5 of 10. Adds the collapsible right-side sidebar with the **Current turn** section: intent badge, engagement state + confidence bar + classifier model id, two-column extracted concepts, per-concept comprehension assessments with depth pills.

### Backend
- **`TurnSignals` DTO** ([`types.rs`](src/crates/primer-gui/src/types.rs)) bundles intent / engagement / concepts / comprehension plus the three subsystem `identifier()` strings.
- **`get_turn_signals` Tauri command** ([`commands/session.rs`](src/crates/primer-gui/src/commands/session.rs)) — locks the DM mutex briefly (no `.await` inside the locked region) and clones the `last_*` accessor outputs. Returns `Ok(None)` when no session is active.
- **Documented one-turn lag**: classifier / extractor / comprehension are awaited at the TOP of the NEXT `respond_to_streaming`, so post-turn `last_*` reflects the previous exchange. `intent` is current. The sidebar shows a small hint explaining this once the lagged cards appear.
- **`read_signals` extracted** as `pub(crate)` so step 6's learner snapshot reuses the same one-lock-per-refresh pattern.

### Frontend
- **`index.html`**: sidebar pane with four cards (Intent, Engagement, Concepts, Comprehension), header toggle button.
- **`styles.css`**: 2-column grid layout that collapses to 1-column when sidebar is toggled closed; depth pill colours per `UnderstandingDepth` variant; confidence bar + chip lists; light/dark via `prefers-color-scheme`.
- **`app.js`**: refreshes signals on `primer://turn_complete`, renders only cards that have data, hides empty state once the first signal lands. Toggle button persists pressed/released semantics via `aria-pressed`.

## Test plan

- [x] `cargo test -p primer-gui --lib` — 37 tests pass (2 new for `read_signals`)
- [x] `cargo clippy -p primer-gui --all-targets` — clean
- [x] 5s background-boot smoke: GUI boots with chat + sidebar; auto-seed runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)