### PR TITLE
docs: evaluate KidRails for child-appropriate fine-tuning

### DIFF
--- a/docs/background_research/KidRails.md
+++ b/docs/background_research/KidRails.md
@@ -1,0 +1,50 @@
+# KidRails (arcee-ai/KidRails) — Evaluation for Primer
+
+**Date:** 2026-05-13
+**Verdict:** Not suitable for Primer's needs. No reuse path for non-English languages.
+
+## Overview
+
+KidRails is a child-safety fine-tuning project by Arcee AI and AngelQ (Feb 2025).
+It ships three artifacts:
+
+- **Fine-tuned model** (`arcee-ai/KidRails` on HuggingFace) — Llama 3.1 8B tuned for child-safe responses. Empty model card, ~7 downloads/month.
+- **Dataset** (`arcee-ai/KidRails-Dataset`) — 1,006 synthetic multi-turn conversations, 5.25 MB. Columns: child name, age (5-12), question, system prompt, conversation (9-13 turns), personality (shy/curious/enthusiastic/etc.), intensity.
+- **Pipeline code** (`github.com/arcee-ai/KidRails`) — MIT-licensed Python for data generation. 14 stars, 5 forks.
+
+## How the data is built
+
+The pipeline is entirely synthetic, seeded from 48 human-curated Q&A pairs (28 safe + 20 unsafe) provided by AngelQ. Steps:
+
+1. Piaget developmental stages mapped to age ranges (preoperational 2-6, concrete operational 7-11, formal operational 12+).
+2. 1,000 child persona profiles generated from random combinations of age, personality traits, and interests.
+3. LLM calls (Llama 3 70B / Qwen 2 72B via OpenRouter) expand persona profiles into paragraph descriptions.
+4. OpenAI API calls paraphrase the 48 seed pairs into ~1,000 variant conversations.
+
+The 48 seed examples are the only non-synthetic grounding. The 1,006 dataset rows are variations on those 48 themes, not independent examples.
+
+## Why it does not fit Primer
+
+**Different problem scope.** KidRails teaches a model to refuse harmful questions and redirect to safe topics. It has no Socratic method, no pedagogical scaffolding, no comprehension verification, no engagement adaptation. Primer already handles all of these at the dialogue-manager and prompt-builder level.
+
+**Too small and narrow.** 1,006 paraphrased examples from 48 seeds cannot cover the breadth of questions children actually ask. Primer's 91-passage EN corpus (+ 66-passage DE corpus) with tuned hybrid retrieval provides richer topical coverage without fine-tuning.
+
+**No evaluation.** The HuggingFace model card is empty — no benchmarks, no safety evaluations, no human assessment of age-appropriateness.
+
+**No vocabulary calibration.** Age differentiation is purely system-prompt instructions ("use simple words" for age 6). No reading-level measurement or per-concept difficulty tracking. Primer already handles this with the Leitner-box scheduler and comprehension classifier.
+
+## Multilingual reuse
+
+English-only throughout. Adapting for German (or any other language) would require rebuilding the entire pipeline from scratch: rewriting all 48 seed pairs, regenerating personas and conversations, re-fine-tuning. The only transferable concept is the Piaget-stage-to-persona mapping, which Primer's `LearnerProfile` already captures more richly.
+
+## What is mildly interesting
+
+- **Spectrum fine-tuning method** (arXiv 2406.06623, Hartford et al. 2024): SNR-based layer-selective training that claims performance comparable to full fine-tuning with reduced GPU memory. Worth knowing about if Primer ever pursues on-device fine-tuning (Phase 1+), but it is one of many PEFT methods.
+- The Piaget-stage developmental framing is pedagogically sound, though not novel.
+
+## References
+
+- Repository: https://github.com/arcee-ai/KidRails
+- Dataset: https://huggingface.co/datasets/arcee-ai/KidRails-Dataset
+- Model: https://huggingface.co/arcee-ai/KidRails
+- Spectrum paper: https://arxiv.org/abs/2406.06623


### PR DESCRIPTION
## Summary
- Adds evaluation of [arcee-ai/KidRails](https://github.com/arcee-ai/KidRails) to `docs/background_research/`
- KidRails is a child-safety fine-tuning project (Llama 3.1 8B + 1,006 synthetic conversations) — assessed and found unsuitable for Primer
- Key reasons: solves a narrower safety-filter problem, dataset too small (48 seed pairs), English-only with no multilingual path, and Primer already exceeds its capabilities

## Test plan
- [x] Document reviewed for accuracy against source repo and HuggingFace artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)