### PR TITLE
tooling: opt-in pre-commit fmt-drift hook (closes #96)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Primer pre-commit hook — rejects commits with cargo fmt drift in src/.
+#
+# Install once (from repo root):
+#     git config core.hooksPath .githooks
+#
+# Disable temporarily with `git commit --no-verify` or by unsetting the
+# config (`git config --unset core.hooksPath`).
+#
+# Behaviour:
+#   - Fast-skips when no staged file is a .rs path. Docs-only / config-only
+#     commits never pay the cost.
+#   - Runs `cargo fmt --all -- --check` from the workspace root (src/) —
+#     identical to the CI step. The CI step in .github/workflows/ci.yml is
+#     the source of truth; this hook is an early-warning copy.
+#   - On drift, prints the exact remediation command and exits 1.
+#   - On missing cargo, warns and exits 0 so non-Rust contributors can still
+#     commit docs. CI catches the drift in either case.
+set -euo pipefail
+
+STAGED_RS=$(git diff --cached --name-only --diff-filter=ACMR -- '*.rs' 2>/dev/null || true)
+if [ -z "$STAGED_RS" ]; then
+  exit 0
+fi
+
+# Resolve cargo: prefer $CARGO, then rustup's default install path, then PATH.
+# The triple lookup matches CLAUDE.md's "Homebrew rust shadows PATH" guidance —
+# rustup's $HOME/.cargo/bin must win over a Homebrew shim.
+CARGO_BIN="${CARGO:-$HOME/.cargo/bin/cargo}"
+if [ ! -x "$CARGO_BIN" ]; then
+  if command -v cargo >/dev/null 2>&1; then
+    CARGO_BIN=$(command -v cargo)
+  else
+    echo "[pre-commit] cargo not found (looked at \$CARGO=$CARGO_BIN and PATH); skipping fmt check." >&2
+    echo "[pre-commit] CI will still enforce; install rustup if you commit Rust often." >&2
+    exit 0
+  fi
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+WORKSPACE="$REPO_ROOT/src"
+
+if ! (cd "$WORKSPACE" && "$CARGO_BIN" fmt --all -- --check >/dev/null 2>&1); then
+  echo "[pre-commit] cargo fmt drift detected in src/. Fix with:" >&2
+  echo "    (cd src && '$CARGO_BIN' fmt --all)" >&2
+  echo "Then re-stage and re-commit. Use --no-verify to bypass (CI will still enforce)." >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,6 +18,10 @@
 #     commit docs. CI catches the drift in either case.
 set -euo pipefail
 
+# All Rust code in this workspace lives under src/, so a repo-wide `*.rs`
+# pathspec is equivalent to scoping to src/. If a .rs file ever lands outside
+# src/, cargo fmt --all (run from src/) won't see it — CI still catches that
+# case.
 STAGED_RS=$(git diff --cached --name-only --diff-filter=ACMR -- '*.rs' 2>/dev/null || true)
 if [ -z "$STAGED_RS" ]; then
   exit 0
@@ -25,8 +29,11 @@ fi
 
 # Resolve cargo: prefer $CARGO, then rustup's default install path, then PATH.
 # The triple lookup matches CLAUDE.md's "Homebrew rust shadows PATH" guidance —
-# rustup's $HOME/.cargo/bin must win over a Homebrew shim.
-CARGO_BIN="${CARGO:-$HOME/.cargo/bin/cargo}"
+# rustup's $HOME/.cargo/bin must win over a Homebrew shim. The `${HOME:-}`
+# defensive default keeps `set -u` from tripping in exotic envs (some
+# container/CI runners) where $HOME is unset; an empty prefix just makes the
+# default path invalid and falls through to the `command -v` lookup below.
+CARGO_BIN="${CARGO:-${HOME:-}/.cargo/bin/cargo}"
 if [ ! -x "$CARGO_BIN" ]; then
   if command -v cargo >/dev/null 2>&1; then
     CARGO_BIN=$(command -v cargo)
@@ -40,8 +47,12 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 WORKSPACE="$REPO_ROOT/src"
 
-if ! (cd "$WORKSPACE" && "$CARGO_BIN" fmt --all -- --check >/dev/null 2>&1); then
-  echo "[pre-commit] cargo fmt drift detected in src/. Fix with:" >&2
+# Let cargo's own output through on failure: the diff it prints on drift is
+# the most useful remediation aid, and on non-drift failures (rustfmt.toml
+# parse error, syntax error, toolchain issue, transient lock contention)
+# users see the real cause instead of a misleading "drift detected" message.
+if ! (cd "$WORKSPACE" && "$CARGO_BIN" fmt --all -- --check); then
+  echo "[pre-commit] cargo fmt --check failed in src/. If the diff above shows formatting differences, fix with:" >&2
   echo "    (cd src && '$CARGO_BIN' fmt --all)" >&2
   echo "Then re-stage and re-commit. Use --no-verify to bypass (CI will still enforce)." >&2
   exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,18 @@ CLI flags exposed by `primer-cli`: `--backend stub|cloud|ollama|openai-compat`, 
 
 Env files are auto-loaded at startup. Two locations checked, in order: (1) project-local `.env` (dotenvy searches cwd and ancestors), then (2) user-global `~/.primer_env`. Earlier sources win, so a per-repo `.env` overrides the home file. Copy `.env.example` → `.env` for a per-repo config, or drop `ANTHROPIC_API_KEY=...` into `~/.primer_env` to share across projects. Both `.env` and `*.local` variants are gitignored.
 
+## Local pre-commit hook (optional, recommended)
+
+A version-controlled pre-commit hook lives at [.githooks/pre-commit](.githooks/pre-commit). It runs `cargo fmt --all -- --check` from `src/` on commits that touch `.rs` files (and fast-skips otherwise). Opt in once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Bypass a single commit with `git commit --no-verify`. Disable permanently with `git config --unset core.hooksPath`. The CI step in [.github/workflows/ci.yml](.github/workflows/ci.yml) is the source of truth; the hook is an early-warning copy so drift fails locally instead of after a CI round-trip. The hook skips (with a one-line warning) when `cargo` isn't on `PATH` and `$CARGO` is unset, so docs-only contributors aren't forced to install rustup.
+
+**Branch protection is the structural fix** for `main`. The recommended setup, configurable from GitHub repo settings, is to require the `cargo test (default features)` status check before merging to `main`. The local hook complements but does not replace this — the local hook closes the loop for direct `git commit` use; branch protection closes it at the merge boundary regardless of contributor discipline. Closes issue #96.
+
 ## Architecture: trait-based hardware abstraction
 
 The central design principle is that **the pedagogical engine is decoupled from any specific inference backend, speech engine, or knowledge store via traits in `primer-core`**. Backend selection is a runtime config choice, not a code change. This is what allows Phase 0 (cloud) to share code with Phase 1 (llama.cpp / QNN NPU / RKNN NPU) and Phase 2 (Whisper + Piper).


### PR DESCRIPTION
## Summary

- Adds version-controlled [`.githooks/pre-commit`](https://github.com/hherb/primer/blob/tooling/pre-commit-hook-fmt-drift/.githooks/pre-commit) that runs `cargo fmt --all -- --check` from `src/` on commits touching `.rs` files. Fast-skips otherwise so docs-only commits stay zero-cost.
- Opt in once per clone via `git config core.hooksPath .githooks`. Bypass with `git commit --no-verify`. Disable with `git config --unset core.hooksPath`.
- [`CLAUDE.md`](https://github.com/hherb/primer/blob/tooling/pre-commit-hook-fmt-drift/CLAUDE.md) gains a brief "Local pre-commit hook" subsection covering install + bypass + the branch-protection recommendation that is the structural fix this hook complements.

## Rationale (from #96)

`main` accumulated ~5 days of `cargo fmt` drift in PRs #79/#82/#83/#85/#89 before PR #94 cleaned it up. The CI `cargo fmt --check` step was already failing on each push but went unnoticed because other steps were green. This is the second time the project has accumulated fmt drift. A structural fix is overdue.

Per #96's recommendation, the primary structural fix is **branch protection on `main`** requiring the `cargo test (default features)` CI status to be green before merge — this is a GitHub repo-settings change (called out in CLAUDE.md, not in this PR). The hook is the optional contributor-convenience layer the issue calls out: closes the loop for direct `git commit` use, doesn't rely on contributor discipline beyond opting in once.

## Hook behaviour (manually verified)

| Scenario                                | Expected            | Observed |
|----------------------------------------|---------------------|----------|
| No staged .rs files                     | exit 0, silent      | ✅       |
| Staged .rs, fmt clean                   | exit 0, silent      | ✅       |
| Staged .rs with fmt drift               | exit 1 + how-to-fix | ✅       |
| Staged .rs, cargo missing on PATH       | exit 0 + warning    | ✅       |

Resolution order for `cargo`: `$CARGO` → `$HOME/.cargo/bin/cargo` → `command -v cargo`. Mirrors CLAUDE.md's "Homebrew rust shadows PATH" guidance.

## Test plan

- [x] `cargo fmt --all -- --check` clean from `src/`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `RUSTFLAGS=-D warnings cargo test --workspace --no-fail-fast` — 830 / 0 / 3 ignored
- [x] `cargo test -p primer-gui --features speech` — 120 / 0 / 0
- [x] Manual hook verification across the 4 scenarios above

Closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)