### PR TITLE
ci: make clippy -D warnings step explicit (closes #95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings
 
 jobs:
   # Default-feature build + test on Linux. The full speech-feature build
@@ -64,11 +63,20 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: cargo clippy
-        run: cargo clippy --workspace --all-targets
+        # `-- -D warnings` is co-located with the step that enforces it
+        # so a CI failure here reads as a policy choice rather than an
+        # invisible workflow-env escalation (closes #95).
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: cargo test
         # Includes the retrieval-quality integration test in
         # primer-kb-load/tests/retrieval_quality.rs, which loads the
         # in-repo seed corpus and asserts canonical child queries
         # surface the right passages.
+        #
+        # `RUSTFLAGS: -D warnings` is set step-locally so test-only
+        # compile warnings (e.g. new dead-code in #[cfg(test)] blocks)
+        # still fail CI, matching the pre-#95 workflow-env behaviour.
+        env:
+          RUSTFLAGS: -D warnings
         run: cargo test --workspace --no-fail-fast


### PR DESCRIPTION
## Summary

- Drop workflow-level `RUSTFLAGS: -D warnings` env.
- Add `-- -D warnings` to the explicit `cargo clippy` step.
- Keep `cargo test` strict by setting `RUSTFLAGS: -D warnings` as a step-local env, mirroring the pre-#95 behaviour.

The policy is now co-located with the steps that enforce it, so a future CI failure reads as a deliberate policy choice rather than an invisible workflow-env effect (the confusion PR #94 hit).

## Test plan

- [x] Local `~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings` — exit 0.
- [x] Local `RUSTFLAGS="-D warnings" ~/.cargo/bin/cargo test --workspace --no-fail-fast` — 826 passed / 0 failed / 3 ignored.
- [x] CI workflow on this PR exercises the new step shape (the PR effectively tests itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)