### PR TITLE
feat(gui): cancel-mid-stream + switch-session header button

### DIFF
--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -25,6 +25,7 @@ pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
         session::list_sessions,
         session::current_session_info,
         session::send_message,
+        session::cancel_response,
         session::get_turn_signals,
         session::get_learner_state,
         session::list_session_turns,

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -560,10 +560,12 @@ pub async fn send_message(
     app: AppHandle,
     input: String,
 ) -> Result<TurnComplete, String> {
-    // Clone both Arcs under the session mutex, then release it. The
-    // DM Arc drives the turn; the snapshot Arc is refreshed at the
-    // end so reader commands see fresh learner/session-id fields
-    // without ever locking the DM.
+    // Clone the Arcs under the session mutex, then release it. The DM
+    // Arc drives the turn; the snapshot Arc is refreshed at the end so
+    // reader commands see fresh learner/session-id fields without ever
+    // locking the DM. The `current_turn_abort` slot is set / cleared
+    // via brief re-locks of `state.session` below so the spawned task
+    // doesn't hold the session lock for its full streaming wallclock.
     let (dm_arc, snapshot_arc) = {
         let guard = state.session.lock().await;
         let active = guard
@@ -575,16 +577,58 @@ pub async fn send_message(
         )
     };
 
-    let payload = run_turn(&dm_arc, &input, |primer_turn_index, chunk| {
-        let payload = ChunkEvent {
-            primer_turn_index,
-            text: chunk.to_string(),
-        };
-        if let Err(e) = app.emit("primer://chunk", &payload) {
-            tracing::warn!("emit primer://chunk failed: {e}");
+    // Spawn the turn in a dedicated task so `cancel_response` can abort
+    // it. The chunk emitter lives inside the spawn because closures
+    // crossing the spawn boundary need owned captures.
+    let dm_clone = Arc::clone(&dm_arc);
+    let app_clone = app.clone();
+    let input_clone = input.clone();
+    let task = tokio::spawn(async move {
+        run_turn(&dm_clone, &input_clone, |primer_turn_index, chunk| {
+            let payload = ChunkEvent {
+                primer_turn_index,
+                text: chunk.to_string(),
+            };
+            if let Err(e) = app_clone.emit("primer://chunk", &payload) {
+                tracing::warn!("emit primer://chunk failed: {e}");
+            }
+        })
+        .await
+    });
+
+    // Stash the abort handle so `cancel_response` can target this turn.
+    // Held only briefly; cleared on completion below.
+    {
+        let guard = state.session.lock().await;
+        if let Some(active) = guard.as_ref() {
+            *active.current_turn_abort.lock().await = Some(task.abort_handle());
         }
-    })
-    .await?;
+    }
+
+    let join_result = task.await;
+
+    // Clear the abort slot whether we succeeded, failed, or were
+    // cancelled — leaving a stale handle behind would let a second
+    // cancel hit a no-op task.
+    {
+        let guard = state.session.lock().await;
+        if let Some(active) = guard.as_ref() {
+            *active.current_turn_abort.lock().await = None;
+        }
+    }
+
+    let payload = match join_result {
+        Ok(Ok(payload)) => payload,
+        Ok(Err(e)) => return Err(e),
+        Err(join_err) if join_err.is_cancelled() => {
+            // User-initiated cancel. The child turn stays in the in-memory
+            // session; the partial Primer turn drops per DM's existing
+            // "mid-stream error" semantic. The frontend's cancellation
+            // path already knows what to do with the streaming bubble.
+            return Err(CANCELLED_MESSAGE.to_string());
+        }
+        Err(join_err) => return Err(format!("turn task crashed: {join_err}")),
+    };
 
     refresh_snapshot(&dm_arc, &snapshot_arc).await;
 
@@ -592,6 +636,42 @@ pub async fn send_message(
         tracing::warn!("emit primer://turn_complete failed: {e}");
     }
     Ok(payload)
+}
+
+/// Sentinel returned by `send_message` when the user cancelled the
+/// turn via `cancel_response`. The frontend matches on the exact
+/// string to suppress the error banner (cancellation isn't an error
+/// the user needs to see acknowledged).
+///
+/// Picked to be self-explanatory in a tracing log line while still
+/// short enough to make sense in a toast if the frontend's match
+/// missed it for any reason.
+pub const CANCELLED_MESSAGE: &str = "Turn cancelled by user.";
+
+/// Abort the in-flight turn, if any. Idempotent — calling with no
+/// active turn (or no active session) is a no-op and returns Ok.
+///
+/// Triggers `JoinHandle::abort()` on the spawned task. The aborted
+/// future drops mid-`respond_to_streaming`, which:
+/// - Releases the DM lock guard.
+/// - Leaves the already-appended child turn in `dm.session.turns`
+///   (so the next `send_message` continues the same conversation).
+/// - Drops the partial Primer response per DM's "mid-stream error
+///   → no Primer turn recorded" invariant.
+///
+/// `send_message` observes the abort via `JoinError::is_cancelled`
+/// and returns the [`CANCELLED_MESSAGE`] sentinel so the frontend
+/// can distinguish user-cancel from a genuine error.
+#[tauri::command]
+pub async fn cancel_response(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let guard = state.session.lock().await;
+    if let Some(active) = guard.as_ref() {
+        let abort_guard = active.current_turn_abort.lock().await;
+        if let Some(handle) = abort_guard.as_ref() {
+            handle.abort();
+        }
+    }
+    Ok(())
 }
 
 /// Re-read learner + session-id fields from the just-completed DM and
@@ -1319,5 +1399,82 @@ mod tests {
             after.session_id.is_some(),
             "post-turn snapshot carries the session id"
         );
+    }
+
+    // ─── Cancel-mid-stream tests ──────────────────────────────────────
+
+    /// Validates the contract `cancel_response` relies on:
+    /// `JoinHandle::abort()` on a still-pending task results in a
+    /// `JoinError::is_cancelled() == true` join result. This is a
+    /// tokio invariant our cancel path is built on; the test exists
+    /// to fail loudly if a future tokio bump changes the semantics
+    /// (which would silently break our cancel path).
+    #[tokio::test]
+    async fn abort_handle_yields_cancelled_join_error() {
+        let task = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            "unreachable"
+        });
+        let handle = task.abort_handle();
+        // Yield once so the task enters its sleep.
+        tokio::task::yield_now().await;
+        handle.abort();
+        let err = task.await.unwrap_err();
+        assert!(
+            err.is_cancelled(),
+            "abort() should produce a cancelled JoinError, got {err:?}"
+        );
+    }
+
+    /// `current_turn_abort` starts None and stays None after a normal
+    /// turn — the send_message path's "clear-on-completion" step keeps
+    /// a stale handle from sitting around between turns.
+    #[tokio::test]
+    async fn current_turn_abort_slot_lifecycle() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+
+        assert!(
+            active.current_turn_abort.lock().await.is_none(),
+            "starts empty"
+        );
+
+        // Mirror the spawn + store + await + clear sequence from
+        // send_message.
+        let dm_arc = Arc::clone(&active.dialogue_manager);
+        let task = tokio::spawn(async move {
+            run_turn(&dm_arc, "hello", |_, _| {}).await
+        });
+        *active.current_turn_abort.lock().await = Some(task.abort_handle());
+
+        let result = task.await.expect("task completes without panic");
+        assert!(result.is_ok(), "stub turn succeeds");
+
+        *active.current_turn_abort.lock().await = None;
+        assert!(
+            active.current_turn_abort.lock().await.is_none(),
+            "cleared after completion"
+        );
+    }
+
+    /// Calling the cancel sequence on a session with no in-flight turn
+    /// is safe — the optional handle is None and the abort branch is
+    /// skipped without panic. Mirrors what `cancel_response` does when
+    /// the user clicks Cancel a moment after the response landed.
+    #[tokio::test]
+    async fn cancel_with_idle_session_is_noop() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+
+        // Mirror what cancel_response does with the slot.
+        let abort_guard = active.current_turn_abort.lock().await;
+        if let Some(handle) = abort_guard.as_ref() {
+            handle.abort();
+        }
+        // We never panicked, and the slot is still None.
+        drop(abort_guard);
+        assert!(active.current_turn_abort.lock().await.is_none());
     }
 }

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -580,6 +580,12 @@ pub async fn send_message(
     // Spawn the turn in a dedicated task so `cancel_response` can abort
     // it. The chunk emitter lives inside the spawn because closures
     // crossing the spawn boundary need owned captures.
+    //
+    // There is a microseconds-wide window between this `spawn` and the
+    // slot-stash below in which a `cancel_response` would observe an
+    // empty slot and silently no-op. Unobservable at human reaction
+    // times; closing it would mean pre-allocating a slot before the
+    // task exists, which adds complexity for no realistic gain.
     let dm_clone = Arc::clone(&dm_arc);
     let app_clone = app.clone();
     let input_clone = input.clone();
@@ -639,14 +645,28 @@ pub async fn send_message(
 }
 
 /// Sentinel returned by `send_message` when the user cancelled the
-/// turn via `cancel_response`. The frontend matches on the exact
-/// string to suppress the error banner (cancellation isn't an error
-/// the user needs to see acknowledged).
+/// turn via `cancel_response`. Deliberately a machine-readable token
+/// (`namespace:event`) rather than a user-facing sentence: the
+/// frontend matches the exact value to suppress the error banner,
+/// and any user-facing wording is the frontend's concern. If the
+/// token ever leaks past the frontend match it reads as an obvious
+/// bug rather than masquerading as a localised string.
 ///
-/// Picked to be self-explanatory in a tracing log line while still
-/// short enough to make sense in a toast if the frontend's match
-/// missed it for any reason.
-pub const CANCELLED_MESSAGE: &str = "Turn cancelled by user.";
+/// Must stay in lockstep with `CANCEL_SENTINEL` in `ui/app.js`. The
+/// `cancelled_message_is_stable_machine_token` unit test pins the
+/// value so a one-sided change here breaks CI immediately.
+pub const CANCELLED_MESSAGE: &str = "primer:turn_cancelled";
+
+/// Abort the in-flight turn associated with `active`, if any. Pure
+/// helper (no Tauri state) so unit tests can drive it directly. The
+/// `cancel_response` command is a thin lookup-then-delegate wrapper
+/// around this.
+async fn cancel_active_turn(active: &ActiveSession) {
+    let abort_guard = active.current_turn_abort.lock().await;
+    if let Some(handle) = abort_guard.as_ref() {
+        handle.abort();
+    }
+}
 
 /// Abort the in-flight turn, if any. Idempotent — calling with no
 /// active turn (or no active session) is a no-op and returns Ok.
@@ -666,10 +686,7 @@ pub const CANCELLED_MESSAGE: &str = "Turn cancelled by user.";
 pub async fn cancel_response(state: tauri::State<'_, AppState>) -> Result<(), String> {
     let guard = state.session.lock().await;
     if let Some(active) = guard.as_ref() {
-        let abort_guard = active.current_turn_abort.lock().await;
-        if let Some(handle) = abort_guard.as_ref() {
-            handle.abort();
-        }
+        cancel_active_turn(active).await;
     }
     Ok(())
 }
@@ -1443,9 +1460,7 @@ mod tests {
         // Mirror the spawn + store + await + clear sequence from
         // send_message.
         let dm_arc = Arc::clone(&active.dialogue_manager);
-        let task = tokio::spawn(async move {
-            run_turn(&dm_arc, "hello", |_, _| {}).await
-        });
+        let task = tokio::spawn(async move { run_turn(&dm_arc, "hello", |_, _| {}).await });
         *active.current_turn_abort.lock().await = Some(task.abort_handle());
 
         let result = task.await.expect("task completes without panic");
@@ -1468,13 +1483,50 @@ mod tests {
         let cfg = stub_config_with_persistence(home.path());
         let active = build_active_session(home.path(), &cfg).await.unwrap();
 
-        // Mirror what cancel_response does with the slot.
-        let abort_guard = active.current_turn_abort.lock().await;
-        if let Some(handle) = abort_guard.as_ref() {
-            handle.abort();
-        }
-        // We never panicked, and the slot is still None.
-        drop(abort_guard);
+        // Drive the production helper directly. With an empty slot
+        // this must return cleanly without panicking.
+        cancel_active_turn(&active).await;
         assert!(active.current_turn_abort.lock().await.is_none());
+    }
+
+    /// End-to-end smoke for the cancel path's effect on a live task:
+    /// spawn a pending task, stash its abort handle, drive
+    /// `cancel_active_turn`, and verify the join result reports
+    /// cancellation. Pins the abort *wiring* (not just the slot
+    /// mechanics) without needing a Tauri runtime in scope.
+    #[tokio::test]
+    async fn cancel_active_turn_aborts_pending_task() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+
+        // A long sleep stands in for an in-flight respond_to_streaming.
+        // What matters is that `.abort()` on the stashed handle drops
+        // the future and yields a cancelled JoinError, which is the
+        // exact contract `send_message`'s match arm relies on.
+        let task = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        *active.current_turn_abort.lock().await = Some(task.abort_handle());
+        tokio::task::yield_now().await;
+
+        cancel_active_turn(&active).await;
+
+        let join_err = task.await.expect_err("task should be cancelled");
+        assert!(
+            join_err.is_cancelled(),
+            "expected cancelled JoinError, got {join_err:?}"
+        );
+    }
+
+    /// The frontend (`ui/app.js`) matches `CANCEL_SENTINEL` against
+    /// this exact string to suppress the error banner on
+    /// user-initiated cancel. A one-sided rename here without an
+    /// equivalent change in `ui/app.js` would silently re-surface
+    /// cancel messages as errors — pin the value so CI catches the
+    /// drift the moment it lands.
+    #[test]
+    fn cancelled_message_is_stable_machine_token() {
+        assert_eq!(CANCELLED_MESSAGE, "primer:turn_cancelled");
     }
 }

--- a/src/crates/primer-gui/src/state.rs
+++ b/src/crates/primer-gui/src/state.rs
@@ -34,6 +34,7 @@ use primer_core::i18n::Locale;
 use primer_core::storage::SessionStore;
 use primer_pedagogy::DialogueManager;
 use tokio::sync::Mutex;
+use tokio::task::AbortHandle;
 use uuid::Uuid;
 
 use crate::config::GuiConfig;
@@ -112,6 +113,14 @@ pub struct ActiveSession {
     /// `load_session`, and we don't want to re-open the SQLite file
     /// just to read one row.
     pub session_store: Arc<dyn SessionStore>,
+
+    /// Abort handle for the in-flight turn, if any. `send_message`
+    /// spawns the turn into a dedicated tokio task and stashes its
+    /// abort handle here; `cancel_response` calls `.abort()` on it to
+    /// drop the in-progress stream. The DM's existing "partial Primer
+    /// turn is not recorded on mid-stream error" invariant cleans up
+    /// the state correctly when the spawned future is dropped.
+    pub current_turn_abort: Mutex<Option<AbortHandle>>,
 }
 
 /// Read-mostly mirror of the DM-owned fields the frontend renders via

--- a/src/crates/primer-gui/src/wiring.rs
+++ b/src/crates/primer-gui/src/wiring.rs
@@ -282,6 +282,7 @@ pub async fn build_active_session(
         backend_name: backend_config.kind.clone(),
         main_model,
         session_store: Arc::clone(&session_store) as _,
+        current_turn_abort: Mutex::new(None),
     })
 }
 

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -72,10 +72,12 @@ const MAX_BOX_LEVEL = 4;
 
 /// Sentinel returned by `send_message` when the user clicked the
 /// Cancel button mid-stream. Matches the `CANCELLED_MESSAGE` const in
-/// `commands/session.rs` — if that string ever changes, this constant
-/// must move in lockstep or the frontend will surface "Turn cancelled
-/// by user." as if it were a real error.
-const CANCEL_SENTINEL = "Turn cancelled by user.";
+/// `commands/session.rs` — a `cancelled_message_is_stable_machine_token`
+/// unit test on the Rust side pins the value, so a one-sided change
+/// here or there breaks CI immediately. A machine-readable token
+/// (rather than a sentence) means a missed match surfaces as obvious
+/// machine output, not a localised-looking string.
+const CANCEL_SENTINEL = "primer:turn_cancelled";
 
 // Live state — `streamingPrimerEl` points at the currently-streaming
 // Primer bubble (if any) so chunk events can append to its text node
@@ -201,10 +203,6 @@ async function handleSessionReady({ info, shouldReplay }) {
   }
 
   setComposerState("idle");
-  // Header "Sessions" button is gated on having an active session —
-  // the picker should only be re-reachable once one exists, otherwise
-  // clicking it does nothing visible.
-  dom.switchSession.disabled = false;
   refreshSidebar();
 }
 
@@ -273,16 +271,21 @@ function renderSessionInfo(info) {
 }
 
 /// Drive the composer's three-state UI from a single function so the
-/// Send/Cancel toggle stays in lockstep with input enabled-ness.
+/// Send/Cancel toggle, input enabled-ness, and the "Sessions" header
+/// button all stay in lockstep.
 ///
-/// - `disabled`: pre-session — both input and send button are inert.
-///   Used between launch and the first session, and after the user
-///   clicks the Sessions button to return to the picker.
+/// - `disabled`: pre-session — both input and send button are inert,
+///   and the Sessions button is hidden behind a disabled state since
+///   there's nothing to switch away from. Used between launch and the
+///   first session, and after `onSwitchSession` returns to the picker.
 /// - `idle`: a session is ready, no turn in flight — input is
-///   editable, Send button posts the typed message.
+///   editable, Send button posts the typed message, Sessions button
+///   is enabled (the picker is reachable).
 /// - `streaming`: a turn is in flight — input is locked (can't queue
 ///   a second turn), Send button shows "Cancel" and dispatches
-///   `cancel_response` on click.
+///   `cancel_response` on click, Sessions button is disabled so a
+///   stray click can't kick off a `close_session` that blocks on the
+///   in-flight turn's DM lock.
 ///
 /// Also flips `state.isStreaming` so the form submit handler can
 /// route between submit-new and cancel-current paths.
@@ -293,6 +296,7 @@ function setComposerState(mode) {
       dom.send.disabled = true;
       dom.send.textContent = "Send";
       dom.send.classList.remove("is-cancel");
+      dom.switchSession.disabled = true;
       state.isStreaming = false;
       break;
     case "idle":
@@ -300,6 +304,7 @@ function setComposerState(mode) {
       dom.send.disabled = false;
       dom.send.textContent = "Send";
       dom.send.classList.remove("is-cancel");
+      dom.switchSession.disabled = false;
       state.isStreaming = false;
       dom.input.focus();
       break;
@@ -309,6 +314,7 @@ function setComposerState(mode) {
       dom.send.disabled = false;
       dom.send.textContent = "Cancel";
       dom.send.classList.add("is-cancel");
+      dom.switchSession.disabled = true;
       state.isStreaming = true;
       break;
     default:
@@ -366,8 +372,9 @@ async function onSubmit(e) {
     // User-initiated cancellation isn't an error the user needs to
     // see acknowledged — they clicked the button, the partial bubble
     // already disappeared as confirmation. A toast would be noise.
-    if (formatErr(err) !== CANCEL_SENTINEL) {
-      showError(formatErr(err));
+    const msg = formatErr(err);
+    if (msg !== CANCEL_SENTINEL) {
+      showError(msg);
     }
     setComposerState("idle");
     // Backend kept the child turn even on mid-stream failure; refresh

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -24,6 +24,7 @@ const dom = {
   send: document.getElementById("send"),
   sidebarToggle: document.getElementById("sidebar-toggle"),
   settingsOpen: document.getElementById("settings-open"),
+  switchSession: document.getElementById("switch-session"),
   signals: {
     empty: document.getElementById("sidebar-empty"),
     lagHint: document.getElementById("signals-lag-hint"),
@@ -69,12 +70,24 @@ const dom = {
 /// Maximum filled box dots — matches MAX_BOX_LEVEL in primer_core::vocab.
 const MAX_BOX_LEVEL = 4;
 
+/// Sentinel returned by `send_message` when the user clicked the
+/// Cancel button mid-stream. Matches the `CANCELLED_MESSAGE` const in
+/// `commands/session.rs` — if that string ever changes, this constant
+/// must move in lockstep or the frontend will surface "Turn cancelled
+/// by user." as if it were a real error.
+const CANCEL_SENTINEL = "Turn cancelled by user.";
+
 // Live state — `streamingPrimerEl` points at the currently-streaming
 // Primer bubble (if any) so chunk events can append to its text node
 // without re-querying the DOM.
 const state = {
   sessionId: null,
   streamingPrimerEl: null,
+  /// `true` while a `send_message` invocation is in flight. Drives the
+  /// Send button's Send⇄Cancel label swap and lets the form submit
+  /// handler route a click to `cancel_response` instead of starting a
+  /// second turn while the first is still streaming.
+  isStreaming: false,
   /// Next zero-based turn index in the session timeline. Grows by 2
   /// per successful exchange (child + primer) and rolls back by 1 on a
   /// mid-stream error (the dropped Primer turn — see CLAUDE.md
@@ -98,13 +111,47 @@ async function main() {
   setupSidebarToggle();
   setupUuidCopy();
   setupSettingsButton();
-  // No auto-start anymore — show the picker and let the user pick
-  // (resume a past session) or click Start new (settings modal →
-  // save & start a fresh session).
-  await window.PrimerPicker.show({
+  setupSwitchSessionButton();
+  showPicker();
+}
+
+/// Open (or re-open) the launch-screen picker. The picker manages its
+/// own lifecycle — it hides itself on resolution and the callbacks
+/// drive the chat shell into the right state.
+function showPicker() {
+  window.PrimerPicker.show({
     onResumed: (info) => handleSessionReady({ info, shouldReplay: true }),
     onStarted: () => handleSessionReady({ info: null, shouldReplay: false }),
   });
+}
+
+function setupSwitchSessionButton() {
+  dom.switchSession.addEventListener("click", onSwitchSession);
+}
+
+/// Tear down the active session and return to the picker. Used by the
+/// header's "Sessions" button. We close the session server-side first
+/// so its background tasks drain cleanly, then wipe the chat surface
+/// before showing the picker — leaving stale bubbles up while the
+/// picker opens would feel like the previous session was still live.
+///
+/// `close_session` is idempotent and silently succeeds with no active
+/// session, so a stray click is harmless.
+async function onSwitchSession() {
+  try {
+    await invoke("close_session");
+  } catch (err) {
+    console.warn("close_session failed:", err);
+  }
+  resetChatSurface();
+  resetSessionHeader();
+  setComposerState("disabled");
+  showPicker();
+}
+
+function resetSessionHeader() {
+  dom.sessionInfo.dataset.state = "loading";
+  dom.sessionInfo.innerHTML = `<span class="muted">No session</span>`;
 }
 
 function setupSettingsButton() {
@@ -153,7 +200,11 @@ async function handleSessionReady({ info, shouldReplay }) {
     }
   }
 
-  enableComposer();
+  setComposerState("idle");
+  // Header "Sessions" button is gated on having an active session —
+  // the picker should only be re-reachable once one exists, otherwise
+  // clicking it does nothing visible.
+  dom.switchSession.disabled = false;
   refreshSidebar();
 }
 
@@ -221,15 +272,48 @@ function renderSessionInfo(info) {
   `;
 }
 
-function enableComposer() {
-  dom.input.disabled = false;
-  dom.send.disabled = false;
-  dom.input.focus();
-}
-
-function disableComposer() {
-  dom.input.disabled = true;
-  dom.send.disabled = true;
+/// Drive the composer's three-state UI from a single function so the
+/// Send/Cancel toggle stays in lockstep with input enabled-ness.
+///
+/// - `disabled`: pre-session — both input and send button are inert.
+///   Used between launch and the first session, and after the user
+///   clicks the Sessions button to return to the picker.
+/// - `idle`: a session is ready, no turn in flight — input is
+///   editable, Send button posts the typed message.
+/// - `streaming`: a turn is in flight — input is locked (can't queue
+///   a second turn), Send button shows "Cancel" and dispatches
+///   `cancel_response` on click.
+///
+/// Also flips `state.isStreaming` so the form submit handler can
+/// route between submit-new and cancel-current paths.
+function setComposerState(mode) {
+  switch (mode) {
+    case "disabled":
+      dom.input.disabled = true;
+      dom.send.disabled = true;
+      dom.send.textContent = "Send";
+      dom.send.classList.remove("is-cancel");
+      state.isStreaming = false;
+      break;
+    case "idle":
+      dom.input.disabled = false;
+      dom.send.disabled = false;
+      dom.send.textContent = "Send";
+      dom.send.classList.remove("is-cancel");
+      state.isStreaming = false;
+      dom.input.focus();
+      break;
+    case "streaming":
+      dom.input.disabled = true;
+      // Send stays clickable so the user can cancel.
+      dom.send.disabled = false;
+      dom.send.textContent = "Cancel";
+      dom.send.classList.add("is-cancel");
+      state.isStreaming = true;
+      break;
+    default:
+      console.warn("setComposerState: unknown mode", mode);
+  }
 }
 
 function setupComposer() {
@@ -253,6 +337,15 @@ function setupAutogrow() {
 
 async function onSubmit(e) {
   e.preventDefault();
+  // The Send button doubles as Cancel during a streaming turn. Route
+  // the click here rather than wiring a second listener so the form's
+  // Enter-key submit (if a future change re-enables the textarea
+  // mid-stream) still hits the same dispatch.
+  if (state.isStreaming) {
+    onCancel();
+    return;
+  }
+
   const text = dom.input.value.trim();
   if (!text || dom.send.disabled) return;
 
@@ -262,7 +355,7 @@ async function onSubmit(e) {
   state.streamingPrimerEl = appendStreamingPrimerBubble();
   dom.input.value = "";
   dom.input.style.height = "auto";
-  disableComposer();
+  setComposerState("streaming");
 
   try {
     await invoke("send_message", { input: text });
@@ -270,12 +363,39 @@ async function onSubmit(e) {
     // re-enable the composer; nothing to do here on success.
   } catch (err) {
     finaliseStreamingBubble({ aborted: true });
-    showError(formatErr(err));
-    enableComposer();
+    // User-initiated cancellation isn't an error the user needs to
+    // see acknowledged — they clicked the button, the partial bubble
+    // already disappeared as confirmation. A toast would be noise.
+    if (formatErr(err) !== CANCEL_SENTINEL) {
+      showError(formatErr(err));
+    }
+    setComposerState("idle");
     // Backend kept the child turn even on mid-stream failure; refresh
     // the sidebar so the Session list reflects it. turn_complete never
     // fired, so the standard refresh path didn't run.
     refreshSidebar();
+  }
+}
+
+/// Best-effort cancel of the in-flight turn. The actual UI cleanup
+/// (drop the streaming bubble, re-enable input) happens in the
+/// `onSubmit` catch branch when `send_message` returns the
+/// [`CANCEL_SENTINEL`] error — keeping the cleanup in one place
+/// avoids racing the backend's abort path. The button briefly disables
+/// here so a rapid double-click doesn't fire two cancel_response
+/// commands (the second would be a no-op but the visual flash looks
+/// glitchy).
+async function onCancel() {
+  dom.send.disabled = true;
+  try {
+    await invoke("cancel_response");
+  } catch (err) {
+    console.warn("cancel_response failed:", err);
+  } finally {
+    // Re-enable so the user can click again if the backend didn't
+    // actually abort (shouldn't happen, but the button shouldn't
+    // become permanently stuck if it does).
+    dom.send.disabled = false;
   }
 }
 
@@ -298,7 +418,7 @@ function setupTurnCompleteListener() {
   listen("primer://turn_complete", (event) => {
     state.sessionId = event.payload.session_id;
     finaliseStreamingBubble({ aborted: false });
-    enableComposer();
+    setComposerState("idle");
     // Fire-and-forget — sidebar updates are non-critical; a failure
     // here shouldn't deny the user the chat surface.
     refreshSidebar();

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -19,6 +19,15 @@
         <button
           type="button"
           class="header-btn"
+          id="switch-session"
+          title="Return to the session picker to switch or start fresh"
+          disabled
+        >
+          Sessions
+        </button>
+        <button
+          type="button"
+          class="header-btn"
           id="settings-open"
           aria-haspopup="dialog"
           aria-controls="settings-modal"

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -322,6 +322,33 @@ body.sidebar-collapsed {
   opacity: 0.55;
 }
 
+/* Send button doubles as Cancel while a turn streams. A red-orange
+   tint is the standard "destructive/abort" affordance and is clearly
+   distinct from the accent-coloured Send state so the user can see
+   the role swap at a glance. */
+#send.is-cancel {
+  background: #dc2626;
+  color: #fff;
+}
+
+#send.is-cancel:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+@media (prefers-color-scheme: dark) {
+  #send.is-cancel {
+    background: #ef4444;
+  }
+  #send.is-cancel:hover:not(:disabled) {
+    background: #dc2626;
+  }
+}
+
+.header-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 /* ─── Sidebar toggle button ─────────────────────────────────────── */
 
 .sidebar-toggle {


### PR DESCRIPTION
## Summary

Step 10 of the [GUI plan](../blob/main/.claude/plans/we-need-a-basic-abstract-wigderson.md) — the polish pass that rounds out day-to-day use.

### Cancel-mid-stream
- New `current_turn_abort: Mutex<Option<AbortHandle>>` on `ActiveSession`. `send_message` now spawns the turn into a tokio task and stashes its `AbortHandle`.
- New **`cancel_response`** Tauri command calls `.abort()` on the slot, dropping the in-flight `respond_to_streaming`. DM's existing "partial Primer turn is not recorded on mid-stream error" invariant does the cleanup — the child turn stays in memory and the next `send_message` continues the conversation cleanly.
- `send_message` returns the sentinel `"Turn cancelled by user."` on `JoinError::is_cancelled`; the frontend matches the exact string to suppress the error banner (a user-initiated cancel isn't an error worth surfacing).
- Three new tests cover the tokio AbortHandle ↔ JoinError contract our code relies on, the abort-slot lifecycle, and the cancel-with-idle-session no-op.

### Frontend Send/Cancel toggle
- Send button text swaps to **Cancel** with a red destructive tint while a turn streams; clicking routes the form submit through `cancel_response` instead of starting a second turn. Input textarea stays locked during streaming (no queueing).
- Replaced ad-hoc `enableComposer` / `disableComposer` with `setComposerState("disabled" | "idle" | "streaming")` so button label / input enabled-ness / `state.isStreaming` stay in lockstep.

### Switch-session header button
- New **Sessions** button in the header (next to Settings). Disabled until a session is active; clicking it calls `close_session`, wipes the chat surface, resets the session-info pill, and re-shows the picker. The same picker callbacks drive `handleSessionReady` so a resumed-from-mid-session picks up exactly like a fresh launch.

## Test plan
- [x] `cargo test --workspace` — 721 tests pass (3 new in primer-gui)
- [x] `cargo clippy -p primer-gui --all-targets` clean
- [ ] Manual: start a streaming response, click Cancel mid-stream → partial bubble drops, no error banner, composer back to idle
- [ ] Manual: send a follow-up message after cancel → child turn lands at the correct index, Session sidebar's click-to-scroll still aligns
- [ ] Manual: click Sessions in header → close happens, picker reopens with the most-recent session visible
- [ ] Manual: send error path (e.g. cloud backend with bad API key) — banner appears, NOT the cancel-silent path
- [ ] Manual: verify Send-as-Cancel button visibly toggles red in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)