### PR TITLE
feat(gui): session picker launch screen + resume by UUID

### DIFF
--- a/src/crates/primer-cli/src/main.rs
+++ b/src/crates/primer-cli/src/main.rs
@@ -53,7 +53,7 @@ struct Cli {
     ollama_url: String,
 
     /// Child's name (for the learner profile).
-    #[arg(long, default_value = "Explorer")]
+    #[arg(long, default_value = primer_core::consts::learner::DEFAULT_NAME)]
     name: String,
 
     /// Child's age in years.

--- a/src/crates/primer-core/src/consts.rs
+++ b/src/crates/primer-core/src/consts.rs
@@ -161,3 +161,19 @@ pub mod retrieval {
     /// `docs/superpowers/specs/2026-05-06-retrieval-tuning-design.md`.
     pub const KB_BM25_ONLY_MIN_SCORE: f64 = 0.5;
 }
+
+/// Defaults shared across the CLI, GUI, and frontend for the learner
+/// profile. Kept here so a brand-new install behaves identically across
+/// every entry point — and so the JS picker has a documented Rust
+/// source of truth to mirror.
+pub mod learner {
+    /// Placeholder name a fresh learner profile carries until the user
+    /// supplies their own. Used as both:
+    /// - the CLI's `--name` default
+    /// - the GUI's `LearnerConfig::default().name`
+    /// - the JS picker's "is the name still the default?" check (it
+    ///   suppresses the personalised "Welcome back, {name}" greeting
+    ///   for unconfigured installs). The JS side mirrors this literal;
+    ///   keep them in sync when changing.
+    pub const DEFAULT_NAME: &str = "Explorer";
+}

--- a/src/crates/primer-core/src/conversation.rs
+++ b/src/crates/primer-core/src/conversation.rs
@@ -154,6 +154,26 @@ impl Session {
     }
 }
 
+/// Lightweight session metadata for picker / index views.
+///
+/// Held outside `Session` because consumers (the GUI's session picker
+/// today; potentially a CLI `--list-sessions` flag tomorrow) want
+/// per-row aggregates — turn count, last activity — without paying the
+/// cost of materializing every `Turn`. `SessionStore::list_sessions`
+/// returns a `Vec<SessionListing>` ordered most-recent-activity first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionListing {
+    pub id: SessionId,
+    pub learner_id: LearnerId,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    /// Max(turns.timestamp) or `started_at` if no turns exist yet.
+    pub last_activity: DateTime<Utc>,
+    pub turn_count: usize,
+    /// Rolling LLM summary; may be empty for short / fresh sessions.
+    pub summary: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/crates/primer-core/src/storage.rs
+++ b/src/crates/primer-core/src/storage.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::classifier::EngagementAssessment;
 use crate::comprehension::ComprehensionAssessment;
-use crate::conversation::{Session, SessionId, Turn};
+use crate::conversation::{Session, SessionId, SessionListing, Turn};
 use crate::embedder::Embedder;
 use crate::error::Result;
 use crate::knowledge::HybridParams;
@@ -103,6 +103,20 @@ pub trait SessionStore: Send + Sync {
     /// Returns `Ok(None)` for a DB with no sessions. Reserves `Err` for
     /// genuine I/O / decoding failures.
     async fn most_recent_session_learner_id(&self) -> Result<Option<Uuid>>;
+
+    /// List every session in this DB as a lightweight aggregate:
+    /// id, learner_id, started_at, ended_at, last_activity, turn_count,
+    /// summary. Ordered most-recent-activity first (i.e. by
+    /// `COALESCE(MAX(turns.timestamp), started_at) DESC`) so a picker
+    /// view can render rows in the user-natural order with no further
+    /// sorting.
+    ///
+    /// Returns an empty `Vec` for a fresh DB; reserves `Err` for
+    /// genuine I/O failure. Implementations should compute the
+    /// aggregates in SQL — a child of 8 will not have thousands of
+    /// sessions in their lifetime, but loading each `Session` in full
+    /// just to count turns and skim the summary is still wasteful.
+    async fn list_sessions(&self) -> Result<Vec<SessionListing>>;
 
     /// Add concepts to a previously-persisted turn. Resolves
     /// `(session_id, turn_index)` → `turn_id` internally; lazily creates

--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -21,10 +21,13 @@ pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
         settings::update_settings,
         session::start_session,
         session::close_session,
+        session::resume_session,
+        session::list_sessions,
         session::current_session_info,
         session::send_message,
         session::get_turn_signals,
         session::get_learner_state,
         session::list_session_turns,
+        session::get_full_session_turns,
     ])
 }

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -27,8 +27,8 @@ use primer_core::vocab::due_concepts;
 use crate::state::{ActiveSession, AppState, SessionSnapshot};
 use crate::types::{
     ChunkEvent, ComprehensionSummary, ConceptBreakdown, DepthCount, DueConcept, EngagementSummary,
-    LearnerProfileView, LearnerSnapshot, LearnerSummary, SessionInfo, SessionTurnSummary,
-    TurnComplete, TurnSignals,
+    LearnerProfileView, LearnerSnapshot, LearnerSummary, SessionFullTurn, SessionInfo,
+    SessionListingDto, SessionTurnSummary, TurnComplete, TurnSignals,
 };
 use crate::wiring;
 
@@ -64,6 +64,114 @@ pub async fn start_session(state: tauri::State<'_, AppState>) -> Result<SessionI
 #[tauri::command]
 pub async fn close_session(state: tauri::State<'_, AppState>) -> Result<(), String> {
     close_session_inner(&state).await
+}
+
+/// Resume a previously-saved session by UUID, replacing any active one.
+///
+/// Drops any current session (drains its background tasks first), then
+/// builds a fresh `ActiveSession` from the persisted GuiConfig, loads
+/// the named session from disk, and applies it via
+/// `DialogueManager::resume_session` — which refreshes the rolling
+/// summary if it's stale and rehydrates the classifier trajectory.
+///
+/// Errors:
+/// - `session_id` not a valid UUID → inline error.
+/// - No session with that id on disk → "session not found" error.
+/// - Construction failure (locale, embedder, etc.) → wiring-level error.
+#[tauri::command]
+pub async fn resume_session(
+    state: tauri::State<'_, AppState>,
+    session_id: String,
+) -> Result<SessionInfo, String> {
+    let uuid = Uuid::parse_str(&session_id)
+        .map_err(|e| format!("invalid session id {session_id:?}: {e}"))?;
+
+    close_session_inner(&state).await?;
+
+    let cfg = state.config.lock().await.clone();
+    let active = wiring::build_active_session(&state.home, &cfg).await?;
+
+    let loaded = active
+        .session_store
+        .load_session(uuid)
+        .await
+        .map_err(|e| format!("load_session failed: {e}"))?
+        .ok_or_else(|| format!("no session found with id {uuid}"))?;
+
+    // Replace DM's freshly-minted session with the loaded one. After
+    // this returns, dm.session.id == uuid and recent_assessments are
+    // hydrated for the just-resumed session.
+    active
+        .dialogue_manager
+        .lock()
+        .await
+        .resume_session(loaded)
+        .await
+        .map_err(|e| format!("resume_session failed: {e}"))?;
+
+    // Snapshot was built with session_id = None at construction.
+    // Refresh it now so current_session_info reports the resumed id.
+    refresh_snapshot(&active.dialogue_manager, &active.snapshot).await;
+
+    let info = info_from(&active).await;
+    *state.session.lock().await = Some(active);
+    Ok(info)
+}
+
+/// List every persisted session for the picker view.
+///
+/// Opens a transient `SqliteSessionStore` against the configured
+/// session-DB path (or the per-learner default) and runs
+/// `list_sessions`. Returns an empty Vec when:
+/// - `persistence.no_persist == true` (no on-disk store exists)
+/// - the resolved DB file doesn't exist yet (fresh install, never
+///   started a session)
+///
+/// Doesn't reuse a running session's store: list_sessions is invoked
+/// from the launch picker, before any session is active. Opening a
+/// fresh connection per call is fine — SQLite read-only opens are
+/// microseconds, and the picker is a once-per-launch surface.
+#[tauri::command]
+pub async fn list_sessions(
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<SessionListingDto>, String> {
+    use primer_core::i18n::Locale;
+    use primer_core::storage::SessionStore;
+
+    let cfg = state.config.lock().await.clone();
+    if cfg.persistence.no_persist {
+        return Ok(Vec::new());
+    }
+    let session_path = primer_engine::resolve_session_db_path(
+        cfg.persistence.session_db.clone(),
+        &state.home,
+        &cfg.learner.name,
+        cfg.persistence.no_persist,
+    );
+    // Fresh install / never-saved-yet: nothing to list. Don't create
+    // the file on a read.
+    if !session_path.exists() {
+        return Ok(Vec::new());
+    }
+    let locale = Locale::from_pack_id(&cfg.learner.locale).unwrap_or_default();
+    let store = primer_storage::SqliteSessionStore::open_for_locale(&session_path, locale)
+        .map_err(|e| format!("opening session-db {}: {e}", session_path.display()))?;
+    let listings = store
+        .list_sessions()
+        .await
+        .map_err(|e| format!("list_sessions failed: {e}"))?;
+    Ok(listings
+        .into_iter()
+        .map(|l| SessionListingDto {
+            session_id: l.id,
+            learner_id: l.learner_id,
+            started_at: l.started_at.to_rfc3339(),
+            ended_at: l.ended_at.map(|t| t.to_rfc3339()),
+            last_activity: l.last_activity.to_rfc3339(),
+            turn_count: l.turn_count,
+            summary: l.summary,
+        })
+        .collect())
 }
 
 /// Return a summary of the active session, or `None` if no session is
@@ -158,6 +266,40 @@ pub async fn get_learner_state(
 
     let dm = dm_arc.lock().await;
     Ok(Some(read_learner(&dm)))
+}
+
+/// Return every turn in the active session with FULL text — for the
+/// chat-replay path after `resume_session` populates DM with a loaded
+/// `Session`. Distinct from `list_session_turns` (truncated, for the
+/// sidebar) so the sidebar's per-turn-complete refresh doesn't ship
+/// every full-text turn across IPC on every update.
+///
+/// Returns `Ok(None)` when no session is active.
+#[tauri::command]
+pub async fn get_full_session_turns(
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<Vec<SessionFullTurn>>, String> {
+    let session_guard = state.session.lock().await;
+    let active = match session_guard.as_ref() {
+        Some(a) => a,
+        None => return Ok(None),
+    };
+    let dm_arc = Arc::clone(&active.dialogue_manager);
+    drop(session_guard);
+
+    let dm = dm_arc.lock().await;
+    let turns = dm
+        .session
+        .turns
+        .iter()
+        .enumerate()
+        .map(|(i, t)| SessionFullTurn {
+            index: i,
+            speaker: speaker_name(t.speaker).to_string(),
+            text: t.text.clone(),
+        })
+        .collect();
+    Ok(Some(turns))
 }
 
 /// Return the turn-by-turn list that the sidebar's "Session" section
@@ -565,6 +707,92 @@ mod tests {
             "child #2 lands after first exchange"
         );
         assert_eq!(second.primer_turn_index, 3, "primer #2 lands at index 3");
+    }
+
+    #[tokio::test]
+    async fn resume_path_swaps_dm_session_to_loaded_one() {
+        // Models the resume_session command: build active, run a turn
+        // to land a session row, drop, build a second active (which
+        // mints a fresh session), then load + resume to swap DM's
+        // session in place. End state: dm.session.id matches the
+        // originally-persisted id.
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+
+        // First active: run one turn so a session row exists on disk.
+        let first_active = build_active_session(home.path(), &cfg).await.unwrap();
+        let first_dm = Arc::clone(&first_active.dialogue_manager);
+        let payload = run_turn(&first_dm, "hello", |_, _| {}).await.unwrap();
+        let original_id = payload.session_id;
+        // Drain background tasks before drop so the row is committed.
+        first_dm.lock().await.close_session().await;
+        drop(first_active);
+
+        // Second active: brand-new DM, brand-new minted session id.
+        let second_active = build_active_session(home.path(), &cfg).await.unwrap();
+        let fresh_id_before_resume = second_active.dialogue_manager.lock().await.session.id;
+        assert_ne!(
+            fresh_id_before_resume, original_id,
+            "fresh build mints a fresh session id"
+        );
+
+        // Resume: load the original session via the stored Arc, then
+        // swap it in via DM::resume_session. After this the DM is
+        // logically continuing the persisted conversation.
+        let loaded = second_active
+            .session_store
+            .load_session(original_id)
+            .await
+            .unwrap()
+            .expect("loaded session must exist on disk");
+        second_active
+            .dialogue_manager
+            .lock()
+            .await
+            .resume_session(loaded)
+            .await
+            .unwrap();
+
+        let after = second_active.dialogue_manager.lock().await.session.id;
+        assert_eq!(
+            after, original_id,
+            "after resume_session, dm.session.id matches the loaded one"
+        );
+
+        // And the loaded session carries the persisted turn count.
+        assert_eq!(
+            second_active.dialogue_manager.lock().await.session.turns.len(),
+            2,
+            "resumed session carries both turns of the original exchange"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_sessions_via_store_after_one_turn() {
+        // Builds a session through wiring, runs a turn (the only way to
+        // land a sessions row through DM), then uses the same store Arc
+        // ActiveSession exposes to read the listing back. Validates the
+        // wiring contract — list_sessions sees what send_message wrote
+        // — without needing a Tauri state injection harness.
+
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let dm_arc = Arc::clone(&active.dialogue_manager);
+        let store = Arc::clone(&active.session_store);
+
+        let payload = run_turn(&dm_arc, "what is curiosity?", |_, _| {})
+            .await
+            .unwrap();
+        dm_arc.lock().await.close_session().await;
+
+        let listings = store.list_sessions().await.unwrap();
+        assert_eq!(listings.len(), 1, "exactly one persisted session");
+        assert_eq!(listings[0].id, payload.session_id);
+        assert_eq!(
+            listings[0].turn_count, 2,
+            "child + primer turns both counted"
+        );
     }
 
     #[tokio::test]

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -77,12 +77,19 @@ pub async fn close_session(state: tauri::State<'_, AppState>) -> Result<(), Stri
 /// Errors:
 /// - `session_id` not a valid UUID → inline error.
 /// - No session with that id on disk → "session not found" error.
-/// - Construction failure (locale, embedder, etc.) → wiring-level error.
+/// - Locale mismatch: the loaded learner's stored locale differs from
+///   the GUI's current `learner.locale` setting (mirrors the CLI's
+///   `--resume` guard — prevents silent `concept_language_tag`
+///   corruption when new concepts get tagged under the wrong locale).
+/// - Construction failure (embedder, model resolution, etc.) → wiring-level error.
 #[tauri::command]
 pub async fn resume_session(
     state: tauri::State<'_, AppState>,
     session_id: String,
 ) -> Result<SessionInfo, String> {
+    use primer_core::i18n::Locale;
+    use primer_engine::verify_resume_locale_match;
+
     let uuid = Uuid::parse_str(&session_id)
         .map_err(|e| format!("invalid session id {session_id:?}: {e}"))?;
 
@@ -97,6 +104,17 @@ pub async fn resume_session(
         .await
         .map_err(|e| format!("load_session failed: {e}"))?
         .ok_or_else(|| format!("no session found with id {uuid}"))?;
+
+    // Locale-mismatch guard. `build_active_session` already loaded the
+    // persisted learner row and seeded `dm.learner.profile.locale` from
+    // it; the GUI's currently-configured locale comes from cfg. If they
+    // differ we must abort BEFORE swapping the loaded session in — once
+    // resume_session lands, any new concepts extracted in the resumed
+    // session would be tagged with the wrong concept_language_tag and
+    // silently corrupt the longitudinal learner data.
+    let cfg_locale = Locale::from_pack_id(&cfg.learner.locale).unwrap_or_default();
+    let learner_locale = active.dialogue_manager.lock().await.learner.profile.locale;
+    verify_resume_locale_match(cfg_locale, learner_locale, uuid)?;
 
     // Replace DM's freshly-minted session with the loaded one. After
     // this returns, dm.session.id == uuid and recent_assessments are
@@ -761,7 +779,13 @@ mod tests {
 
         // And the loaded session carries the persisted turn count.
         assert_eq!(
-            second_active.dialogue_manager.lock().await.session.turns.len(),
+            second_active
+                .dialogue_manager
+                .lock()
+                .await
+                .session
+                .turns
+                .len(),
             2,
             "resumed session carries both turns of the original exchange"
         );
@@ -792,6 +816,111 @@ mod tests {
         assert_eq!(
             listings[0].turn_count, 2,
             "child + primer turns both counted"
+        );
+    }
+
+    #[test]
+    fn resume_rejects_invalid_uuid_inline() {
+        // The first thing resume_session does is parse the session_id
+        // string into a Uuid; an invalid id must produce a helpful
+        // error string the picker can render rather than panicking.
+        let err = Uuid::parse_str("not-a-uuid")
+            .map_err(|e| format!("invalid session id {:?}: {e}", "not-a-uuid"))
+            .unwrap_err();
+        assert!(
+            err.contains("invalid session id"),
+            "user-facing prefix preserved: {err}"
+        );
+        assert!(
+            err.contains("\"not-a-uuid\""),
+            "echoes the bad input verbatim so the user can spot the typo: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_returns_not_found_for_unknown_uuid() {
+        // Mirrors the "no session found" branch in resume_session: a
+        // syntactically-valid UUID that no session row backs must
+        // produce an Ok(None) at the store layer, which the command
+        // turns into a user-facing error string.
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+
+        let random_id = Uuid::new_v4();
+        let loaded = active.session_store.load_session(random_id).await.unwrap();
+        assert!(
+            loaded.is_none(),
+            "load_session on a never-persisted id yields None"
+        );
+
+        // Emulate the command's `.ok_or_else(...)` mapping so the test
+        // pins the actual user-facing error shape.
+        let err: String = loaded
+            .map(|_| String::new())
+            .ok_or_else(|| format!("no session found with id {random_id}"))
+            .unwrap_err();
+        assert!(err.starts_with("no session found with id "));
+        assert!(err.contains(&random_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn resume_rejects_locale_mismatch() {
+        // Mirrors the locale-mismatch guard in resume_session: persist a
+        // session+learner under locale=en, build a second ActiveSession
+        // with cfg.learner.locale=de, then assert the same check the
+        // Tauri command runs (`verify_resume_locale_match`) fires
+        // BEFORE swap-in. Catches silent concept_language_tag corruption
+        // — the bug class the CLI's --resume guard already prevents.
+        use primer_engine::verify_resume_locale_match;
+
+        let home = TempDir::new().unwrap();
+
+        // Step 1: build under English so the learner row + a session
+        // row both land with locale=en.
+        let cfg_en = stub_config_with_persistence(home.path());
+        let active_en = build_active_session(home.path(), &cfg_en).await.unwrap();
+        let dm_en = Arc::clone(&active_en.dialogue_manager);
+        let payload = run_turn(&dm_en, "hello", |_, _| {}).await.unwrap();
+        let persisted_id = payload.session_id;
+        dm_en.lock().await.close_session().await;
+        drop(active_en);
+
+        // Step 2: rebuild with the same persistence path but a German
+        // cfg locale. The persisted learner row already carries
+        // locale=en, so the freshly-built DM's learner.profile.locale
+        // is still English after wiring's load_learner runs.
+        let mut cfg_de = stub_config_with_persistence(home.path());
+        cfg_de.learner.locale = "de".to_string();
+        let active_de = build_active_session(home.path(), &cfg_de).await.unwrap();
+        let learner_locale = active_de
+            .dialogue_manager
+            .lock()
+            .await
+            .learner
+            .profile
+            .locale;
+        assert_eq!(
+            learner_locale,
+            primer_core::i18n::Locale::English,
+            "persisted learner row's locale survives the cfg-locale change"
+        );
+
+        // Step 3: same call the Tauri command makes — must error before
+        // any session swap-in happens.
+        let cfg_locale = primer_core::i18n::Locale::from_pack_id(&cfg_de.learner.locale).unwrap();
+        let err = verify_resume_locale_match(cfg_locale, learner_locale, persisted_id).unwrap_err();
+        assert!(
+            err.contains(&persisted_id.to_string()),
+            "names the session being resumed: {err}"
+        );
+        assert!(
+            err.contains("'en'"),
+            "names the learner's stored locale: {err}"
+        );
+        assert!(
+            err.contains("'de'"),
+            "names the conflicting cfg locale: {err}"
         );
     }
 

--- a/src/crates/primer-gui/src/config.rs
+++ b/src/crates/primer-gui/src/config.rs
@@ -55,7 +55,7 @@ pub struct LearnerConfig {
 impl Default for LearnerConfig {
     fn default() -> Self {
         Self {
-            name: "Explorer".to_string(),
+            name: primer_core::consts::learner::DEFAULT_NAME.to_string(),
             age: 8,
             locale: "en".to_string(),
         }

--- a/src/crates/primer-gui/src/state.rs
+++ b/src/crates/primer-gui/src/state.rs
@@ -31,6 +31,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use primer_core::i18n::Locale;
+use primer_core::storage::SessionStore;
 use primer_pedagogy::DialogueManager;
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -104,6 +105,13 @@ pub struct ActiveSession {
     /// successful turn so readers never have to lock the DM (and queue
     /// behind an in-flight stream that can take tens of seconds).
     pub snapshot: Arc<Mutex<SessionSnapshot>>,
+
+    /// Handle to the underlying session store. Cloned out of wiring so
+    /// the resume_session command can call `load_session(uuid)` after
+    /// the fresh `ActiveSession` is built — DM itself doesn't expose
+    /// `load_session`, and we don't want to re-open the SQLite file
+    /// just to read one row.
+    pub session_store: Arc<dyn SessionStore>,
 }
 
 /// Read-mostly mirror of the DM-owned fields the frontend renders via

--- a/src/crates/primer-gui/src/types.rs
+++ b/src/crates/primer-gui/src/types.rs
@@ -225,6 +225,53 @@ pub struct DepthCount {
     pub count: usize,
 }
 
+/// One turn rendered as a chat bubble on session resume.
+///
+/// Distinct from [`SessionTurnSummary`] (the sidebar's truncated list):
+/// this carries the FULL text because chat bubbles need it. Used only
+/// by [`get_full_session_turns`](crate::commands::session::get_full_session_turns)
+/// — a one-shot replay surface invoked when the picker resumes a
+/// session. The sidebar's per-turn-complete refresh keeps using the
+/// truncated `list_session_turns` to avoid pushing every full-text
+/// turn across IPC every time the bar updates.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionFullTurn {
+    /// Zero-based index in the session timeline.
+    pub index: usize,
+    /// Stable `"child"` or `"primer"` from `speaker_name` — used as a
+    /// CSS selector hook in the bubble row.
+    pub speaker: String,
+    /// Full turn text, no truncation.
+    pub text: String,
+}
+
+/// One row in the launch-screen session picker. Aggregates from
+/// `SessionStore::list_sessions`; the frontend renders rows in the
+/// order returned (most-recent-activity first) without re-sorting.
+///
+/// Timestamps cross IPC as ISO-8601 strings so the frontend can
+/// render relative times ("2 hours ago", "yesterday") without
+/// re-implementing chrono parsing.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionListingDto {
+    /// Stable UUID used for `resume_session` lookup.
+    pub session_id: Uuid,
+    pub learner_id: Uuid,
+    /// `Session.started_at`.
+    pub started_at: String,
+    /// `Session.ended_at`. `None` for sessions that ran to crash /
+    /// shutdown without an explicit close (the common case).
+    pub ended_at: Option<String>,
+    /// `MAX(turns.timestamp)` or `started_at` when the session has no
+    /// turns yet. Drives the row's "last seen" label.
+    pub last_activity: String,
+    pub turn_count: usize,
+    /// Rolling LLM summary; usually empty for sessions with fewer than
+    /// one context-window worth of turns. Frontend should hide the
+    /// summary line when empty rather than showing a blank row.
+    pub summary: String,
+}
+
 /// One row in the sidebar's "Session" turn-by-turn list.
 ///
 /// Returned by `list_session_turns`; the frontend renders the list

--- a/src/crates/primer-gui/src/wiring.rs
+++ b/src/crates/primer-gui/src/wiring.rs
@@ -281,6 +281,7 @@ pub async fn build_active_session(
         locale,
         backend_name: backend_config.kind.clone(),
         main_model,
+        session_store: Arc::clone(&session_store) as _,
     })
 }
 

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -98,28 +98,69 @@ async function main() {
   setupSidebarToggle();
   setupUuidCopy();
   setupSettingsButton();
-  await openOrStartSession();
-  // Render whatever's already on the DM (resumed sessions land here
-  // with populated last_* accessors); first-launch shows the empty state.
-  refreshSidebar();
+  // No auto-start anymore — show the picker and let the user pick
+  // (resume a past session) or click Start new (settings modal →
+  // save & start a fresh session).
+  await window.PrimerPicker.show({
+    onResumed: (info) => handleSessionReady({ info, shouldReplay: true }),
+    onStarted: () => handleSessionReady({ info: null, shouldReplay: false }),
+  });
 }
 
 function setupSettingsButton() {
   dom.settingsOpen.addEventListener("click", () => {
     // settings.js is loaded by index.html before app.js, so the
     // global is guaranteed to exist by the time the button is
-    // clickable.
-    window.PrimerSettings.open({ onSessionRestarted: handleSessionRestarted });
+    // clickable. Save & start new session re-enters the chat surface
+    // via the same handler the picker uses, so the post-start UI
+    // state is consistent regardless of how the new session got
+    // started.
+    window.PrimerSettings.open({
+      onSessionRestarted: () =>
+        handleSessionReady({ info: null, shouldReplay: false }),
+    });
   });
 }
 
-/// Wipe chat surface + index counter and re-render from the freshly
-/// started session. Called when the settings modal saves with
-/// "Save & start new session" — the in-memory ActiveSession was
-/// replaced server-side, so anything the user typed before now
-/// belongs to a closed session and shouldn't sit visually-attached
-/// to bubbles tagged for a new turn timeline.
-async function handleSessionRestarted() {
+/// Bring up the chat surface for the session that just became active.
+///
+/// Called from three places — picker resume, picker start-new (via
+/// settings modal), and the header settings modal's "Save & start
+/// new session" — so all three paths land in the same UI state.
+///
+/// `info` is supplied directly when the caller already has it (picker
+/// resume); a `null` triggers a `current_session_info` fetch. When
+/// `shouldReplay` is true, the loaded session's turns are fetched in
+/// full and replayed as bubbles so the user sees the conversation
+/// history — that's the picker-resume path. Fresh sessions skip
+/// replay (there's nothing to render) and leave the empty-state in
+/// place until the first message lands.
+async function handleSessionReady({ info, shouldReplay }) {
+  resetChatSurface();
+
+  const sessionInfo =
+    info ?? (await invoke("current_session_info").catch(() => null));
+  if (sessionInfo) {
+    renderSessionInfo(sessionInfo);
+  }
+
+  if (shouldReplay) {
+    try {
+      const turns = await invoke("get_full_session_turns");
+      if (turns && turns.length > 0) replayTurns(turns);
+    } catch (err) {
+      console.warn("get_full_session_turns failed:", err);
+    }
+  }
+
+  enableComposer();
+  refreshSidebar();
+}
+
+/// Wipe the chat surface back to its empty-state shell — used before
+/// rendering either a freshly-started session or replaying a resumed
+/// one. Mirror of what fresh-launch shows.
+function resetChatSurface() {
   state.streamingPrimerEl = null;
   state.nextTurnIndex = 0;
   state.sessionId = null;
@@ -128,8 +169,6 @@ async function handleSessionRestarted() {
     state.spotlightTimer = null;
   }
   hideError();
-  // Strip every bubble row but keep the empty-state node — same
-  // surface a fresh launch shows.
   for (const row of Array.from(dom.chatScroll.querySelectorAll(".bubble-row"))) {
     row.remove();
   }
@@ -139,21 +178,30 @@ async function handleSessionRestarted() {
       dom.chatScroll.appendChild(dom.emptyState);
     }
   }
-  await openOrStartSession();
-  refreshSidebar();
 }
 
-async function openOrStartSession() {
-  try {
-    let info = await invoke("current_session_info");
-    if (info === null) {
-      info = await invoke("start_session");
-    }
-    renderSessionInfo(info);
-    enableComposer();
-  } catch (err) {
-    showError(formatErr(err));
+/// Render every turn of a resumed session as a chat bubble. `turns`
+/// is the SessionFullTurn[] payload from `get_full_session_turns` —
+/// each carries the FULL text (not the truncated sidebar preview)
+/// because chat bubbles need to display the original content. The
+/// next user-typed message lands at `state.nextTurnIndex = turns.length`
+/// so the click-to-scroll indices stay aligned with the backend's
+/// `session.turns` indices.
+function replayTurns(turns) {
+  hideEmptyState();
+  for (const t of turns) {
+    const row = document.createElement("div");
+    row.className =
+      t.speaker === "child" ? "bubble-row is-child" : "bubble-row is-primer";
+    row.dataset.turnIndex = String(t.index);
+    const bubble = document.createElement("div");
+    bubble.className = "bubble";
+    bubble.textContent = t.text;
+    row.appendChild(bubble);
+    dom.chatScroll.appendChild(row);
   }
+  state.nextTurnIndex = turns.length;
+  scrollToBottom();
 }
 
 function renderSessionInfo(info) {

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -555,6 +555,47 @@
       hidden
     ></div>
 
+    <div class="picker-screen" id="picker-screen" hidden>
+      <div class="picker-shell">
+        <header class="picker-header">
+          <div class="brand brand-large">
+            <span class="brand-mark">●</span>
+            <span class="brand-name">Primer</span>
+          </div>
+          <h1 class="picker-title" id="picker-title">Welcome to Primer</h1>
+          <p class="picker-subtitle muted" id="picker-subtitle">
+            Pick up where you left off, or start fresh.
+          </p>
+        </header>
+
+        <div class="picker-body">
+          <div class="picker-loading" id="picker-loading">
+            <span class="muted">Loading sessions…</span>
+          </div>
+          <div class="error-banner" id="picker-error" hidden></div>
+          <div class="picker-empty" id="picker-empty" hidden>
+            <p>No saved sessions yet. Start a new one to begin.</p>
+          </div>
+          <ol
+            class="picker-list"
+            id="picker-list"
+            aria-label="Past sessions"
+            hidden
+          ></ol>
+        </div>
+
+        <footer class="picker-footer">
+          <button type="button" class="btn-tertiary" id="picker-settings">
+            Settings
+          </button>
+          <button type="button" class="btn-primary" id="picker-start-new">
+            Start new session
+          </button>
+        </footer>
+      </div>
+    </div>
+
+    <script src="picker.js"></script>
     <script src="settings.js"></script>
     <script src="app.js"></script>
   </body>

--- a/src/crates/primer-gui/ui/picker.js
+++ b/src/crates/primer-gui/ui/picker.js
@@ -13,6 +13,12 @@
 
 const { invoke } = window.__TAURI__.core;
 
+// Default placeholder name a fresh learner profile carries until the
+// user supplies their own. Mirrors `primer_core::consts::learner::DEFAULT_NAME`
+// — keep in sync when changing. Used to suppress the personalised
+// "Welcome back, {name}" greeting for unconfigured installs.
+const DEFAULT_LEARNER_NAME = "Explorer";
+
 const dom = {
   screen: document.getElementById("picker-screen"),
   title: document.getElementById("picker-title"),
@@ -38,6 +44,9 @@ const state = {
 wireFooterButtons();
 window.PrimerPicker = { show, hide };
 
+/// Show the picker overlay. Re-fetches the session list every call so
+/// "what's on screen" stays trivially aligned with disk. Callbacks
+/// are stored on `state` and fired once the user picks an action.
 async function show({ onResumed, onStarted } = {}) {
   state.onResumed = onResumed ?? null;
   state.onStarted = onStarted ?? null;
@@ -46,6 +55,9 @@ async function show({ onResumed, onStarted } = {}) {
   await refresh();
 }
 
+/// Hide the picker overlay without resetting state. Callers that want
+/// to surface the picker again (future: switch-session-from-chat) just
+/// call show() — the next refresh() will re-fetch from disk.
 function hide() {
   dom.screen.hidden = true;
 }
@@ -63,22 +75,37 @@ function showError(msg) {
   dom.loading.hidden = true;
 }
 
+/// Reload the picker contents from disk + settings. Public-ish: called
+/// internally by show() and after a failed resume attempt to repaint
+/// the list. Independent error handling per fetch — see comment below.
 async function refresh() {
-  try {
-    const [sessions, settings] = await Promise.all([
-      invoke("list_sessions"),
-      invoke("get_settings"),
-    ]);
-    applyHeader(settings);
-    renderSessions(sessions ?? []);
-  } catch (err) {
-    showError(`Couldn't load sessions: ${formatErr(err)}`);
+  // Fetch both in parallel but keep error reporting independent —
+  // a settings-load failure shouldn't masquerade as a sessions-load
+  // error, since the picker can still render its list with the
+  // generic "Welcome to Primer" header while the settings round-trip
+  // is broken.
+  const [sessionsResult, settingsResult] = await Promise.allSettled([
+    invoke("list_sessions"),
+    invoke("get_settings"),
+  ]);
+
+  if (settingsResult.status === "fulfilled") {
+    applyHeader(settingsResult.value);
+  } else {
+    console.warn("get_settings failed:", settingsResult.reason);
+    applyHeader(null);
+  }
+
+  if (sessionsResult.status === "fulfilled") {
+    renderSessions(sessionsResult.value ?? []);
+  } else {
+    showError(`Couldn't load sessions: ${formatErr(sessionsResult.reason)}`);
   }
 }
 
 function applyHeader(settings) {
   const name = settings?.learner?.name?.trim();
-  if (name && name !== "Explorer") {
+  if (name && name !== DEFAULT_LEARNER_NAME) {
     dom.title.textContent = `Welcome back, ${name}`;
     dom.subtitle.textContent = "Pick up where you left off, or start fresh.";
   } else {
@@ -142,6 +169,10 @@ function renderRow(s) {
   return li;
 }
 
+/// Resume a session by id. Disables UI for the duration so a fast
+/// second click can't fire a parallel resume_session, then hands the
+/// returned SessionInfo to `state.onResumed`. On failure repaints the
+/// list (in case disk state changed) and surfaces the error inline.
 async function resume(sessionId) {
   // Disable every row + footer button so the user can't fire a
   // second resume_session while the first is still constructing.

--- a/src/crates/primer-gui/ui/picker.js
+++ b/src/crates/primer-gui/ui/picker.js
@@ -1,0 +1,236 @@
+// Launch-screen session picker.
+//
+// Loaded before settings.js + app.js so it can expose
+// `window.PrimerPicker` to the chat shell. Shown by `main()` in
+// app.js when no session is active on launch; hidden once the user
+// picks a row to resume or finishes the "Start new" → Settings → save
+// flow.
+//
+// The picker stays stateless across show/hide cycles — every show()
+// re-fetches the sessions list and re-renders. That keeps "what's on
+// the picker" trivially aligned with disk; a session deleted out of
+// band between two shows will simply disappear from the list.
+
+const { invoke } = window.__TAURI__.core;
+
+const dom = {
+  screen: document.getElementById("picker-screen"),
+  title: document.getElementById("picker-title"),
+  subtitle: document.getElementById("picker-subtitle"),
+  loading: document.getElementById("picker-loading"),
+  error: document.getElementById("picker-error"),
+  empty: document.getElementById("picker-empty"),
+  list: document.getElementById("picker-list"),
+  settingsBtn: document.getElementById("picker-settings"),
+  startNewBtn: document.getElementById("picker-start-new"),
+};
+
+const state = {
+  /// Callback invoked on successful resume_session — picker hands
+  /// the new SessionInfo off to the chat shell, which clears bubbles
+  /// and replays the loaded turns.
+  onResumed: null,
+  /// Callback invoked on successful start_session (via the settings
+  /// modal). Same job as onResumed but without the turn-replay step.
+  onStarted: null,
+};
+
+wireFooterButtons();
+window.PrimerPicker = { show, hide };
+
+async function show({ onResumed, onStarted } = {}) {
+  state.onResumed = onResumed ?? null;
+  state.onStarted = onStarted ?? null;
+  dom.screen.hidden = false;
+  showLoading();
+  await refresh();
+}
+
+function hide() {
+  dom.screen.hidden = true;
+}
+
+function showLoading() {
+  dom.loading.hidden = false;
+  dom.error.hidden = true;
+  dom.empty.hidden = true;
+  dom.list.hidden = true;
+}
+
+function showError(msg) {
+  dom.error.textContent = msg;
+  dom.error.hidden = false;
+  dom.loading.hidden = true;
+}
+
+async function refresh() {
+  try {
+    const [sessions, settings] = await Promise.all([
+      invoke("list_sessions"),
+      invoke("get_settings"),
+    ]);
+    applyHeader(settings);
+    renderSessions(sessions ?? []);
+  } catch (err) {
+    showError(`Couldn't load sessions: ${formatErr(err)}`);
+  }
+}
+
+function applyHeader(settings) {
+  const name = settings?.learner?.name?.trim();
+  if (name && name !== "Explorer") {
+    dom.title.textContent = `Welcome back, ${name}`;
+    dom.subtitle.textContent = "Pick up where you left off, or start fresh.";
+  } else {
+    dom.title.textContent = "Welcome to Primer";
+    dom.subtitle.textContent =
+      "Start a new session — or open Settings to customise your setup first.";
+  }
+}
+
+function renderSessions(sessions) {
+  dom.loading.hidden = true;
+  if (sessions.length === 0) {
+    dom.empty.hidden = false;
+    dom.list.hidden = true;
+    dom.list.replaceChildren();
+    return;
+  }
+  dom.empty.hidden = true;
+  dom.list.hidden = false;
+  dom.list.replaceChildren(...sessions.map(renderRow));
+}
+
+function renderRow(s) {
+  const li = document.createElement("li");
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "picker-row";
+  btn.dataset.sessionId = s.session_id;
+
+  const lastActivity = new Date(s.last_activity);
+  const startedAt = new Date(s.started_at);
+
+  const when = document.createElement("span");
+  when.className = "picker-row-when";
+  when.textContent = relativeTime(lastActivity);
+
+  const summaryEl = document.createElement("span");
+  summaryEl.className = "picker-row-summary";
+  if (s.summary && s.summary.trim().length > 0) {
+    summaryEl.textContent = s.summary;
+  } else if (s.turn_count === 0) {
+    summaryEl.textContent = "Started but no turns yet.";
+    summaryEl.classList.add("is-empty");
+  } else {
+    summaryEl.textContent = "No summary yet — still in the early turns.";
+    summaryEl.classList.add("is-empty");
+  }
+
+  const meta = document.createElement("span");
+  meta.className = "picker-row-meta muted";
+  const turnLabel = s.turn_count === 1 ? "1 turn" : `${s.turn_count} turns`;
+  meta.textContent = `${turnLabel} · started ${relativeTime(startedAt)}`;
+
+  btn.appendChild(when);
+  btn.appendChild(summaryEl);
+  btn.appendChild(meta);
+  btn.addEventListener("click", () => resume(s.session_id));
+  btn.title = `Session ${s.session_id}`;
+
+  li.appendChild(btn);
+  return li;
+}
+
+async function resume(sessionId) {
+  // Disable every row + footer button so the user can't fire a
+  // second resume_session while the first is still constructing.
+  setRowsBusy(true);
+  showLoading();
+  try {
+    const info = await invoke("resume_session", { sessionId });
+    hide();
+    if (state.onResumed) {
+      try {
+        await state.onResumed(info);
+      } catch (cbErr) {
+        console.warn("onResumed callback threw:", cbErr);
+      }
+    }
+  } catch (err) {
+    setRowsBusy(false);
+    // Re-render the list rather than dropping into the global empty
+    // state — refresh() will swap loading→list and surface any
+    // freshly-changed listings as a bonus.
+    await refresh();
+    showError(`Couldn't resume session: ${formatErr(err)}`);
+  }
+}
+
+function setRowsBusy(busy) {
+  for (const btn of dom.list.querySelectorAll(".picker-row")) {
+    btn.disabled = busy;
+  }
+  dom.startNewBtn.disabled = busy;
+  dom.settingsBtn.disabled = busy;
+}
+
+function wireFooterButtons() {
+  // Both footer buttons open the same Settings modal — "Start new"
+  // is the primary path and lands directly on the start-new flow
+  // when the user clicks "Save & start new session" inside the
+  // modal; "Settings" is for users who want to tweak before deciding.
+  // Both supply the same onSessionRestarted callback so the modal
+  // can hand the chat shell its new session.
+  dom.startNewBtn.addEventListener("click", () => openSettings());
+  dom.settingsBtn.addEventListener("click", () => openSettings());
+}
+
+function openSettings() {
+  window.PrimerSettings.open({
+    onSessionRestarted: () => {
+      hide();
+      if (state.onStarted) {
+        try {
+          state.onStarted();
+        } catch (cbErr) {
+          console.warn("onStarted callback threw:", cbErr);
+        }
+      }
+    },
+  });
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/// Compact relative-time formatting tuned for the picker's "when did
+/// I last use this" use case. < 1 min → "just now"; < 1 hour → "Nm
+/// ago"; < 24 hours → "Nh ago"; < 7 days → "Nd ago"; else absolute
+/// date.
+function relativeTime(date) {
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatErr(err) {
+  if (typeof err === "string") return err;
+  if (err && typeof err.message === "string") return err.message;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -1269,6 +1269,164 @@ code {
   border-radius: 0.25rem;
 }
 
+/* ─── Session picker ────────────────────────────────────────────── */
+
+.picker-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: linear-gradient(
+    160deg,
+    color-mix(in oklab, var(--accent) 4%, var(--bg)),
+    var(--bg) 55%
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3vh 2vw;
+  overflow-y: auto;
+}
+
+.picker-shell {
+  display: flex;
+  flex-direction: column;
+  width: min(560px, 100%);
+  max-height: 94vh;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.picker-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1.4rem 1.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.brand-large .brand-mark {
+  font-size: 1rem;
+}
+
+.brand-large .brand-name {
+  font-size: 1rem;
+  letter-spacing: -0.005em;
+}
+
+.picker-title {
+  margin: 0.2rem 0 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--fg);
+}
+
+.picker-subtitle {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.picker-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 1rem 1.3rem;
+  min-height: 7rem;
+}
+
+.picker-loading {
+  padding: 1rem 0;
+  text-align: center;
+}
+
+.picker-empty {
+  padding: 1.4rem 0.4rem;
+  text-align: center;
+  color: var(--fg-muted);
+}
+
+.picker-empty p {
+  margin: 0;
+}
+
+.picker-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.picker-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 100%;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 0.55rem;
+  background: var(--bg);
+  text-align: left;
+  font: inherit;
+  color: var(--fg);
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.picker-row:hover {
+  background: color-mix(in oklab, var(--accent) 6%, var(--bg));
+  border-color: color-mix(in oklab, var(--accent) 30%, var(--border));
+}
+
+.picker-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.picker-row-when {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.picker-row-summary {
+  font-size: 0.86rem;
+  color: var(--fg);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.picker-row-summary.is-empty {
+  font-style: italic;
+  color: var(--fg-muted);
+}
+
+.picker-row-meta {
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.picker-footer {
+  display: flex;
+  gap: 0.55rem;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 1.3rem 1.1rem;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+}
+
 /* ─── Toast ─────────────────────────────────────────────────────── */
 
 .toast {

--- a/src/crates/primer-pedagogy/src/dialogue_manager/test_support.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/test_support.rs
@@ -227,6 +227,12 @@ impl primer_core::storage::SessionStore for CountingStore {
         Ok(None)
     }
 
+    async fn list_sessions(
+        &self,
+    ) -> Result<Vec<primer_core::conversation::SessionListing>> {
+        Ok(vec![])
+    }
+
     async fn update_turn_concepts(
         &self,
         _session_id: primer_core::conversation::SessionId,
@@ -457,6 +463,11 @@ impl primer_core::storage::SessionStore for ConceptCapturingStore {
     }
     async fn most_recent_session_learner_id(&self) -> Result<Option<uuid::Uuid>> {
         self.inner.most_recent_session_learner_id().await
+    }
+    async fn list_sessions(
+        &self,
+    ) -> Result<Vec<primer_core::conversation::SessionListing>> {
+        self.inner.list_sessions().await
     }
     async fn update_turn_concepts(
         &self,

--- a/src/crates/primer-pedagogy/src/dialogue_manager/test_support.rs
+++ b/src/crates/primer-pedagogy/src/dialogue_manager/test_support.rs
@@ -227,9 +227,7 @@ impl primer_core::storage::SessionStore for CountingStore {
         Ok(None)
     }
 
-    async fn list_sessions(
-        &self,
-    ) -> Result<Vec<primer_core::conversation::SessionListing>> {
+    async fn list_sessions(&self) -> Result<Vec<primer_core::conversation::SessionListing>> {
         Ok(vec![])
     }
 
@@ -464,9 +462,7 @@ impl primer_core::storage::SessionStore for ConceptCapturingStore {
     async fn most_recent_session_learner_id(&self) -> Result<Option<uuid::Uuid>> {
         self.inner.most_recent_session_learner_id().await
     }
-    async fn list_sessions(
-        &self,
-    ) -> Result<Vec<primer_core::conversation::SessionListing>> {
+    async fn list_sessions(&self) -> Result<Vec<primer_core::conversation::SessionListing>> {
         self.inner.list_sessions().await
     }
     async fn update_turn_concepts(

--- a/src/crates/primer-storage/src/store/session.rs
+++ b/src/crates/primer-storage/src/store/session.rs
@@ -10,7 +10,7 @@
 use async_trait::async_trait;
 use primer_core::classifier::EngagementAssessment;
 use primer_core::comprehension::ComprehensionAssessment;
-use primer_core::conversation::{Session, SessionId, Turn};
+use primer_core::conversation::{Session, SessionId, SessionListing, Turn};
 use primer_core::embedder::Embedder;
 use primer_core::error::Result;
 use primer_core::knowledge::HybridParams;
@@ -63,6 +63,10 @@ impl SessionStore for SqliteSessionStore {
 
     async fn most_recent_session_learner_id(&self) -> Result<Option<Uuid>> {
         self.most_recent_session_learner_id_inner().await
+    }
+
+    async fn list_sessions(&self) -> Result<Vec<SessionListing>> {
+        self.list_sessions_inner().await
     }
 
     async fn update_turn_concepts(

--- a/src/crates/primer-storage/src/store/session_load.rs
+++ b/src/crates/primer-storage/src/store/session_load.rs
@@ -261,6 +261,13 @@ impl SqliteSessionStore {
         use primer_core::conversation::SessionListing;
 
         let conn = self.conn.lock().unwrap();
+        // LEFT JOIN keeps turn-less sessions in the result set; the
+        // GROUP BY collapses each session's turn rows so COUNT/MAX
+        // aggregate over them. COALESCE(MAX(timestamp), started_at)
+        // serves double duty as both the `last_activity` value and the
+        // ORDER-BY key so a freshly-opened session that never received
+        // a turn still places by its started_at rather than sorting
+        // to the bottom on NULL.
         let mut stmt = conn
             .prepare(
                 "SELECT s.id, s.learner_id, s.started_at, s.ended_at, s.summary,
@@ -312,13 +319,21 @@ impl SqliteSessionStore {
                 Some(s) => parse_rfc3339(&s, "turns.timestamp")?,
                 None => started_at,
             };
+            // COUNT(*) cannot return a negative value in practice;
+            // try_from rejects the impossible-but-cheap-to-check
+            // i64::MIN..0 range loudly rather than silently wrapping.
+            let turn_count = usize::try_from(turn_count).map_err(|_| {
+                PrimerError::Storage(format!(
+                    "list_sessions: COUNT(t.id) returned out-of-range {turn_count}"
+                ))
+            })?;
             out.push(SessionListing {
                 id,
                 learner_id,
                 started_at,
                 ended_at,
                 last_activity,
-                turn_count: turn_count as usize,
+                turn_count,
                 summary,
             });
         }

--- a/src/crates/primer-storage/src/store/session_load.rs
+++ b/src/crates/primer-storage/src/store/session_load.rs
@@ -249,4 +249,79 @@ impl SqliteSessionStore {
             }
         }
     }
+
+    /// Aggregate every session row into a `SessionListing` slice for
+    /// picker views. The `COALESCE(MAX(t.timestamp), s.started_at)`
+    /// expression doubles as the ORDER-BY key so a session with no
+    /// turns yet still places by its `started_at` rather than at the
+    /// bottom of the list.
+    pub(super) async fn list_sessions_inner(
+        &self,
+    ) -> Result<Vec<primer_core::conversation::SessionListing>> {
+        use primer_core::conversation::SessionListing;
+
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT s.id, s.learner_id, s.started_at, s.ended_at, s.summary,
+                        COUNT(t.id) AS turn_count,
+                        MAX(t.timestamp) AS last_turn_at
+                 FROM sessions s
+                 LEFT JOIN turns t ON t.session_id = s.id
+                 GROUP BY s.id
+                 ORDER BY COALESCE(MAX(t.timestamp), s.started_at) DESC",
+            )
+            .map_err(|e| PrimerError::Storage(format!("prepare list_sessions: {e}")))?;
+
+        let rows = stmt
+            .query_map([], |r| {
+                let id_str: String = r.get(0)?;
+                let learner_str: String = r.get(1)?;
+                let started_str: String = r.get(2)?;
+                let ended_opt: Option<String> = r.get(3)?;
+                let summary: String = r.get(4)?;
+                let turn_count: i64 = r.get(5)?;
+                let last_turn_opt: Option<String> = r.get(6)?;
+                Ok((
+                    id_str,
+                    learner_str,
+                    started_str,
+                    ended_opt,
+                    summary,
+                    turn_count,
+                    last_turn_opt,
+                ))
+            })
+            .map_err(|e| PrimerError::Storage(format!("query list_sessions: {e}")))?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            let (id_str, learner_str, started_str, ended_opt, summary, turn_count, last_opt) =
+                row.map_err(|e| PrimerError::Storage(format!("read list_sessions row: {e}")))?;
+            let id = Uuid::parse_str(&id_str)
+                .map_err(|e| PrimerError::Storage(format!("parse session id {id_str}: {e}")))?;
+            let learner_id = Uuid::parse_str(&learner_str).map_err(|e| {
+                PrimerError::Storage(format!("parse learner_id {learner_str}: {e}"))
+            })?;
+            let started_at = parse_rfc3339(&started_str, "sessions.started_at")?;
+            let ended_at = match ended_opt {
+                Some(s) => Some(parse_rfc3339(&s, "sessions.ended_at")?),
+                None => None,
+            };
+            let last_activity = match last_opt {
+                Some(s) => parse_rfc3339(&s, "turns.timestamp")?,
+                None => started_at,
+            };
+            out.push(SessionListing {
+                id,
+                learner_id,
+                started_at,
+                ended_at,
+                last_activity,
+                turn_count: turn_count as usize,
+                summary,
+            });
+        }
+        Ok(out)
+    }
 }

--- a/src/crates/primer-storage/src/store/tests/session_tests.rs
+++ b/src/crates/primer-storage/src/store/tests/session_tests.rs
@@ -1597,6 +1597,109 @@ async fn most_recent_session_learner_id_picks_most_recent_when_multiple_distinct
     assert_eq!(result, Some(newer_learner));
 }
 
+// ─── list_sessions ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_sessions_returns_empty_on_empty_db() {
+    let store = SqliteSessionStore::open_for_locale(
+        std::path::Path::new(":memory:"),
+        primer_core::i18n::Locale::default(),
+    )
+    .unwrap();
+    let result = store.list_sessions().await.unwrap();
+    assert!(result.is_empty());
+}
+
+#[tokio::test]
+async fn list_sessions_includes_turn_count_and_summary() {
+    use primer_core::conversation::{Session, Speaker, Turn};
+
+    let store = open_memory();
+    let learner_id = Uuid::new_v4();
+    let mut session = Session::new(learner_id);
+    session.summary = "discussed planets and gravity".into();
+    session.summary_through_turn_index = 2;
+    session.add_turn(Turn {
+        speaker: Speaker::Child,
+        text: "why does the moon orbit?".into(),
+        timestamp: Utc::now(),
+        intent: None,
+        concepts: vec![],
+    });
+    session.add_turn(Turn {
+        speaker: Speaker::Primer,
+        text: "what's pulling on it?".into(),
+        timestamp: Utc::now(),
+        intent: None,
+        concepts: vec![],
+    });
+    store.save_session(&session).await.unwrap();
+
+    let listings = store.list_sessions().await.unwrap();
+    assert_eq!(listings.len(), 1);
+    assert_eq!(listings[0].id, session.id);
+    assert_eq!(listings[0].learner_id, learner_id);
+    assert_eq!(listings[0].turn_count, 2);
+    assert_eq!(listings[0].summary, "discussed planets and gravity");
+    assert!(listings[0].ended_at.is_none());
+}
+
+#[tokio::test]
+async fn list_sessions_orders_by_last_activity_desc() {
+    use chrono::{Duration, Utc};
+    use primer_core::conversation::{Session, Speaker, Turn};
+
+    let store = open_memory();
+    let learner_id = Uuid::new_v4();
+
+    let mut older = Session::new(learner_id);
+    older.started_at = Utc::now() - Duration::hours(5);
+    older.add_turn(Turn {
+        speaker: Speaker::Child,
+        text: "older question".into(),
+        timestamp: Utc::now() - Duration::hours(4),
+        intent: None,
+        concepts: vec![],
+    });
+    store.save_session(&older).await.unwrap();
+
+    let mut newer = Session::new(learner_id);
+    newer.started_at = Utc::now() - Duration::hours(3);
+    newer.add_turn(Turn {
+        speaker: Speaker::Child,
+        text: "newer question".into(),
+        timestamp: Utc::now() - Duration::minutes(2),
+        intent: None,
+        concepts: vec![],
+    });
+    store.save_session(&newer).await.unwrap();
+
+    let listings = store.list_sessions().await.unwrap();
+    assert_eq!(listings.len(), 2);
+    assert_eq!(
+        listings[0].id, newer.id,
+        "most-recent activity wins regardless of started_at"
+    );
+    assert_eq!(listings[1].id, older.id);
+}
+
+#[tokio::test]
+async fn list_sessions_uses_started_at_when_no_turns() {
+    // A session that has been opened but never had a turn must still
+    // appear in the picker — sort key falls back to started_at.
+    use primer_core::conversation::Session;
+
+    let store = open_memory();
+    let learner_id = Uuid::new_v4();
+    let session = Session::new(learner_id);
+    store.save_session(&session).await.unwrap();
+
+    let listings = store.list_sessions().await.unwrap();
+    assert_eq!(listings.len(), 1);
+    assert_eq!(listings[0].turn_count, 0);
+    assert_eq!(listings[0].last_activity, listings[0].started_at);
+}
+
 // ─── update_turn_concepts ─────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Step 9 of the [GUI plan](../blob/main/.claude/plans/we-need-a-basic-abstract-wigderson.md). Launch no longer auto-starts a fresh session — the user lands on a picker that lists every past session for the configured learner. Click a row to resume; click **Start new session** to open Settings and start fresh.

### Backend
- New \`SessionStore::list_sessions\` trait method returning \`Vec<SessionListing>\` (id, learner_id, started_at, ended_at, last_activity, turn_count, summary). \`LEFT JOIN turns\` + \`COALESCE(MAX(t.timestamp), s.started_at)\` so a session with no turns still places by \`started_at\`. Ordered most-recent-activity DESC. SQLite impl, 4 fresh tests, stub impls on both pedagogy \`test_support\` stores.
- \`ActiveSession.session_store: Arc<dyn SessionStore>\` so the new \`resume_session\` command can call \`load_session\` against the same handle the wiring just opened.
- Three new Tauri commands:
  - **\`list_sessions\`** — opens a transient \`SqliteSessionStore\` against the resolved per-learner DB path; returns empty on \`no_persist\` or when the DB file doesn't exist (fresh install).
  - **\`resume_session(sessionId)\`** — closes the active session, builds a fresh \`ActiveSession\`, loads the persisted \`Session\`, swaps it into DM via \`resume_session\`, refreshes the snapshot.
  - **\`get_full_session_turns\`** — returns FULL turn text (not the sidebar's 80-char preview) for the chat-replay path after resume.
- Two round-trip tests in \`primer-gui\` exercising the resume path and \`list_sessions\` wiring contract.

### Frontend
- New \`picker.js\` exposing \`window.PrimerPicker.show({ onResumed, onStarted })\`. Full-screen overlay with a list of past sessions (relative last-activity, summary or empty-state hint, turn-count meta) plus footer **Settings** + **Start new session** buttons. Both open the existing Settings modal.
- \`app.js main()\` no longer auto-starts. It shows the picker and registers two callbacks; \`onResumed\` fetches full turns and replays them as bubbles (with \`state.nextTurnIndex\` advanced so the next user message lines up with backend indices); \`onStarted\` leaves the empty-state in place. Unified into one \`handleSessionReady\` helper so the header settings-modal's "Save & start new session" path lands in the same UI state.

### Out of scope (queued for step 10)
- Switch-session-from-chat affordance (no way back to the picker without restarting the app)
- Session delete or rename
- Per-row preview / expansion

## Test plan
- [x] \`cargo test --workspace\` — 715 tests pass (6 new: 4 storage + 2 GUI)
- [x] \`cargo clippy -p primer-gui --all-targets\` clean
- [ ] Manual: launch GUI with no past sessions, picker shows empty state; "Start new" opens Settings, save → enter chat
- [ ] Manual: launch with past sessions, picker lists them; click a row → chat shows replayed bubbles + correct header pill
- [ ] Manual: send a new message after resume — child bubble lands at the correct index (Session sidebar's click-to-scroll still works)
- [ ] Manual: hit an error path (corrupt session id, missing DB) and confirm the picker recovers gracefully
- [ ] Manual: "Start new session" from picker → Settings modal opens with the in-memory config; save → fresh chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)