### PR TITLE
gui: expose Locale::ALL via list_locales Tauri command (closes #80)

### DIFF
--- a/src/crates/primer-core/src/i18n.rs
+++ b/src/crates/primer-core/src/i18n.rs
@@ -92,6 +92,18 @@ impl Locale {
         }
     }
 
+    /// The locale's name written in its own language (an "endonym" or
+    /// "autonym"). Used as the user-facing label in a locale picker so a
+    /// German child sees "Deutsch", not "German". Distinct from
+    /// [`Self::name`], which is the English exonym (stable machine id).
+    pub fn endonym(self) -> &'static str {
+        match self {
+            Self::English => "English",
+            Self::German => "Deutsch",
+            Self::Hindi => "हिन्दी",
+        }
+    }
+
     /// Parse a short pack id back to a `Locale`. Returns `None` for
     /// unknown ids (caller decides whether that's a hard error or a
     /// fall-back to `Locale::default()`).
@@ -319,6 +331,17 @@ mod tests {
         assert_eq!(Locale::Hindi.bcp47(), "hi-IN");
         assert_eq!(Locale::Hindi.name(), "Hindi");
         assert_eq!(Locale::from_pack_id("hi"), Some(Locale::Hindi));
+    }
+
+    /// `endonym()` returns each locale's name in its own language —
+    /// the label shown in a locale-picker UI so a German child sees
+    /// "Deutsch" rather than "German". Pinned for every variant so a
+    /// future locale addition can't silently fall through to a default.
+    #[test]
+    fn locale_endonym_matches_locale_native_spelling() {
+        assert_eq!(Locale::English.endonym(), "English");
+        assert_eq!(Locale::German.endonym(), "Deutsch");
+        assert_eq!(Locale::Hindi.endonym(), "हिन्दी");
     }
 
     /// Hindi is gated as a preview locale: present in the enum, available

--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
     builder.invoke_handler(tauri::generate_handler![
         settings::get_settings,
         settings::update_settings,
+        settings::list_locales,
         session::start_session,
         session::close_session,
         session::resume_session,

--- a/src/crates/primer-gui/src/commands/settings.rs
+++ b/src/crates/primer-gui/src/commands/settings.rs
@@ -6,10 +6,18 @@
 //! lets the frontend save the rest of the config without ever holding
 //! the secret. Validation runs *before* the disk write so a bad config
 //! never lands on disk.
+//!
+//! `list_locales` exposes [`primer_core::i18n::Locale::ALL`] to the
+//! settings modal so the locale-picker dropdown is sourced from Rust
+//! rather than a hand-mirrored JS list. Preview locales (those not in
+//! `Locale::ALL`) are automatically excluded — the IPC surface is the
+//! single source of truth for "which locales are advertised to users".
 
 use crate::config::{self, GuiConfigUpdate, GuiConfigView};
 use crate::state::AppState;
 use crate::validation;
+use primer_core::i18n::Locale;
+use serde::Serialize;
 
 /// Return the current GUI settings (redacted view — no inline API key).
 /// Always succeeds; missing-on-disk returns the in-memory defaults
@@ -46,4 +54,83 @@ pub async fn update_settings(
     config::save(&state.home, &resolved).map_err(|e| e.to_string())?;
     *guard = resolved;
     Ok(())
+}
+
+/// One row of the locale-picker dropdown.
+///
+/// `id` is the stable pack id (round-trips through `learners.locale` and
+/// the `update_settings` validator). `label` is the endonym — the
+/// locale's name written in its own language — for direct display in the
+/// dropdown. The shape is JSON-serialized as `{"id":"...","label":"..."}`;
+/// the frontend reads both fields verbatim.
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct LocaleChoice {
+    pub id: String,
+    pub label: String,
+}
+
+/// Locales that are advertised to end users in the settings picker.
+///
+/// Mirrors `Locale::ALL` exactly — preview locales (e.g. Hindi while the
+/// machine translation awaits native-speaker review) are excluded from
+/// `Locale::ALL` and therefore from this command's output. Pure, no
+/// state, never errors.
+#[tauri::command]
+pub async fn list_locales() -> Result<Vec<LocaleChoice>, String> {
+    Ok(Locale::ALL
+        .iter()
+        .map(|l| LocaleChoice {
+            id: l.pack_id().to_string(),
+            label: l.endonym().to_string(),
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `list_locales` returns exactly `Locale::ALL` in declaration order,
+    /// each row carrying `(pack_id, endonym)`. This is the load-bearing
+    /// invariant that lets the settings modal drop its hand-mirrored
+    /// JS list — drift would re-introduce the divergence #80 was filed
+    /// against.
+    #[tokio::test]
+    async fn list_locales_mirrors_locale_all_with_endonyms() {
+        let result = list_locales().await.expect("list_locales never errors");
+        let expected: Vec<LocaleChoice> = Locale::ALL
+            .iter()
+            .map(|l| LocaleChoice {
+                id: l.pack_id().to_string(),
+                label: l.endonym().to_string(),
+            })
+            .collect();
+        assert_eq!(result, expected);
+    }
+
+    /// Preview locales (currently Hindi) must never appear in the
+    /// dropdown — they're excluded from `Locale::ALL` by design. Pinning
+    /// the specific id here makes a future "oh I'll add Hindi without
+    /// reviewing the prompt pack" mistake a hard test failure.
+    #[tokio::test]
+    async fn list_locales_excludes_preview_hindi() {
+        let result = list_locales().await.expect("list_locales never errors");
+        assert!(
+            result.iter().all(|c| c.id != "hi"),
+            "Hindi must stay out of the picker until native-speaker review; got: {result:?}"
+        );
+    }
+
+    /// Pin the JSON shape — the frontend reads `id` and `label` fields
+    /// verbatim. A rename here silently breaks the settings modal.
+    #[test]
+    fn locale_choice_serialises_with_id_and_label() {
+        let c = LocaleChoice {
+            id: "en".into(),
+            label: "English".into(),
+        };
+        let json = serde_json::to_value(&c).unwrap();
+        assert_eq!(json["id"], "en");
+        assert_eq!(json["label"], "English");
+    }
 }

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -317,8 +317,9 @@
               <label class="field">
                 <span>Locale</span>
                 <select id="f-learner-locale">
-                  <!-- Options injected from JS so adding a locale pack
-                       only requires updating LOCALE_CHOICES in settings.js. -->
+                  <!-- Options injected from JS via the `list_locales` Tauri
+                       command, so adding a locale pack is a Rust-only edit
+                       (extend `Locale::ALL` in primer-core). -->
                 </select>
               </label>
             </div>
@@ -592,8 +593,9 @@
 
               <h3 class="settings-subhead">Per-locale overrides</h3>
               <div id="f-speech-overrides">
-                <!-- One sub-card per locale; rendered from JS so adding a locale
-                     pack only requires updating LOCALE_CHOICES in settings.js. -->
+                <!-- One sub-card per locale; rendered from JS using the
+                     `list_locales` Tauri command, so adding a locale pack
+                     is a Rust-only edit (extend `Locale::ALL` in primer-core). -->
               </div>
             </div>
           </details>

--- a/src/crates/primer-gui/ui/settings.js
+++ b/src/crates/primer-gui/ui/settings.js
@@ -18,13 +18,11 @@
 (() => {
 const { invoke } = window.__TAURI__.core;
 
-// Locale list must stay in sync with `primer_core::i18n::Locale::ALL`.
-// The validation step (`validate_locale`) is the authoritative check;
-// this list is just for the dropdown UI.
-const LOCALE_CHOICES = [
-  { id: "en", label: "English" },
-  { id: "de", label: "Deutsch" },
-];
+// Locale choices come from the `list_locales` Tauri command, which
+// reads `primer_core::i18n::Locale::ALL`. Sourcing the list from Rust
+// means a new locale pack is a Rust-only edit — preview locales are
+// excluded automatically. `state.localeChoices` is populated by the
+// first `open()` call.
 
 const SUBSYSTEMS = ["classifier", "extractor", "comprehension"];
 
@@ -95,11 +93,18 @@ const state = {
   /// button in PR 3+), so we round-trip it verbatim — never reset it
   /// to false when the user saves the speech settings form.
   lastVoiceModeEnabled: false,
+  /// `[{id, label}]` returned by the `list_locales` Tauri command. Cached
+  /// across `open()` calls so we don't re-invoke on every modal open.
+  /// `null` until the first successful fetch; a load failure leaves it
+  /// null and the modal degrades gracefully (only the persisted locale
+  /// shows in the dropdown).
+  localeChoices: null,
 };
 
 // Initial DOM wiring — runs at script-load time. The modal stays
-// hidden via the `hidden` attribute until `open()` is called.
-populateLocaleChoices();
+// hidden via the `hidden` attribute until `open()` is called. The
+// locale dropdown is populated lazily inside `open()` once the
+// `list_locales` IPC returns.
 wireDismiss();
 wireBackendKindReveal();
 wireEmbedderKindReveal();
@@ -116,10 +121,19 @@ async function open({ onSessionRestarted } = {}) {
   state.onSessionRestarted = onSessionRestarted ?? null;
   hideBanner();
   try {
-    const [view, sessionInfo] = await Promise.all([
+    // `list_locales` is cached after the first successful fetch; on a
+    // re-open we skip the IPC and reuse the stored choices.
+    const localesPromise =
+      state.localeChoices === null
+        ? invoke("list_locales")
+        : Promise.resolve(state.localeChoices);
+    const [view, sessionInfo, locales] = await Promise.all([
       invoke("get_settings"),
       invoke("current_session_info").catch(() => null),
+      localesPromise,
     ]);
+    state.localeChoices = locales;
+    populateLocaleChoices();
     populate(view);
     dom.activeHint.hidden = sessionInfo === null;
     dom.backdrop.hidden = false;
@@ -162,7 +176,7 @@ function wireDismiss() {
 function populateLocaleChoices() {
   const sel = dom.fields.learnerLocale;
   sel.replaceChildren();
-  for (const { id, label } of LOCALE_CHOICES) {
+  for (const { id, label } of state.localeChoices ?? []) {
     const opt = document.createElement("option");
     opt.value = id;
     opt.textContent = `${label} (${id})`;
@@ -176,9 +190,11 @@ function populate(view) {
   // Learner
   f.learnerName.value = view.learner.name;
   f.learnerAge.value = view.learner.age;
-  // If the persisted locale isn't in LOCALE_CHOICES (e.g. a future
-  // pack), still show it so the user isn't silently switched.
-  if (!LOCALE_CHOICES.some((l) => l.id === view.learner.locale)) {
+  // If the persisted locale isn't in the choices returned by Rust (e.g.
+  // a preview pack reached the user via --language, or a pack id was
+  // retired), still show it so the user isn't silently switched.
+  const choices = state.localeChoices ?? [];
+  if (!choices.some((l) => l.id === view.learner.locale)) {
     const opt = document.createElement("option");
     opt.value = view.learner.locale;
     opt.textContent = `${view.learner.locale} (unknown pack)`;
@@ -255,7 +271,11 @@ function populate(view) {
 function populateSpeechOverrides(overrides) {
   const container = dom.fields.speechOverrides;
   container.replaceChildren();
-  for (const { id: locale } of LOCALE_CHOICES) {
+  // Speech-override cards mirror the locale dropdown — same source of
+  // truth (`list_locales`) so a preview locale doesn't accidentally
+  // show up here while excluded from the picker. `populate()` always
+  // runs after `state.localeChoices` has been resolved, so this is safe.
+  for (const { id: locale } of state.localeChoices ?? []) {
     const ov = overrides[locale] ?? {};
     const card = document.createElement("div");
     card.className = "settings-grid";

--- a/src/crates/primer-gui/ui/settings.js
+++ b/src/crates/primer-gui/ui/settings.js
@@ -95,9 +95,10 @@ const state = {
   lastVoiceModeEnabled: false,
   /// `[{id, label}]` returned by the `list_locales` Tauri command. Cached
   /// across `open()` calls so we don't re-invoke on every modal open.
-  /// `null` until the first successful fetch; a load failure leaves it
-  /// null and the modal degrades gracefully (only the persisted locale
-  /// shows in the dropdown).
+  /// `null` until the first successful fetch; the fetch shares the same
+  /// `Promise.all` as `get_settings`, so an IPC failure aborts the whole
+  /// modal load and surfaces an error banner — there is no
+  /// partially-populated state to worry about downstream.
   localeChoices: null,
 };
 
@@ -173,10 +174,13 @@ function wireDismiss() {
   });
 }
 
+// Reads `state.localeChoices`, which is guaranteed non-null here because
+// `open()` only calls this after the `list_locales` IPC resolves
+// successfully (a rejected IPC short-circuits into the catch branch).
 function populateLocaleChoices() {
   const sel = dom.fields.learnerLocale;
   sel.replaceChildren();
-  for (const { id, label } of state.localeChoices ?? []) {
+  for (const { id, label } of state.localeChoices) {
     const opt = document.createElement("option");
     opt.value = id;
     opt.textContent = `${label} (${id})`;
@@ -193,8 +197,7 @@ function populate(view) {
   // If the persisted locale isn't in the choices returned by Rust (e.g.
   // a preview pack reached the user via --language, or a pack id was
   // retired), still show it so the user isn't silently switched.
-  const choices = state.localeChoices ?? [];
-  if (!choices.some((l) => l.id === view.learner.locale)) {
+  if (!state.localeChoices.some((l) => l.id === view.learner.locale)) {
     const opt = document.createElement("option");
     opt.value = view.learner.locale;
     opt.textContent = `${view.learner.locale} (unknown pack)`;
@@ -273,9 +276,10 @@ function populateSpeechOverrides(overrides) {
   container.replaceChildren();
   // Speech-override cards mirror the locale dropdown — same source of
   // truth (`list_locales`) so a preview locale doesn't accidentally
-  // show up here while excluded from the picker. `populate()` always
-  // runs after `state.localeChoices` has been resolved, so this is safe.
-  for (const { id: locale } of state.localeChoices ?? []) {
+  // show up here while excluded from the picker. `populate()` only
+  // runs after `state.localeChoices` has been resolved, so it's
+  // guaranteed non-null here.
+  for (const { id: locale } of state.localeChoices) {
     const ov = overrides[locale] ?? {};
     const card = document.createElement("div");
     card.className = "settings-grid";


### PR DESCRIPTION
## Summary

- New `list_locales` Tauri command returns `Vec<LocaleChoice>` sourced from `primer_core::i18n::Locale::ALL`. Preview locales (currently Hindi) are excluded automatically — they're not in `Locale::ALL` by design.
- New `Locale::endonym()` method returns each locale's name in its own language ("English", "Deutsch", "हिन्दी"), preserving the existing dropdown labels exactly. Distinct from `Locale::name()` (the English exonym, used as a stable machine id).
- `settings.js` drops the hand-mirrored `LOCALE_CHOICES` array and calls `list_locales` on first modal open (cached thereafter). Both the locale dropdown and the per-locale speech-override cards now read from `state.localeChoices`. Closes the divergence risk #80 was filed for: adding a new locale pack is a Rust-only edit.

## What changed

| file | net |
|---|---|
| `primer-core/src/i18n.rs` | +23 (`endonym()` + pinning test) |
| `primer-gui/src/commands/settings.rs` | +87 (`LocaleChoice`, `list_locales`, 3 tests) |
| `primer-gui/src/commands/mod.rs` | +1 (handler registration) |
| `primer-gui/ui/settings.js` | +35 / −15 (drop hard-coded list, lazy IPC fetch) |

TDD throughout: every new function landed via a failing test first.

## Test plan

- [x] `~/.cargo/bin/cargo test --workspace --no-fail-fast` → **830 passed / 0 failed / 3 ignored** (was 826 → +1 in primer-core, +3 in primer-gui)
- [x] `~/.cargo/bin/cargo test -p primer-gui --features speech` → **120 passed / 0 failed / 0 ignored** (was 117 → +3)
- [x] `~/.cargo/bin/cargo fmt --all -- --check` → clean
- [x] `~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] `RUSTFLAGS="-D warnings" ~/.cargo/bin/cargo clippy --workspace --all-targets --features primer-gui/speech` → clean
- [ ] Manual: open the GUI settings modal, confirm the locale dropdown still shows "English (en)" and "Deutsch (de)" and that the per-locale speech-override cards still render for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)