### PR TITLE
feat(gui): sidebar — Learner section

### DIFF
--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -24,5 +24,6 @@ pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
         session::current_session_info,
         session::send_message,
         session::get_turn_signals,
+        session::get_learner_state,
     ])
 }

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -19,10 +19,14 @@ use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
+use chrono::Utc;
+use primer_core::learner::UnderstandingDepth;
+use primer_core::vocab::due_concepts;
+
 use crate::state::{ActiveSession, AppState, SessionSnapshot};
 use crate::types::{
-    ChunkEvent, ComprehensionSummary, ConceptBreakdown, EngagementSummary, LearnerSummary,
-    SessionInfo, TurnComplete, TurnSignals,
+    ChunkEvent, ComprehensionSummary, ConceptBreakdown, DepthCount, DueConcept, EngagementSummary,
+    LearnerProfileView, LearnerSnapshot, LearnerSummary, SessionInfo, TurnComplete, TurnSignals,
 };
 use crate::wiring;
 
@@ -107,6 +111,117 @@ pub async fn get_turn_signals(
 
     let dm = dm_arc.lock().await;
     Ok(Some(read_signals(&dm)))
+}
+
+/// Default ceiling on the vocab-due list returned to the sidebar.
+/// The CLI's `--vocab-max-per-prompt` setting is for prompt injection
+/// (a much smaller cap, ~4); the sidebar's "review queue" is allowed
+/// to be longer because it's just a display affordance. Tuned for
+/// "see at a glance" without scrolling.
+const VOCAB_DUE_DISPLAY_LIMIT: usize = 8;
+
+/// Maximum number of recent engagement states the sidebar shows as a
+/// sparkline-style dot strip. Mirrors the typical classifier
+/// `history_depth` setting — we clamp to this here so the frontend
+/// doesn't need to truncate.
+const RECENT_ENGAGEMENT_DISPLAY_LIMIT: usize = 8;
+
+/// Return the longitudinal learner snapshot — profile + vocab-due list
+/// + depth distribution + recent engagement strip. Same DM-lock-once
+/// pattern as `get_turn_signals` so the sidebar can refresh both
+/// sections from the same trigger without contending.
+///
+/// Returns `Ok(None)` when no session is active.
+#[tauri::command]
+pub async fn get_learner_state(
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<LearnerSnapshot>, String> {
+    let session_guard = state.session.lock().await;
+    let active = match session_guard.as_ref() {
+        Some(a) => a,
+        None => return Ok(None),
+    };
+    let dm_arc = Arc::clone(&active.dialogue_manager);
+    drop(session_guard);
+
+    let dm = dm_arc.lock().await;
+    Ok(Some(read_learner(&dm)))
+}
+
+/// Pure shape mapping from a held DM into a [`LearnerSnapshot`].
+/// Split out so a unit test can call it without round-tripping
+/// through a Tauri state. No `.await` — caller must already hold the
+/// DM lock.
+pub(crate) fn read_learner(dm: &DialogueManager) -> LearnerSnapshot {
+    let learner = &dm.learner;
+    let now = Utc::now();
+
+    let vocab_due = due_concepts(learner, now, VOCAB_DUE_DISPLAY_LIMIT)
+        .into_iter()
+        .map(|c| DueConcept {
+            concept_id: c.concept_id.clone(),
+            box_level: c.box_level,
+            depth: c.depth.name().to_string(),
+            days_until_due: days_until_due(c, now),
+        })
+        .collect();
+
+    let mut depth_counts: Vec<DepthCount> = UnderstandingDepth::ALL
+        .iter()
+        .map(|d| DepthCount {
+            depth: d.name().to_string(),
+            count: 0,
+        })
+        .collect();
+    for concept in &learner.concepts {
+        if let Some(row) = depth_counts
+            .iter_mut()
+            .find(|r| r.depth == concept.depth.name())
+        {
+            row.count += 1;
+        }
+    }
+
+    // recent_assessments grows over time; clamp the tail to the most
+    // recent N for the dot strip. Already oldest-first within the slice.
+    let recent_engagement = learner
+        .recent_assessments
+        .iter()
+        .rev()
+        .take(RECENT_ENGAGEMENT_DISPLAY_LIMIT)
+        .map(|a| a.state.name().to_string())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+
+    LearnerSnapshot {
+        profile: LearnerProfileView {
+            id: learner.profile.id,
+            name: learner.profile.name.clone(),
+            age: learner.profile.age,
+            locale: learner.profile.locale.pack_id().to_string(),
+        },
+        vocab_due,
+        depth_distribution: depth_counts,
+        recent_engagement,
+        concept_count: learner.concepts.len(),
+    }
+}
+
+/// Days until a concept's next due date. Negative = already overdue.
+/// Floors fractional days so "0.4 days" reads as "due now" rather
+/// than "due tomorrow" — matches what the user expects from a
+/// "next review" timer.
+fn days_until_due(c: &primer_core::learner::ConceptState, now: chrono::DateTime<Utc>) -> i64 {
+    use primer_core::consts::vocab::BOX_INTERVALS_DAYS;
+    let Some(last) = c.last_encountered else {
+        return 0;
+    };
+    let box_idx = (c.box_level as usize).min(BOX_INTERVALS_DAYS.len() - 1);
+    let interval = chrono::Duration::days(BOX_INTERVALS_DAYS[box_idx] as i64);
+    let due_at = last + interval;
+    (due_at - now).num_days()
 }
 
 /// Pure-ish read of the DM's `last_*` accessors. Split out from
@@ -395,6 +510,92 @@ mod tests {
             "session must persist both the child and primer turns; got {} turns",
             loaded.turns.len()
         );
+    }
+
+    #[tokio::test]
+    async fn read_learner_fresh_session_shape() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm = active.dialogue_manager.lock().await;
+        let snap = read_learner(&dm);
+
+        assert_eq!(snap.profile.name, cfg.learner.name);
+        assert_eq!(snap.profile.age, cfg.learner.age);
+        assert_eq!(snap.profile.locale, cfg.learner.locale);
+        assert_eq!(snap.concept_count, 0);
+        assert!(snap.vocab_due.is_empty());
+        assert!(snap.recent_engagement.is_empty());
+        // Distribution is always six entries — depths the learner
+        // has never reached carry count=0. Canonical order matches
+        // UnderstandingDepth::ALL.
+        let names: Vec<&str> = snap.depth_distribution.iter().map(|r| r.depth.as_str()).collect();
+        assert_eq!(
+            names,
+            ["Unknown", "Aware", "Recall", "Comprehension", "Application", "Analysis"]
+        );
+        for row in &snap.depth_distribution {
+            assert_eq!(row.count, 0, "fresh learner has no concepts at {}", row.depth);
+        }
+    }
+
+    #[tokio::test]
+    async fn read_learner_counts_concepts_by_depth() {
+        use primer_core::learner::{ConceptState, UnderstandingDepth};
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        {
+            let mut dm = active.dialogue_manager.lock().await;
+            // Inject concepts directly into the in-memory learner —
+            // the extractor stub returns empty, so this is the only
+            // way to exercise the populated counting path in a unit test.
+            dm.learner.concepts.push(ConceptState {
+                concept_id: "physics:gravity".into(),
+                depth: UnderstandingDepth::Aware,
+                confidence: 0.6,
+                encounter_count: 1,
+                last_encountered: Some(Utc::now()),
+                notes: vec![],
+                box_level: 0,
+            });
+            dm.learner.concepts.push(ConceptState {
+                concept_id: "biology:photosynthesis".into(),
+                depth: UnderstandingDepth::Recall,
+                confidence: 0.8,
+                encounter_count: 2,
+                last_encountered: Some(Utc::now() - chrono::Duration::days(2)),
+                notes: vec![],
+                box_level: 0,
+            });
+            dm.learner.concepts.push(ConceptState {
+                concept_id: "physics:mass".into(),
+                depth: UnderstandingDepth::Aware,
+                confidence: 0.5,
+                encounter_count: 1,
+                last_encountered: Some(Utc::now()),
+                notes: vec![],
+                box_level: 0,
+            });
+        }
+        let dm = active.dialogue_manager.lock().await;
+        let snap = read_learner(&dm);
+
+        assert_eq!(snap.concept_count, 3);
+        let by_depth: std::collections::HashMap<_, _> = snap
+            .depth_distribution
+            .iter()
+            .map(|r| (r.depth.as_str(), r.count))
+            .collect();
+        assert_eq!(by_depth["Aware"], 2);
+        assert_eq!(by_depth["Recall"], 1);
+        assert_eq!(by_depth["Analysis"], 0);
+        // Vocab due: photosynthesis is 2 days past its 1-day box-0
+        // interval, so it lands in the due list. Mass and gravity
+        // were "just encountered" so are not yet due.
+        let due_ids: Vec<&str> = snap.vocab_due.iter().map(|c| c.concept_id.as_str()).collect();
+        assert_eq!(due_ids, vec!["biology:photosynthesis"]);
+        assert!(snap.vocab_due[0].days_until_due <= 0, "must be overdue");
     }
 
     #[tokio::test]

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -20,6 +20,7 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use chrono::Utc;
+use primer_classifier::consts::DEFAULT_HISTORY_DEPTH;
 use primer_core::learner::UnderstandingDepth;
 use primer_core::vocab::due_concepts;
 
@@ -121,10 +122,15 @@ pub async fn get_turn_signals(
 const VOCAB_DUE_DISPLAY_LIMIT: usize = 8;
 
 /// Maximum number of recent engagement states the sidebar shows as a
-/// sparkline-style dot strip. Mirrors the typical classifier
-/// `history_depth` setting — we clamp to this here so the frontend
-/// doesn't need to truncate.
-const RECENT_ENGAGEMENT_DISPLAY_LIMIT: usize = 8;
+/// sparkline-style dot strip. The in-memory `recent_assessments` Vec
+/// is trimmed to `ClassifierSettings::history_depth` on every push
+/// (see `dialogue_manager::apply::apply_assessment`), so the dot strip
+/// can never exceed that bound today. We pin the display cap to the
+/// same default so the named limit reflects what's actually rendered;
+/// a future change that hydrates from `turn_classifications` (the
+/// persisted longitudinal record) would let this bound grow
+/// independently.
+const RECENT_ENGAGEMENT_DISPLAY_LIMIT: usize = DEFAULT_HISTORY_DEPTH;
 
 /// Return the longitudinal learner snapshot — profile + vocab-due list
 /// + depth distribution + recent engagement strip. Same DM-lock-once
@@ -182,17 +188,15 @@ pub(crate) fn read_learner(dm: &DialogueManager) -> LearnerSnapshot {
         }
     }
 
-    // recent_assessments grows over time; clamp the tail to the most
-    // recent N for the dot strip. Already oldest-first within the slice.
-    let recent_engagement = learner
+    // recent_assessments is push-back/remove-front so it's already
+    // oldest-first; take the tail slice for the dot strip.
+    let start = learner
         .recent_assessments
+        .len()
+        .saturating_sub(RECENT_ENGAGEMENT_DISPLAY_LIMIT);
+    let recent_engagement = learner.recent_assessments[start..]
         .iter()
-        .rev()
-        .take(RECENT_ENGAGEMENT_DISPLAY_LIMIT)
         .map(|a| a.state.name().to_string())
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
         .collect();
 
     LearnerSnapshot {
@@ -210,9 +214,12 @@ pub(crate) fn read_learner(dm: &DialogueManager) -> LearnerSnapshot {
 }
 
 /// Days until a concept's next due date. Negative = already overdue.
-/// Floors fractional days so "0.4 days" reads as "due now" rather
-/// than "due tomorrow" — matches what the user expects from a
-/// "next review" timer.
+/// `chrono::Duration::num_days` truncates toward zero, so sub-day
+/// remainders on both sides round to 0 — "0.4 days" reads as "due
+/// now" rather than "due tomorrow", and "-0.4 days" reads as "due
+/// now" rather than "1 day late". That's the rendering we want from
+/// a "next review" timer; the asymmetric-overdue side is the
+/// deliberate forgiving choice over a true floor.
 fn days_until_due(c: &primer_core::learner::ConceptState, now: chrono::DateTime<Utc>) -> i64 {
     use primer_core::consts::vocab::BOX_INTERVALS_DAYS;
     let Some(last) = c.last_encountered else {
@@ -529,13 +536,28 @@ mod tests {
         // Distribution is always six entries — depths the learner
         // has never reached carry count=0. Canonical order matches
         // UnderstandingDepth::ALL.
-        let names: Vec<&str> = snap.depth_distribution.iter().map(|r| r.depth.as_str()).collect();
+        let names: Vec<&str> = snap
+            .depth_distribution
+            .iter()
+            .map(|r| r.depth.as_str())
+            .collect();
         assert_eq!(
             names,
-            ["Unknown", "Aware", "Recall", "Comprehension", "Application", "Analysis"]
+            [
+                "Unknown",
+                "Aware",
+                "Recall",
+                "Comprehension",
+                "Application",
+                "Analysis"
+            ]
         );
         for row in &snap.depth_distribution {
-            assert_eq!(row.count, 0, "fresh learner has no concepts at {}", row.depth);
+            assert_eq!(
+                row.count, 0,
+                "fresh learner has no concepts at {}",
+                row.depth
+            );
         }
     }
 
@@ -593,9 +615,60 @@ mod tests {
         // Vocab due: photosynthesis is 2 days past its 1-day box-0
         // interval, so it lands in the due list. Mass and gravity
         // were "just encountered" so are not yet due.
-        let due_ids: Vec<&str> = snap.vocab_due.iter().map(|c| c.concept_id.as_str()).collect();
+        let due_ids: Vec<&str> = snap
+            .vocab_due
+            .iter()
+            .map(|c| c.concept_id.as_str())
+            .collect();
         assert_eq!(due_ids, vec!["biology:photosynthesis"]);
         assert!(snap.vocab_due[0].days_until_due <= 0, "must be overdue");
+    }
+
+    #[tokio::test]
+    async fn read_learner_recent_engagement_oldest_first_and_clamped() {
+        use primer_core::classifier::EngagementAssessment;
+        use primer_core::learner::EngagementState;
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        // Inject more than DEFAULT_HISTORY_DEPTH assessments in
+        // chronological order; the snapshot must preserve order
+        // (oldest first) and clamp to the display limit. Pushed
+        // directly because the in-memory cap from apply_assessment is
+        // exactly what we want to exercise from the snapshot side.
+        let states = [
+            EngagementState::Disengaging,
+            EngagementState::Reflecting,
+            EngagementState::Engaged,
+            EngagementState::FrustratedTrying,
+            EngagementState::Engaged,
+        ];
+        {
+            let mut dm = active.dialogue_manager.lock().await;
+            for s in states {
+                dm.learner.recent_assessments.push(EngagementAssessment {
+                    state: s,
+                    confidence: 0.8,
+                    reasoning: None,
+                });
+            }
+        }
+        let dm = active.dialogue_manager.lock().await;
+        let snap = read_learner(&dm);
+
+        assert_eq!(
+            snap.recent_engagement.len(),
+            RECENT_ENGAGEMENT_DISPLAY_LIMIT,
+            "clamped to the display limit when source exceeds it"
+        );
+        // Tail-slice preserves order — the displayed slice is the
+        // most-recent N states in the same order they were appended.
+        let tail_start = states.len() - RECENT_ENGAGEMENT_DISPLAY_LIMIT;
+        let expected: Vec<String> = states[tail_start..]
+            .iter()
+            .map(|s| s.name().to_string())
+            .collect();
+        assert_eq!(snap.recent_engagement, expected);
     }
 
     #[tokio::test]

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -180,7 +180,9 @@ pub struct LearnerSnapshot {
     /// variant, in canonical order (Unknown → Analysis). Always six
     /// entries — depths the learner has never reached carry `count = 0`.
     pub depth_distribution: Vec<DepthCount>,
-    /// Recent engagement states in chronological order (oldest first).
+    /// Recent engagement states in chronological order (oldest first,
+    /// newest last). The sidebar renders left-to-right, so the
+    /// most-recent state is the rightmost dot.
     /// Variant names match [`primer_core::learner::EngagementState::name`].
     pub recent_engagement: Vec<String>,
     /// Total concept count. `depth_distribution` sums to the same
@@ -207,8 +209,12 @@ pub struct DueConcept {
     /// wants to show the depth alongside the dot row.
     pub depth: String,
     /// Days until the concept next becomes due. Negative = already
-    /// overdue by that many days. Floor so "due in 0.4 days" reads as
-    /// "due now" rather than "due tomorrow".
+    /// overdue by that many days. `chrono::Duration::num_days`
+    /// truncates toward zero, so sub-day remainders on both sides
+    /// round to 0 — "0.4 days" reads as "due now" rather than "due
+    /// tomorrow", "-0.4 days" reads as "due now" rather than "1 day
+    /// late". The asymmetric-overdue side is the deliberate forgiving
+    /// choice over a true floor.
     pub days_until_due: i64,
 }
 

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -159,3 +159,62 @@ pub struct ComprehensionSummary {
     /// Optional short rationale — usually a phrase the child said.
     pub evidence: Option<String>,
 }
+
+/// Snapshot of the learner's longitudinal state — what the sidebar's
+/// "Learner" section renders.
+///
+/// Refreshed at the same trigger as [`TurnSignals`] (the
+/// `primer://turn_complete` event); the underlying `LearnerModel`
+/// mutates across turns as the comprehension classifier promotes
+/// depth, the extractor adds concepts, and the vocab scheduler moves
+/// box levels. Reading it is cheap — one short DM-mutex lock for the
+/// shape transform, no I/O.
+#[derive(Debug, Clone, Serialize)]
+pub struct LearnerSnapshot {
+    pub profile: LearnerProfileView,
+    /// Top-N concepts that are most overdue for passive review, picked
+    /// by [`primer_core::vocab::due_concepts`]. Empty for a fresh
+    /// learner with no concepts yet.
+    pub vocab_due: Vec<DueConcept>,
+    /// Counts of concepts at each [`primer_core::learner::UnderstandingDepth`]
+    /// variant, in canonical order (Unknown → Analysis). Always six
+    /// entries — depths the learner has never reached carry `count = 0`.
+    pub depth_distribution: Vec<DepthCount>,
+    /// Recent engagement states in chronological order (oldest first).
+    /// Variant names match [`primer_core::learner::EngagementState::name`].
+    pub recent_engagement: Vec<String>,
+    /// Total concept count. `depth_distribution` sums to the same
+    /// number, but a direct field saves a JS reduce.
+    pub concept_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LearnerProfileView {
+    pub id: Uuid,
+    pub name: String,
+    pub age: u8,
+    /// Locale pack id ("en", "de", ...).
+    pub locale: String,
+}
+
+/// One row in the vocab-due list.
+#[derive(Debug, Clone, Serialize)]
+pub struct DueConcept {
+    pub concept_id: String,
+    /// 0..=4 — number of filled dots to render. `4` is the 30-day box.
+    pub box_level: u8,
+    /// `UnderstandingDepth` variant name — useful when the sidebar
+    /// wants to show the depth alongside the dot row.
+    pub depth: String,
+    /// Days until the concept next becomes due. Negative = already
+    /// overdue by that many days. Floor so "due in 0.4 days" reads as
+    /// "due now" rather than "due tomorrow".
+    pub days_until_due: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DepthCount {
+    /// `UnderstandingDepth` variant name.
+    pub depth: String,
+    pub count: usize,
+}

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -42,7 +42,26 @@ const dom = {
     comprehensionList: document.getElementById("signals-comprehension-list"),
     comprehensionModel: document.getElementById("signals-comprehension-model"),
   },
+  learner: {
+    profileCard: document.getElementById("learner-profile-card"),
+    name: document.getElementById("learner-name"),
+    ageLocale: document.getElementById("learner-age-locale"),
+    uuid: document.getElementById("learner-uuid"),
+    uuidCopy: document.getElementById("learner-uuid-copy"),
+    vocabCard: document.getElementById("learner-vocab-card"),
+    vocabCount: document.getElementById("learner-vocab-count"),
+    vocabList: document.getElementById("learner-vocab-list"),
+    distributionCard: document.getElementById("learner-distribution-card"),
+    conceptCount: document.getElementById("learner-concept-count"),
+    depthBar: document.getElementById("learner-depth-bar"),
+    depthLegend: document.getElementById("learner-depth-legend"),
+    engagementCard: document.getElementById("learner-engagement-card"),
+    engagementStrip: document.getElementById("learner-engagement-strip"),
+  },
 };
+
+/// Maximum filled box dots — matches MAX_BOX_LEVEL in primer_core::vocab.
+const MAX_BOX_LEVEL = 4;
 
 // Live state — `streamingPrimerEl` points at the currently-streaming
 // Primer bubble (if any) so chunk events can append to its text node
@@ -60,10 +79,11 @@ async function main() {
   setupComposer();
   setupAutogrow();
   setupSidebarToggle();
+  setupUuidCopy();
   await openOrStartSession();
   // Render whatever's already on the DM (resumed sessions land here
   // with populated last_* accessors); first-launch shows the empty state.
-  refreshSignals();
+  refreshSidebar();
 }
 
 async function openOrStartSession() {
@@ -172,7 +192,7 @@ function setupTurnCompleteListener() {
     enableComposer();
     // Fire-and-forget — sidebar updates are non-critical; a failure
     // here shouldn't deny the user the chat surface.
-    refreshSignals();
+    refreshSidebar();
   });
 }
 
@@ -187,6 +207,13 @@ function setupSidebarToggle() {
   });
 }
 
+/// Refresh both sidebar sections (Current turn + Learner) in parallel.
+/// One IPC round-trip per section keeps the DM-lock duration small and
+/// lets the two sections fail independently.
+async function refreshSidebar() {
+  await Promise.all([refreshSignals(), refreshLearner()]);
+}
+
 async function refreshSignals() {
   try {
     const signals = await invoke("get_turn_signals");
@@ -194,6 +221,15 @@ async function refreshSignals() {
   } catch (err) {
     // Sidebar errors are non-critical — log but don't surface.
     console.warn("get_turn_signals failed:", err);
+  }
+}
+
+async function refreshLearner() {
+  try {
+    const snap = await invoke("get_learner_state");
+    renderLearner(snap);
+  } catch (err) {
+    console.warn("get_learner_state failed:", err);
   }
 }
 
@@ -296,6 +332,154 @@ function renderChips(ulEl, items) {
     li.textContent = item;
     ulEl.appendChild(li);
   }
+}
+
+function renderLearner(snap) {
+  const l = dom.learner;
+  if (!snap) {
+    l.profileCard.hidden = true;
+    l.vocabCard.hidden = true;
+    l.distributionCard.hidden = true;
+    l.engagementCard.hidden = true;
+    return;
+  }
+
+  // Profile
+  l.profileCard.hidden = false;
+  l.name.textContent = snap.profile.name;
+  l.ageLocale.textContent = `age ${snap.profile.age} · ${snap.profile.locale}`;
+  l.uuid.textContent = snap.profile.id;
+  l.uuid.dataset.uuid = snap.profile.id;
+
+  // Vocabulary
+  const due = snap.vocab_due ?? [];
+  if (snap.concept_count > 0) {
+    l.vocabCard.hidden = false;
+    l.vocabCount.textContent = `${due.length} due`;
+    l.vocabList.replaceChildren();
+    if (due.length === 0) {
+      const div = document.createElement("div");
+      div.className = "vocab-empty";
+      div.textContent = "Nothing's due — all concepts are within their review intervals.";
+      l.vocabList.appendChild(div);
+    } else {
+      for (const concept of due) {
+        l.vocabList.appendChild(renderVocabItem(concept));
+      }
+    }
+  } else {
+    l.vocabCard.hidden = true;
+  }
+
+  // Depth distribution
+  if (snap.concept_count > 0) {
+    l.distributionCard.hidden = false;
+    l.conceptCount.textContent = `${snap.concept_count} total`;
+    renderDepthBar(l.depthBar, snap.depth_distribution);
+    renderDepthLegend(l.depthLegend, snap.depth_distribution);
+  } else {
+    l.distributionCard.hidden = true;
+  }
+
+  // Recent engagement strip
+  const recent = snap.recent_engagement ?? [];
+  if (recent.length > 0) {
+    l.engagementCard.hidden = false;
+    l.engagementStrip.replaceChildren();
+    for (const state of recent) {
+      const dot = document.createElement("span");
+      dot.className = "dot";
+      dot.dataset.state = state.toLowerCase();
+      dot.title = state;
+      l.engagementStrip.appendChild(dot);
+    }
+  } else {
+    l.engagementCard.hidden = true;
+  }
+}
+
+function renderVocabItem(c) {
+  const li = document.createElement("li");
+  const concept = document.createElement("span");
+  concept.className = "concept";
+  concept.textContent = c.concept_id;
+  concept.title = `${c.concept_id} (${c.depth})`;
+  const dots = document.createElement("span");
+  dots.className = "box-dots";
+  dots.setAttribute("aria-label", `box level ${c.box_level} of ${MAX_BOX_LEVEL}`);
+  dots.textContent = renderBoxDots(c.box_level);
+  const when = document.createElement("span");
+  when.className = "due-when";
+  when.textContent = formatDueWhen(c.days_until_due);
+  when.dataset.overdue = String(c.days_until_due < 0);
+  li.appendChild(concept);
+  li.appendChild(dots);
+  li.appendChild(when);
+  return li;
+}
+
+function renderBoxDots(level) {
+  const filled = Math.max(0, Math.min(MAX_BOX_LEVEL, level));
+  return "●".repeat(filled) + "○".repeat(MAX_BOX_LEVEL - filled);
+}
+
+function formatDueWhen(days) {
+  if (days < 0) {
+    const n = -days;
+    return n === 1 ? "1 day late" : `${n} days late`;
+  }
+  if (days === 0) return "due now";
+  if (days === 1) return "due tmrw";
+  return `due ${days}d`;
+}
+
+function renderDepthBar(barEl, counts) {
+  barEl.replaceChildren();
+  const total = counts.reduce((s, r) => s + r.count, 0);
+  for (const row of counts) {
+    if (row.count === 0) continue;
+    const seg = document.createElement("span");
+    seg.className = "seg";
+    seg.dataset.depth = row.depth.toLowerCase();
+    seg.style.flexGrow = String(row.count);
+    seg.title = `${row.depth}: ${row.count} of ${total}`;
+    barEl.appendChild(seg);
+  }
+}
+
+function renderDepthLegend(legendEl, counts) {
+  legendEl.replaceChildren();
+  for (const row of counts) {
+    const li = document.createElement("li");
+    const swatch = document.createElement("span");
+    swatch.className = "swatch";
+    swatch.style.background = `var(--depth-${row.depth.toLowerCase()})`;
+    const label = document.createElement("span");
+    label.textContent = `${row.depth} · ${row.count}`;
+    li.appendChild(swatch);
+    li.appendChild(label);
+    legendEl.appendChild(li);
+  }
+}
+
+function setupUuidCopy() {
+  dom.learner.uuidCopy.addEventListener("click", async () => {
+    const uuid = dom.learner.uuid.dataset.uuid || dom.learner.uuid.textContent || "";
+    if (!uuid || uuid === "—") return;
+    try {
+      await navigator.clipboard.writeText(uuid);
+      dom.learner.uuidCopy.dataset.state = "copied";
+      dom.learner.uuidCopy.textContent = "Copied";
+      setTimeout(() => {
+        dom.learner.uuidCopy.dataset.state = "";
+        dom.learner.uuidCopy.textContent = "Copy";
+      }, 1400);
+    } catch (err) {
+      // Tauri's WebView clipboard is generally available; falling
+      // through is just a no-op for the rare case the API isn't.
+      console.warn("clipboard.writeText failed:", err);
+    }
+  });
 }
 
 function renderComprehensionItem(a) {

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -355,7 +355,9 @@ function renderLearner(snap) {
   const due = snap.vocab_due ?? [];
   if (snap.concept_count > 0) {
     l.vocabCard.hidden = false;
-    l.vocabCount.textContent = `${due.length} due`;
+    // Suppress the "0 due" pill when the list is empty — the inline
+    // empty-state message already says it more clearly.
+    l.vocabCount.textContent = due.length > 0 ? `${due.length} due` : "";
     l.vocabList.replaceChildren();
     if (due.length === 0) {
       const div = document.createElement("div");

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -128,6 +128,72 @@
           ></div>
         </div>
       </section>
+
+      <section class="sidebar-section" data-section="learner">
+        <header class="sidebar-section-header">
+          <h2>Learner</h2>
+        </header>
+
+        <div class="sidebar-card" id="learner-profile-card" hidden>
+          <div class="sidebar-card-label">Profile</div>
+          <div class="sidebar-card-body">
+            <div class="row" id="learner-profile-row">
+              <span class="learner-name" id="learner-name">—</span>
+              <span class="muted" id="learner-age-locale">—</span>
+            </div>
+            <div class="row uuid-row">
+              <code class="learner-uuid" id="learner-uuid">—</code>
+              <button
+                type="button"
+                class="copy-btn"
+                id="learner-uuid-copy"
+                title="Copy learner UUID"
+                aria-label="Copy learner UUID"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="sidebar-card" id="learner-vocab-card" hidden>
+          <div class="sidebar-card-label">
+            Vocabulary
+            <span class="muted vocab-count" id="learner-vocab-count"></span>
+          </div>
+          <div class="sidebar-card-body">
+            <ul class="vocab-list" id="learner-vocab-list"></ul>
+          </div>
+        </div>
+
+        <div class="sidebar-card" id="learner-distribution-card" hidden>
+          <div class="sidebar-card-label">
+            Concept depth
+            <span class="muted concept-count" id="learner-concept-count"></span>
+          </div>
+          <div class="sidebar-card-body">
+            <div
+              class="depth-bar"
+              id="learner-depth-bar"
+              role="img"
+              aria-label="Concept depth distribution"
+            ></div>
+            <ul class="depth-legend" id="learner-depth-legend"></ul>
+          </div>
+        </div>
+
+        <div class="sidebar-card" id="learner-engagement-card" hidden>
+          <div class="sidebar-card-label">Recent engagement</div>
+          <div class="sidebar-card-body">
+            <div
+              class="engagement-strip"
+              id="learner-engagement-strip"
+              role="img"
+              aria-label="Recent engagement state strip"
+            ></div>
+          </div>
+        </div>
+      </section>
     </aside>
 
     <script src="app.js"></script>

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -576,3 +576,212 @@ body.sidebar-collapsed .sidebar {
   background: color-mix(in oklab, var(--depth-analysis) 18%, transparent);
   color: var(--depth-analysis-fg);
 }
+
+/* ─── Learner section ───────────────────────────────────────────── */
+
+.learner-name {
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+.uuid-row {
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.learner-uuid {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Consolas,
+    monospace;
+  font-size: 0.72rem;
+  padding: 0.12rem 0.4rem;
+  background: color-mix(in oklab, var(--fg) 6%, transparent);
+  border-radius: 0.35rem;
+  letter-spacing: 0;
+  word-break: break-all;
+}
+
+.copy-btn {
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--border);
+  border-radius: 0.35rem;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: 0.72rem;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.copy-btn:hover {
+  background: color-mix(in oklab, var(--accent) 8%, var(--bg));
+}
+
+.copy-btn[data-state="copied"] {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.vocab-count,
+.concept-count {
+  margin-left: 0.4rem;
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.vocab-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.vocab-list li {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+}
+
+.vocab-list .concept {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.box-dots {
+  display: inline-flex;
+  gap: 0.12rem;
+  font-size: 0.62rem;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  line-height: 1;
+}
+
+.vocab-list .due-when {
+  font-size: 0.72rem;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 4.2rem;
+  text-align: right;
+}
+
+.vocab-list .due-when[data-overdue="true"] {
+  color: #b91c1c;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme: dark) {
+  .vocab-list .due-when[data-overdue="true"] {
+    color: #fda4af;
+  }
+}
+
+.vocab-empty {
+  font-size: 0.82rem;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
+/* Stacked horizontal depth-distribution bar. Each segment's flex-grow
+   is set inline from JS to the concept count, so empty depths
+   collapse to zero width and don't take visual space. Colours pull
+   from the same --depth-* variables the depth-pill uses, so the bar
+   and the pills stay in lockstep across light/dark themes. */
+.depth-bar {
+  display: flex;
+  width: 100%;
+  height: 0.7rem;
+  border-radius: 0.35rem;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--fg) 8%, transparent);
+}
+
+.depth-bar .seg {
+  height: 100%;
+  transition: flex-grow 220ms ease;
+}
+
+.depth-bar .seg[data-depth="unknown"] {
+  background: var(--depth-unknown);
+}
+.depth-bar .seg[data-depth="aware"] {
+  background: var(--depth-aware);
+}
+.depth-bar .seg[data-depth="recall"] {
+  background: var(--depth-recall);
+}
+.depth-bar .seg[data-depth="comprehension"] {
+  background: var(--depth-comprehension);
+}
+.depth-bar .seg[data-depth="application"] {
+  background: var(--depth-application);
+}
+.depth-bar .seg[data-depth="analysis"] {
+  background: var(--depth-analysis);
+}
+
+.depth-legend {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.7rem;
+  font-size: 0.72rem;
+  color: var(--fg-muted);
+}
+
+.depth-legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.depth-legend .swatch {
+  display: inline-block;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 0.15rem;
+}
+
+/* Engagement state dot strip — sparkline-style row of dots, each
+   coloured by the EngagementState variant name. Variant slugs match
+   EngagementState::name() lowercased. */
+.engagement-strip {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.engagement-strip .dot {
+  display: inline-block;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: color-mix(in oklab, var(--fg-muted) 35%, transparent);
+}
+
+.engagement-strip .dot[data-state="engaged"] {
+  background: #16a34a;
+}
+.engagement-strip .dot[data-state="reflecting"] {
+  background: #2563eb;
+}
+.engagement-strip .dot[data-state="frustratedstuck"] {
+  background: #dc2626;
+}
+.engagement-strip .dot[data-state="frustratedtrying"] {
+  background: #f97316;
+}
+.engagement-strip .dot[data-state="disengaging"] {
+  background: #a16207;
+}
+/* unknown / default: stays the muted base colour */


### PR DESCRIPTION
## Summary

Step 6 of 10. Adds the longitudinal **Learner** section below "Current turn" in the right-side sidebar: profile + UUID with copy button, vocabulary due-list with box-level dots and days-until-due, depth distribution as a stacked horizontal bar, recent engagement states as a sparkline dot strip.

### Backend
- **`LearnerSnapshot` DTO** ([types.rs](src/crates/primer-gui/src/types.rs)) bundles profile, `vocab_due` (top-8 via `primer_core::vocab::due_concepts`), `depth_distribution` (always six entries in canonical `UnderstandingDepth` order), `recent_engagement` (last 8, oldest-first), and `concept_count`.
- **`get_learner_state` Tauri command** ([commands/session.rs](src/crates/primer-gui/src/commands/session.rs)) — same one-DM-lock-per-refresh pattern as `get_turn_signals`; no `.await` inside the locked region.
- **`read_learner` extracted** as `pub(crate)` so step 7's session-turn rendering can reuse the snapshot shape.
- **Days-until-due** computed locally from `last_encountered + BOX_INTERVAL`, floored so "0.4 days" reads as "due now" not "due tomorrow".

### Frontend
- **Profile card** — name + age + locale + UUID with a copy button that flips to "Copied" for 1.4 s on click.
- **Vocab card** — top-N due concepts with `●●○○○` box-level dots and per-row "due tmrw" / "3d late" labels; overdue rows render red.
- **Depth distribution card** — stacked horizontal bar with segment widths proportional to count, coloured from the same `--depth-*` custom properties the depth-pills use (so the two views stay in lockstep across light/dark). Legend lists every depth with its count.
- **Recent engagement card** — sparkline dot strip, one dot per state, colour-coded by `EngagementState` variant; title attribute carries the variant name for accessibility.
- Single `refreshSidebar()` fans out two parallel IPC calls (signals + learner) — small per-section DM-lock duration, sections fail independently.

## Test plan

- [x] `cargo test -p primer-gui --lib` — 40 tests pass (2 new for `read_learner`)
- [x] `cargo clippy -p primer-gui --all-targets` — clean
- [x] 5s background-boot smoke: GUI renders chat + 2-section sidebar; auto-seed runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)