### PR TITLE
feat(gui): sidebar — Session turn list + click-to-scroll

### DIFF
--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -25,5 +25,6 @@ pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
         session::send_message,
         session::get_turn_signals,
         session::get_learner_state,
+        session::list_session_turns,
     ])
 }

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -209,9 +209,13 @@ pub(crate) fn read_turn_list(dm: &DialogueManager) -> Vec<SessionTurnSummary> {
 
 /// Canonical lowercase name for a `Speaker`. Mirrors the
 /// `EngagementState::name()` / `PedagogicalIntent::name()` convention
-/// used elsewhere in this crate so the frontend can lowercase the
-/// returned string for a `data-speaker` selector.
-fn speaker_name(s: primer_core::conversation::Speaker) -> &'static str {
+/// used elsewhere in this crate. The returned string flows out to the
+/// frontend via [`SessionTurnSummary::speaker`] and is consumed as a
+/// `[data-speaker=…]` selector hook; do not rename.
+///
+/// `Speaker` itself has no `name()` method (only `ALL`) so this helper
+/// lives here rather than on the core enum.
+pub(crate) fn speaker_name(s: primer_core::conversation::Speaker) -> &'static str {
     match s {
         primer_core::conversation::Speaker::Child => "child",
         primer_core::conversation::Speaker::Primer => "primer",

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -27,9 +27,15 @@ use primer_core::vocab::due_concepts;
 use crate::state::{ActiveSession, AppState, SessionSnapshot};
 use crate::types::{
     ChunkEvent, ComprehensionSummary, ConceptBreakdown, DepthCount, DueConcept, EngagementSummary,
-    LearnerProfileView, LearnerSnapshot, LearnerSummary, SessionInfo, TurnComplete, TurnSignals,
+    LearnerProfileView, LearnerSnapshot, LearnerSummary, SessionInfo, SessionTurnSummary,
+    TurnComplete, TurnSignals,
 };
 use crate::wiring;
+
+/// Maximum characters of turn text the sidebar's Session list shows
+/// inline. Chosen so a single row at the default sidebar width
+/// doesn't wrap — the full text is in the chat bubble and on disk.
+const TURN_TEXT_PREVIEW_CHARS: usize = 80;
 
 /// Construct an `ActiveSession` from the persisted settings and store
 /// it in `AppState`. Errors surface as `String` for inline rendering.
@@ -152,6 +158,77 @@ pub async fn get_learner_state(
 
     let dm = dm_arc.lock().await;
     Ok(Some(read_learner(&dm)))
+}
+
+/// Return the turn-by-turn list that the sidebar's "Session" section
+/// renders. Reads from the in-memory `dm.session.turns` — same source
+/// the chat bubbles render from — so the list is always consistent
+/// with what's on screen without round-tripping through the DB.
+///
+/// One DM-mutex lock per refresh, same pattern as the other sidebar
+/// readers. Returns `Ok(None)` when no session is active.
+#[tauri::command]
+pub async fn list_session_turns(
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<Vec<SessionTurnSummary>>, String> {
+    let session_guard = state.session.lock().await;
+    let active = match session_guard.as_ref() {
+        Some(a) => a,
+        None => return Ok(None),
+    };
+    let dm_arc = Arc::clone(&active.dialogue_manager);
+    drop(session_guard);
+
+    let dm = dm_arc.lock().await;
+    Ok(Some(read_turn_list(&dm)))
+}
+
+/// Pure shape mapping from a held DM into the sidebar turn list.
+/// Split out so a unit test can call it without a Tauri state.
+/// No `.await` — caller must already hold the DM lock.
+pub(crate) fn read_turn_list(dm: &DialogueManager) -> Vec<SessionTurnSummary> {
+    dm.session
+        .turns
+        .iter()
+        .enumerate()
+        .map(|(i, turn)| {
+            let (text_preview, truncated) =
+                truncate_to_preview(&turn.text, TURN_TEXT_PREVIEW_CHARS);
+            SessionTurnSummary {
+                index: i,
+                speaker: speaker_name(turn.speaker).to_string(),
+                text_preview,
+                truncated,
+                intent: turn.intent.map(|i| i.name().to_string()),
+                concepts: turn.concepts.clone(),
+                timestamp: turn.timestamp.to_rfc3339(),
+            }
+        })
+        .collect()
+}
+
+/// Canonical lowercase name for a `Speaker`. Mirrors the
+/// `EngagementState::name()` / `PedagogicalIntent::name()` convention
+/// used elsewhere in this crate so the frontend can lowercase the
+/// returned string for a `data-speaker` selector.
+fn speaker_name(s: primer_core::conversation::Speaker) -> &'static str {
+    match s {
+        primer_core::conversation::Speaker::Child => "child",
+        primer_core::conversation::Speaker::Primer => "primer",
+    }
+}
+
+/// Truncate `s` to at most `max_chars` *characters* (not bytes — never
+/// splits a multibyte codepoint). Adds an ellipsis when truncated.
+/// Returns `(preview, truncated)`.
+fn truncate_to_preview(s: &str, max_chars: usize) -> (String, bool) {
+    let count = s.chars().count();
+    if count <= max_chars {
+        (s.trim().to_string(), false)
+    } else {
+        let truncated: String = s.chars().take(max_chars).collect();
+        (format!("{}…", truncated.trim_end()), true)
+    }
 }
 
 /// Pure shape mapping from a held DM into a [`LearnerSnapshot`].
@@ -516,6 +593,71 @@ mod tests {
             loaded.turns.len() >= 2,
             "session must persist both the child and primer turns; got {} turns",
             loaded.turns.len()
+        );
+    }
+
+    #[test]
+    fn truncate_short_text_passes_through() {
+        let (preview, truncated) = truncate_to_preview("hello", 80);
+        assert_eq!(preview, "hello");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_long_text_adds_ellipsis() {
+        let s = "a".repeat(200);
+        let (preview, truncated) = truncate_to_preview(&s, 80);
+        assert!(truncated);
+        assert!(preview.ends_with('…'));
+        // 80 a's + ellipsis = 81 chars
+        assert_eq!(preview.chars().count(), 81);
+    }
+
+    #[test]
+    fn truncate_respects_codepoint_boundaries() {
+        // A run of multibyte characters; max_chars is a *char* limit,
+        // so we must not split a codepoint.
+        let s = "🌟".repeat(10); // 10 chars, 40 bytes
+        let (preview, truncated) = truncate_to_preview(&s, 5);
+        assert!(truncated);
+        // 5 stars + ellipsis = 6 chars
+        assert_eq!(preview.chars().count(), 6);
+        assert!(preview.starts_with("🌟🌟🌟🌟🌟"));
+    }
+
+    #[tokio::test]
+    async fn read_turn_list_empty_for_fresh_session() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm = active.dialogue_manager.lock().await;
+        let list = read_turn_list(&dm);
+        assert!(list.is_empty(), "no turns before first send_message");
+    }
+
+    #[tokio::test]
+    async fn read_turn_list_after_one_exchange() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm_arc = Arc::clone(&active.dialogue_manager);
+
+        run_turn(&dm_arc, "hello", |_, _| {}).await.unwrap();
+
+        let dm = dm_arc.lock().await;
+        let list = read_turn_list(&dm);
+        assert_eq!(list.len(), 2, "one exchange = child + primer turns");
+        assert_eq!(list[0].index, 0);
+        assert_eq!(list[0].speaker, "child");
+        assert_eq!(list[0].text_preview, "hello");
+        assert!(!list[0].truncated);
+        assert!(list[0].intent.is_none(), "child turns have no intent");
+
+        assert_eq!(list[1].index, 1);
+        assert_eq!(list[1].speaker, "primer");
+        assert!(
+            list[1].intent.is_some(),
+            "primer turn carries the decided intent"
         );
     }
 

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -224,3 +224,42 @@ pub struct DepthCount {
     pub depth: String,
     pub count: usize,
 }
+
+/// One row in the sidebar's "Session" turn-by-turn list.
+///
+/// Returned by `list_session_turns`; the frontend renders the list
+/// once on session start and updates it after each `primer://turn_complete`.
+/// Click-to-scroll uses [`Self::index`] as the
+/// `data-turn-index` selector on the matching chat bubble.
+///
+/// Lightweight by design — `text_preview` is truncated server-side
+/// so big sessions don't blow up the IPC payload. The full turn text
+/// is still on disk via `SessionStore::load_session` for any future
+/// "Inspect turn N" panel.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionTurnSummary {
+    /// Zero-based index in the session's turn timeline. Matches
+    /// [`TurnComplete::child_turn_index`] / `primer_turn_index`.
+    pub index: usize,
+    /// `Speaker::name()` — `"child"` or `"primer"`. The frontend lowercases
+    /// for a `data-speaker` selector; keep in sync with [`primer_core::conversation::Speaker::name`].
+    pub speaker: String,
+    /// Truncated turn text — server-side cap matches the sidebar's
+    /// visual budget for an at-a-glance scan. The full text is in the
+    /// rendered chat bubble; this is just the row label.
+    pub text_preview: String,
+    /// `true` when the original text was truncated. Useful for the
+    /// frontend's tooltip ("…") or for a future "expand" affordance.
+    pub truncated: bool,
+    /// `PedagogicalIntent::name()` from the turn's stored intent. `None` for
+    /// child turns and for any Primer turn whose intent was never set
+    /// (only `open_session`'s greeting hits that today).
+    pub intent: Option<String>,
+    /// Concepts that the extractor backfilled onto this turn. Stable
+    /// for past turns; an in-flight current-turn entry shows what the
+    /// extractor has surfaced so far (may grow on subsequent refresh).
+    pub concepts: Vec<String>,
+    /// Wallclock at which the turn landed. Surfaced as an ISO-8601
+    /// string so the frontend can format relatively without parsing.
+    pub timestamp: String,
+}

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -241,8 +241,9 @@ pub struct SessionTurnSummary {
     /// Zero-based index in the session's turn timeline. Matches
     /// [`TurnComplete::child_turn_index`] / `primer_turn_index`.
     pub index: usize,
-    /// `Speaker::name()` — `"child"` or `"primer"`. The frontend lowercases
-    /// for a `data-speaker` selector; keep in sync with [`primer_core::conversation::Speaker::name`].
+    /// Stable lowercase identifier — `"child"` or `"primer"` — produced
+    /// by `commands::session::speaker_name`. Used directly as a
+    /// `[data-speaker=…]` selector hook on the frontend; do not rename.
     pub speaker: String,
     /// Truncated turn text — server-side cap matches the sidebar's
     /// visual budget for an at-a-glance scan. The full text is in the

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -58,6 +58,11 @@ const dom = {
     engagementCard: document.getElementById("learner-engagement-card"),
     engagementStrip: document.getElementById("learner-engagement-strip"),
   },
+  session: {
+    empty: document.getElementById("session-empty"),
+    hint: document.getElementById("session-list-hint"),
+    list: document.getElementById("session-turn-list"),
+  },
 };
 
 /// Maximum filled box dots — matches MAX_BOX_LEVEL in primer_core::vocab.
@@ -69,6 +74,11 @@ const MAX_BOX_LEVEL = 4;
 const state = {
   sessionId: null,
   streamingPrimerEl: null,
+  /// Next zero-based turn index in the session timeline. Grows by 2
+  /// per exchange (child + primer). Used to tag bubble DOM elements
+  /// with `data-turn-index` so the Session sidebar's click-to-scroll
+  /// can address them in O(1).
+  nextTurnIndex: 0,
 };
 
 main();
@@ -207,11 +217,11 @@ function setupSidebarToggle() {
   });
 }
 
-/// Refresh both sidebar sections (Current turn + Learner) in parallel.
-/// One IPC round-trip per section keeps the DM-lock duration small and
-/// lets the two sections fail independently.
+/// Refresh every sidebar section in parallel. One IPC round-trip per
+/// section keeps the DM-lock duration small (each is a brief read,
+/// not a stream) and lets the sections fail independently.
 async function refreshSidebar() {
-  await Promise.all([refreshSignals(), refreshLearner()]);
+  await Promise.all([refreshSignals(), refreshLearner(), refreshTurnList()]);
 }
 
 async function refreshSignals() {
@@ -231,6 +241,107 @@ async function refreshLearner() {
   } catch (err) {
     console.warn("get_learner_state failed:", err);
   }
+}
+
+async function refreshTurnList() {
+  try {
+    const list = await invoke("list_session_turns");
+    renderTurnList(list);
+  } catch (err) {
+    console.warn("list_session_turns failed:", err);
+  }
+}
+
+function renderTurnList(list) {
+  const s = dom.session;
+  const turns = list ?? [];
+  if (turns.length === 0) {
+    s.list.hidden = true;
+    s.list.replaceChildren();
+    s.empty.hidden = false;
+    s.hint.hidden = true;
+    return;
+  }
+  s.empty.hidden = true;
+  s.list.hidden = false;
+  s.hint.hidden = false;
+  s.list.replaceChildren(...turns.map(renderTurnRow));
+}
+
+function renderTurnRow(turn) {
+  // Use a <button> inside <li> so the row is keyboard-focusable and
+  // announced as an interactive element rather than plain text.
+  const li = document.createElement("li");
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "turn-row";
+  btn.dataset.turnIndex = String(turn.index);
+  btn.dataset.speaker = String(turn.speaker || "").toLowerCase();
+  btn.setAttribute(
+    "aria-label",
+    `Turn ${turn.index + 1}, ${turn.speaker}: ${turn.text_preview}`,
+  );
+
+  const idxEl = document.createElement("span");
+  idxEl.className = "turn-index";
+  idxEl.textContent = `T${turn.index + 1}`;
+
+  const speakerEl = document.createElement("span");
+  speakerEl.className = "turn-speaker";
+  speakerEl.textContent = turn.speaker;
+
+  const previewEl = document.createElement("span");
+  previewEl.className = "turn-preview";
+
+  const textEl = document.createElement("span");
+  textEl.className = "turn-text";
+  textEl.textContent = turn.text_preview;
+  if (turn.truncated) {
+    textEl.title = `${turn.text_preview} (truncated)`;
+  }
+  previewEl.appendChild(textEl);
+
+  const intent = turn.intent;
+  const conceptCount = Array.isArray(turn.concepts) ? turn.concepts.length : 0;
+  if (intent || conceptCount > 0) {
+    const meta = document.createElement("span");
+    meta.className = "turn-meta";
+    if (intent) {
+      const intentBadge = document.createElement("span");
+      intentBadge.className = "turn-intent";
+      intentBadge.textContent = intent;
+      meta.appendChild(intentBadge);
+    }
+    if (conceptCount > 0) {
+      const conceptEl = document.createElement("span");
+      conceptEl.className = "turn-concept-count";
+      conceptEl.textContent =
+        conceptCount === 1 ? "1 concept" : `${conceptCount} concepts`;
+      meta.appendChild(conceptEl);
+    }
+    previewEl.appendChild(meta);
+  }
+
+  btn.appendChild(idxEl);
+  btn.appendChild(speakerEl);
+  btn.appendChild(previewEl);
+  btn.addEventListener("click", () => scrollChatToTurn(turn.index));
+  li.appendChild(btn);
+  return li;
+}
+
+/// Scroll the main chat scroll area to the bubble matching the given
+/// turn index, then briefly outline it so the user can find it. The
+/// bubbles are tagged at append-time with `data-turn-index`; this is
+/// a direct DOM query, no per-row event-listener bookkeeping needed.
+function scrollChatToTurn(index) {
+  const row = dom.chatScroll.querySelector(
+    `.bubble-row[data-turn-index="${index}"]`,
+  );
+  if (!row) return;
+  row.scrollIntoView({ behavior: "smooth", block: "center" });
+  row.classList.add("is-spotlight");
+  setTimeout(() => row.classList.remove("is-spotlight"), 1600);
 }
 
 function renderSignals(signals) {
@@ -510,6 +621,8 @@ function renderComprehensionItem(a) {
 function appendChildBubble(text) {
   const row = document.createElement("div");
   row.className = "bubble-row is-child";
+  row.dataset.turnIndex = String(state.nextTurnIndex);
+  state.nextTurnIndex += 1;
   const bubble = document.createElement("div");
   bubble.className = "bubble";
   bubble.textContent = text;
@@ -521,6 +634,8 @@ function appendChildBubble(text) {
 function appendStreamingPrimerBubble() {
   const row = document.createElement("div");
   row.className = "bubble-row is-primer";
+  row.dataset.turnIndex = String(state.nextTurnIndex);
+  state.nextTurnIndex += 1;
   const bubble = document.createElement("div");
   bubble.className = "bubble is-streaming";
   bubble.textContent = "";

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -75,10 +75,16 @@ const state = {
   sessionId: null,
   streamingPrimerEl: null,
   /// Next zero-based turn index in the session timeline. Grows by 2
-  /// per exchange (child + primer). Used to tag bubble DOM elements
-  /// with `data-turn-index` so the Session sidebar's click-to-scroll
-  /// can address them in O(1).
+  /// per successful exchange (child + primer) and rolls back by 1 on a
+  /// mid-stream error (the dropped Primer turn — see CLAUDE.md
+  /// "the partial Primer turn is not recorded into the session"). Used
+  /// to tag bubble DOM elements with `data-turn-index` so the Session
+  /// sidebar's click-to-scroll can address them in O(1).
   nextTurnIndex: 0,
+  /// setTimeout id for the spotlight-clear on click-to-scroll. Tracked
+  /// so a second click within the highlight window cancels the prior
+  /// timeout instead of letting it strip the new target's highlight.
+  spotlightTimer: null,
 };
 
 main();
@@ -177,6 +183,10 @@ async function onSubmit(e) {
     finaliseStreamingBubble({ aborted: true });
     showError(formatErr(err));
     enableComposer();
+    // Backend kept the child turn even on mid-stream failure; refresh
+    // the sidebar so the Session list reflects it. turn_complete never
+    // fired, so the standard refresh path didn't run.
+    refreshSidebar();
   }
 }
 
@@ -276,7 +286,10 @@ function renderTurnRow(turn) {
   btn.type = "button";
   btn.className = "turn-row";
   btn.dataset.turnIndex = String(turn.index);
-  btn.dataset.speaker = String(turn.speaker || "").toLowerCase();
+  // Backend serialises `Speaker` as lowercase `"child"` / `"primer"`
+  // via `speaker_name` in commands/session.rs — used as a `[data-speaker=…]`
+  // selector hook in styles.css.
+  btn.dataset.speaker = turn.speaker;
   btn.setAttribute(
     "aria-label",
     `Turn ${turn.index + 1}, ${turn.speaker}: ${turn.text_preview}`,
@@ -302,7 +315,7 @@ function renderTurnRow(turn) {
   previewEl.appendChild(textEl);
 
   const intent = turn.intent;
-  const conceptCount = Array.isArray(turn.concepts) ? turn.concepts.length : 0;
+  const conceptCount = turn.concepts.length;
   if (intent || conceptCount > 0) {
     const meta = document.createElement("span");
     meta.className = "turn-meta";
@@ -332,16 +345,30 @@ function renderTurnRow(turn) {
 
 /// Scroll the main chat scroll area to the bubble matching the given
 /// turn index, then briefly outline it so the user can find it. The
-/// bubbles are tagged at append-time with `data-turn-index`; this is
-/// a direct DOM query, no per-row event-listener bookkeeping needed.
+/// bubbles carry `data-turn-index` from append-time (with a roll-back
+/// path on mid-stream error so indices stay aligned with the backend's
+/// session turns); this is a direct DOM query, no per-row
+/// event-listener bookkeeping needed.
 function scrollChatToTurn(index) {
   const row = dom.chatScroll.querySelector(
     `.bubble-row[data-turn-index="${index}"]`,
   );
   if (!row) return;
   row.scrollIntoView({ behavior: "smooth", block: "center" });
+  // Cancel any in-flight spotlight before scheduling this one so a
+  // rapid click sequence within the 1.6 s highlight window doesn't
+  // let an earlier timeout strip the new target's highlight.
+  if (state.spotlightTimer !== null) {
+    clearTimeout(state.spotlightTimer);
+    dom.chatScroll
+      .querySelectorAll(".bubble-row.is-spotlight")
+      .forEach((r) => r.classList.remove("is-spotlight"));
+  }
   row.classList.add("is-spotlight");
-  setTimeout(() => row.classList.remove("is-spotlight"), 1600);
+  state.spotlightTimer = setTimeout(() => {
+    row.classList.remove("is-spotlight");
+    state.spotlightTimer = null;
+  }, 1600);
 }
 
 function renderSignals(signals) {
@@ -649,11 +676,24 @@ function finaliseStreamingBubble({ aborted }) {
   const el = state.streamingPrimerEl;
   if (!el) return;
   el.classList.remove("is-streaming");
-  if (aborted && el.textContent.trim() === "") {
-    // Empty-aborted: drop the placeholder rather than leaving a blank
-    // Primer bubble. Matches DM's "partial Primer turn dropped on
-    // mid-stream error" semantic.
-    el.parentElement?.remove();
+  if (aborted) {
+    // The partial Primer turn is never persisted (CLAUDE.md: "On a
+    // mid-stream error, the partial Primer turn is not recorded into
+    // the session"). Roll back the index we provisionally claimed in
+    // `appendStreamingPrimerBubble` so the next exchange's bubbles
+    // realign with backend `session.turns` indices; otherwise the
+    // Session-sidebar click-to-scroll would target the wrong bubble.
+    state.nextTurnIndex -= 1;
+    if (el.textContent.trim() === "") {
+      // Empty-aborted: drop the placeholder entirely.
+      el.parentElement?.remove();
+    } else {
+      // Non-empty partial: keep the visible text (the child saw it)
+      // but strip its data-turn-index — there's no backend turn for
+      // this bubble to be addressed by, and leaving the attribute on
+      // would collide with the next exchange's primer bubble.
+      el.parentElement?.removeAttribute("data-turn-index");
+    }
   }
   state.streamingPrimerEl = null;
 }

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -194,6 +194,26 @@
           </div>
         </div>
       </section>
+
+      <section class="sidebar-section" data-section="session">
+        <header class="sidebar-section-header">
+          <h2>Session</h2>
+          <span class="sidebar-section-hint muted" id="session-list-hint" hidden>
+            Click any row to scroll the chat to that turn.
+          </span>
+        </header>
+
+        <div class="sidebar-empty" id="session-empty">
+          <p>The turn-by-turn timeline appears here after the first exchange.</p>
+        </div>
+
+        <ol
+          class="turn-list"
+          id="session-turn-list"
+          aria-label="Turn-by-turn session timeline"
+          hidden
+        ></ol>
+      </section>
     </aside>
 
     <script src="app.js"></script>

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -785,3 +785,115 @@ body.sidebar-collapsed .sidebar {
   background: #a16207;
 }
 /* unknown / default: stays the muted base colour */
+
+/* ─── Session timeline list ─────────────────────────────────────── */
+
+.turn-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.turn-list .turn-row {
+  display: grid;
+  grid-template-columns: 1.6rem auto 1fr;
+  align-items: baseline;
+  gap: 0.45rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 0.45rem;
+  background: var(--bg);
+  text-align: left;
+  font: inherit;
+  font-size: 0.83rem;
+  color: var(--fg);
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.turn-list .turn-row:hover {
+  background: color-mix(in oklab, var(--accent) 6%, var(--bg));
+  border-color: color-mix(in oklab, var(--accent) 30%, var(--border));
+}
+
+.turn-list .turn-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.turn-list .turn-row[data-speaker="child"] {
+  border-left: 3px solid var(--bubble-child-bg);
+}
+
+.turn-list .turn-row[data-speaker="primer"] {
+  border-left: 3px solid color-mix(in oklab, var(--fg) 40%, transparent);
+}
+
+.turn-list .turn-index {
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+}
+
+.turn-list .turn-speaker {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.turn-list .turn-row[data-speaker="child"] .turn-speaker {
+  color: var(--bubble-child-bg);
+}
+
+.turn-list .turn-preview {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.turn-list .turn-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.turn-list .turn-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+}
+
+.turn-list .turn-intent {
+  display: inline-block;
+  padding: 0 0.4rem;
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+  color: var(--accent);
+  border-radius: 0.3rem;
+  font-weight: 500;
+}
+
+.turn-list .turn-concept-count::before {
+  content: "•";
+  margin-right: 0.2rem;
+}
+
+/* Highlight the bubble we just scrolled to so the user can find it
+   after the click. Added in JS for a short window then removed. */
+.bubble-row.is-spotlight .bubble {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  transition: outline-color 600ms ease;
+}


### PR DESCRIPTION
## Summary

Step 7 of 10. Adds the third sidebar section: a turn-by-turn list of the active Session, with click-to-scroll that jumps the chat to the matching bubble and briefly outlines it.

### Scope decision

The plan also called for time-travel to **swap the Current-turn pane** to show that turn's stored signals. Per-turn engagement / comprehension live in `turn_classifications` / `turn_comprehensions` — surfacing them needs new `SessionStore` methods that aren't on the trait yet. Step 7 ships the list + scroll affordance (high-value, self-contained); per-turn signal time-travel is a candidate follow-up.

### Backend
- **`SessionTurnSummary` DTO** ([types.rs](src/crates/primer-gui/src/types.rs)) — index / speaker / preview / intent / concepts / ISO timestamp.
- **`list_session_turns` Tauri command** ([commands/session.rs](src/crates/primer-gui/src/commands/session.rs)) — same one-DM-lock-per-refresh pattern as the other readers; walks `dm.session.turns` (no DB round-trip — the in-memory session stays consistent with the rendered bubbles).
- **`truncate_to_preview`** is char-count-aware (not byte-aware) so an emoji-heavy turn never splits a multibyte sequence.
- **`speaker_name` helper** — `Speaker` lacks a `name()` method in `primer-core`; added a local match.

### Frontend
- New **Session** section (third, below Learner) with empty state + hint copy ("Click any row to scroll the chat to that turn.").
- Each row is a `<button>` inside an `<ol>` so the row is keyboard-focusable and announced as interactive. Layout: `T# / SPEAKER / preview + meta (intent badge + concept count)`. Left-border colour-coded by speaker for at-a-glance scanning.
- Bubbles tagged with `data-turn-index` at append-time; `state.nextTurnIndex` increments by 2 per exchange. Click queries the matching bubble and scrolls it into view with `behavior: smooth, block: center`; a 1.6 s `.is-spotlight` outline highlights the destination.
- `refreshSidebar` now fans out **three** parallel IPC calls (signals + learner + turn list) rather than two; sections still fail independently.

## Test plan

- [x] `cargo test -p primer-gui --lib` — 46 tests pass (5 new: truncate edge cases + populated/empty turn-list tests)
- [x] `cargo clippy -p primer-gui --all-targets` — clean
- [x] 5s background-boot smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)