### PR TITLE
ci: install Tauri system deps on the Linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Tauri Linux system deps
+        # primer-gui depends on Tauri 2.x, which on Linux uses
+        # webkit2gtk for its webview. The dev headers and their
+        # transitive pkg-config files (glib-2.0, gtk, soup, etc.)
+        # aren't in the default ubuntu-latest image. libxdo-dev is
+        # required by tauri-runtime-wry for hotkey/clipboard;
+        # libayatana-appindicator3-dev is for tray. macOS uses Apple's
+        # WebKit framework directly so no equivalent step is needed
+        # there.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
       - name: Install Rust toolchain
         # rust-toolchain.toml lives at src/rust-toolchain.toml — pinned
         # to 1.87 + rustfmt + clippy. The action picks it up automatically


### PR DESCRIPTION
## Summary

- `cargo test (default features)` started failing on ubuntu-latest as soon as primer-gui (Tauri 2.x) joined the workspace — `glib-sys` can't find `glib-2.0.pc` because the dev headers aren't in the default runner image.
- Adds an apt-get step ahead of cache + clippy/test that installs `libwebkit2gtk-4.1-dev` (which pulls glib/gtk/soup transitively) plus the `libxdo-dev` / `libayatana-appindicator3-dev` / `librsvg2-dev` / `libssl-dev` helpers `tauri-runtime-wry` depends on.
- macOS uses Apple's WebKit framework directly, so no equivalent step is needed there.

## Test plan

- [ ] CI green on this PR (was red on every PR touching the workspace after primer-gui landed)
- [ ] Workflow run logs show the apt-get step completes and the subsequent `cargo clippy` / `cargo test` no longer fail at `glib-sys`'s build script

🤖 Generated with [Claude Code](https://claude.com/claude-code)