### PR TITLE
gui: tear down voice loop on session switch (closes #102)

### DIFF
--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -46,7 +46,7 @@ const TURN_TEXT_PREVIEW_CHARS: usize = 80;
 /// internal drain.
 #[tauri::command]
 pub async fn start_session(state: tauri::State<'_, AppState>) -> Result<SessionInfo, String> {
-    close_session_inner(&state).await?;
+    prepare_for_session_change(&state).await?;
 
     let cfg = state.config.lock().await.clone();
     let active = wiring::build_active_session(&state.home, &cfg).await?;
@@ -102,7 +102,7 @@ pub async fn resume_session(
     let uuid = Uuid::parse_str(&session_id)
         .map_err(|e| format!("invalid session id {session_id:?}: {e}"))?;
 
-    close_session_inner(&state).await?;
+    prepare_for_session_change(&state).await?;
 
     let mut cfg = state.config.lock().await.clone();
 
@@ -546,13 +546,51 @@ pub(crate) fn read_signals(dm: &DialogueManager) -> TurnSignals {
 ///
 /// Also called by `commands::voice::start_voice_mode` so that switching
 /// to voice mode cleanly drains any active text session first.
-pub(crate) async fn close_session_inner(state: &tauri::State<'_, AppState>) -> Result<(), String> {
+///
+/// Takes `&AppState` rather than `&tauri::State<…>` so the unit tests
+/// for `prepare_for_session_change` can drive it without a Tauri runtime.
+/// Deref coercion lets `tauri::State<'_, AppState>` callers continue to
+/// pass `&state`.
+pub(crate) async fn close_session_inner(state: &AppState) -> Result<(), String> {
     let active = state.session.lock().await.take();
     if let Some(active) = active {
         let mut dm = active.dialogue_manager.lock().await;
         dm.close_session().await;
     }
     Ok(())
+}
+
+/// Tear down both the active voice loop (if any) and the active text
+/// session (if any) before switching to a new session. On non-speech
+/// builds the voice teardown is a compile-time no-op (the
+/// `#[cfg(feature = "speech")]`-guarded call below disappears entirely),
+/// so this collapses to just `close_session_inner` and remains correct.
+///
+/// Order matters: `voice::stop_voice_mode_inner` ALSO drops
+/// `state.session` (because the voice loop's responder owns the same
+/// DM Arc the GUI session held). Calling it first means
+/// `close_session_inner` becomes a no-op when voice mode was active,
+/// and the reverse when only a text session was open. This restores
+/// the invariant that `start_session` / `resume_session` always
+/// rebuild backends — including the locale-bound voice ones — from
+/// the new config (closes #102).
+///
+/// Without this teardown, a session switch from `de` → `en` would
+/// leave the voice loop running with its original German-locale
+/// Whisper + Piper backends until the GUI was fully restarted.
+///
+/// **Sticky-toggle preservation.** Passes `preserve_toggle = true` so
+/// `speech.voice_mode_enabled` stays at its current value across the
+/// teardown. The frontend reads the still-`true` flag after
+/// `start_session` / `resume_session` returns and auto-invokes
+/// `start_voice_mode` against the new locale — the user sees voice
+/// mode flow seamlessly into the new session instead of needing to
+/// re-toggle it. (Without this, every session switch silently flipped
+/// voice mode off and required a manual re-enable.)
+async fn prepare_for_session_change(state: &AppState) -> Result<(), String> {
+    #[cfg(feature = "speech")]
+    super::voice::stop_voice_mode_inner(state, true).await.ok();
+    close_session_inner(state).await
 }
 
 /// Read the persisted learner's locale from disk without constructing
@@ -1595,5 +1633,161 @@ mod tests {
         let info = info_from(&active).await;
         // The flag matches whatever feature the test binary was built with.
         assert_eq!(info.voice_mode_available, cfg!(feature = "speech"));
+    }
+
+    // ─── Issue #102: session switch tears down voice mode ────────────
+
+    /// `prepare_for_session_change` clears `state.session` even on
+    /// non-speech builds — the pre-existing `close_session_inner`
+    /// behaviour must survive the refactor through the new helper.
+    /// Compiled in every build so the no-speech path stays covered.
+    #[tokio::test]
+    async fn prepare_for_session_change_clears_text_session() {
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+
+        let state = AppState::new(home.path().to_path_buf(), cfg);
+        *state.session.lock().await = Some(active);
+
+        prepare_for_session_change(&state).await.unwrap();
+
+        assert!(
+            state.session.lock().await.is_none(),
+            "text session must be torn down so the next start_session rebuilds it"
+        );
+    }
+
+    /// Voice-build only: `prepare_for_session_change` tears down a
+    /// running voice loop AND preserves `speech.voice_mode_enabled`
+    /// so the frontend can auto-restart voice mode under the new
+    /// locale (closes #102 polished follow-up). Without this, every
+    /// session switch silently flipped voice mode off and required a
+    /// manual re-enable.
+    #[cfg(feature = "speech")]
+    #[tokio::test]
+    async fn prepare_for_session_change_stops_voice_loop() {
+        use primer_speech::voice_loop::VoiceLoopError;
+
+        let home = TempDir::new().unwrap();
+        let cfg = stub_config_with_persistence(home.path());
+
+        // Synthesize a voice-loop handle whose task exits cleanly the
+        // moment stop_tx is signaled — mirrors the production
+        // contract without spinning up cpal/whisper/piper.
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::channel::<()>(8);
+        let join: tokio::task::JoinHandle<Result<(), VoiceLoopError>> = tokio::spawn(async move {
+            let _ = stop_rx.await;
+            Ok(())
+        });
+
+        let active = build_active_session(home.path(), &cfg).await.unwrap();
+        let info = info_from(&active).await;
+
+        // Sticky toggle is on — mirrors the user having voice mode
+        // active at the moment of the session switch.
+        let mut cfg_with_voice_on = cfg.clone();
+        cfg_with_voice_on.speech.voice_mode_enabled = true;
+        let state = AppState::new(home.path().to_path_buf(), cfg_with_voice_on);
+        *state.session.lock().await = Some(active);
+        *state.voice.lock().await = Some(crate::state::ActiveVoiceLoop {
+            join,
+            stop_tx,
+            cancel_response_tx: cancel_tx,
+            info,
+        });
+
+        prepare_for_session_change(&state).await.unwrap();
+
+        assert!(
+            state.voice.lock().await.is_none(),
+            "voice loop must be cleared so the next start_voice_mode rebuilds backends \
+             under the new locale (issue #102)"
+        );
+        assert!(
+            state.session.lock().await.is_none(),
+            "active session must also be cleared — stop_voice_mode_inner drops it as part \
+             of its teardown"
+        );
+        assert!(
+            state.config.lock().await.speech.voice_mode_enabled,
+            "sticky toggle must survive the session-change teardown — the frontend reads \
+             this flag after start_session/resume_session returns and auto-invokes \
+             start_voice_mode against the new locale (#102 polished follow-up)"
+        );
+    }
+
+    /// Voice-build only: after a session switch from `de` → `en` via
+    /// `prepare_for_session_change` + rebuild, the new active session
+    /// is configured under the new locale. This is the
+    /// construction-time witness of the fix — the broken behaviour
+    /// from #102 was that the running voice loop kept its German
+    /// Whisper + Piper backends because `state.voice` was untouched.
+    /// With the loop now cleared, a subsequent `start_voice_mode`
+    /// (production path) rebuilds backends from the new cfg.
+    #[cfg(feature = "speech")]
+    #[tokio::test]
+    async fn session_switch_rebuilds_under_new_locale() {
+        use primer_speech::voice_loop::VoiceLoopError;
+
+        let home = TempDir::new().unwrap();
+
+        // Step 1: start under German. Uses `no_persist` so neither
+        // learner row touches disk — otherwise the locale-mismatch
+        // hard-fail from PR #101 would fire on the en-side build (it
+        // protects against silent retagging of an existing learner,
+        // a separate bug class from the voice-loop teardown gap).
+        let mut cfg_de = GuiConfig::default();
+        cfg_de.persistence.no_persist = true;
+        cfg_de.learner.locale = "de".to_string();
+        cfg_de.learner.name = "Hans".to_string();
+        let active_de = build_active_session(home.path(), &cfg_de).await.unwrap();
+        let info_de = info_from(&active_de).await;
+        assert_eq!(active_de.locale.pack_id(), "de");
+
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::channel::<()>(8);
+        let join: tokio::task::JoinHandle<Result<(), VoiceLoopError>> = tokio::spawn(async move {
+            let _ = stop_rx.await;
+            Ok(())
+        });
+
+        let state = AppState::new(home.path().to_path_buf(), cfg_de);
+        *state.session.lock().await = Some(active_de);
+        *state.voice.lock().await = Some(crate::state::ActiveVoiceLoop {
+            join,
+            stop_tx,
+            cancel_response_tx: cancel_tx,
+            info: info_de,
+        });
+
+        // Step 2: user switches to English. Mirrors what start_session
+        // does after the fix: tear down, then rebuild from current cfg.
+        {
+            let mut c = state.config.lock().await;
+            c.learner.locale = "en".to_string();
+            c.learner.name = "Alice".to_string();
+        }
+        prepare_for_session_change(&state).await.unwrap();
+
+        // Voice loop is gone — this is the *necessary condition* for
+        // the production `start_voice_mode` path to rebuild backends
+        // (LoopBackends is built once from `cfg.learner.locale` at
+        // voice.rs:118-131; pulling the loop out of `state.voice` is
+        // what frees the next `start_voice_mode` to construct new
+        // ones). This test pins that necessary condition; the actual
+        // rebuild is exercised by `start_voice_mode`'s own happy-path
+        // tests (cf. #102).
+        assert!(state.voice.lock().await.is_none());
+
+        let cfg_en = state.config.lock().await.clone();
+        let active_en = build_active_session(&state.home, &cfg_en).await.unwrap();
+        assert_eq!(
+            active_en.locale.pack_id(),
+            "en",
+            "freshly-built session uses the new cfg's locale — the production \
+             `start_voice_mode` would build LoopBackends against this same cfg"
+        );
     }
 }

--- a/src/crates/primer-gui/src/commands/voice.rs
+++ b/src/crates/primer-gui/src/commands/voice.rs
@@ -103,8 +103,10 @@ pub async fn start_voice_mode(
         .await
         .map_err(StartVoiceModeError::from)?;
 
-    // 2. Close any already-active voice loop.
-    stop_voice_mode_inner(&state).await.ok();
+    // 2. Close any already-active voice loop. The toggle flip-down
+    //    inside stop_voice_mode_inner is harmless here because step 8
+    //    below flips it back to `true` after the new loop is up.
+    stop_voice_mode_inner(&state, false).await.ok();
 
     let cfg = state.config.lock().await.clone();
 
@@ -250,7 +252,7 @@ pub async fn start_voice_mode(
 #[cfg(feature = "speech")]
 #[tauri::command]
 pub async fn stop_voice_mode(state: tauri::State<'_, AppState>) -> Result<(), String> {
-    stop_voice_mode_inner(&state).await
+    stop_voice_mode_inner(&state, false).await
 }
 
 /// Stub for builds without the speech feature.
@@ -263,15 +265,25 @@ pub async fn stop_voice_mode(_state: tauri::State<'_, AppState>) -> Result<(), S
 /// Internal helper so `start_voice_mode` can close any active loop
 /// before spawning a new one.
 ///
-/// Flips `speech.voice_mode_enabled = false` on the way out, AFTER the
-/// loop has actually been joined (or timed out). That keeps the sticky
-/// toggle aligned with what the user just did: pressing Stop persists
-/// the off-state durably, while a start-failure leaves the prior value
-/// untouched so the consent-dialog reach-back from `start_voice_mode`'s
-/// `AssetMissing` path continues to render the toggle in its original
-/// position.
+/// When `preserve_toggle == false`, flips `speech.voice_mode_enabled = false`
+/// on the way out, AFTER the loop has actually been joined (or timed out).
+/// That keeps the sticky toggle aligned with what the user just did:
+/// pressing Stop persists the off-state durably, while a start-failure
+/// leaves the prior value untouched so the consent-dialog reach-back
+/// from `start_voice_mode`'s `AssetMissing` path continues to render the
+/// toggle in its original position.
+///
+/// When `preserve_toggle == true`, the sticky-toggle flip is skipped.
+/// Used by `session::prepare_for_session_change` so a transient
+/// teardown across a session switch doesn't surface as the user having
+/// pressed the off button — the frontend reads the still-`true` flag
+/// and auto-restarts voice mode under the new locale (closes #102
+/// polished follow-up).
 #[cfg(feature = "speech")]
-pub(crate) async fn stop_voice_mode_inner(state: &AppState) -> Result<(), String> {
+pub(crate) async fn stop_voice_mode_inner(
+    state: &AppState,
+    preserve_toggle: bool,
+) -> Result<(), String> {
     let Some(active) = state.voice.lock().await.take() else {
         return Ok(());
     };
@@ -284,7 +296,8 @@ pub(crate) async fn stop_voice_mode_inner(state: &AppState) -> Result<(), String
     // Flip the sticky toggle off — voice mode just stopped. Persist
     // failure is logged but doesn't propagate; the in-memory state is
     // already correct and the next save_settings will pick it up.
-    {
+    // Skipped on a transient teardown (`preserve_toggle == true`).
+    if !preserve_toggle {
         let mut c = state.config.lock().await;
         c.speech.voice_mode_enabled = false;
         if let Err(e) = crate::config::save(&state.home, &c) {
@@ -538,5 +551,98 @@ mod tests {
         let json = serde_json::to_value(&err).unwrap();
         assert_eq!(json["kind"], "other");
         assert_eq!(json["message"], "test message");
+    }
+
+    // ─── Issue #102 polished follow-up: preserve sticky toggle ──────
+
+    /// Synthesize an `ActiveVoiceLoop` whose task completes the moment
+    /// `stop_tx` is signaled — mirrors the production join contract
+    /// without spinning up cpal/whisper/piper. Returned ready to stash
+    /// into `state.voice`.
+    #[cfg(feature = "speech")]
+    fn fake_voice_loop(info: crate::types::SessionInfo) -> crate::state::ActiveVoiceLoop {
+        use primer_speech::voice_loop::VoiceLoopError;
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::channel::<()>(8);
+        let join: tokio::task::JoinHandle<Result<(), VoiceLoopError>> = tokio::spawn(async move {
+            let _ = stop_rx.await;
+            Ok(())
+        });
+        crate::state::ActiveVoiceLoop {
+            join,
+            stop_tx,
+            cancel_response_tx: cancel_tx,
+            info,
+        }
+    }
+
+    #[cfg(feature = "speech")]
+    fn make_synthetic_session_info() -> crate::types::SessionInfo {
+        use crate::types::LearnerSummary;
+        crate::types::SessionInfo {
+            session_id: None,
+            learner: LearnerSummary {
+                id: uuid::Uuid::nil(),
+                name: "test".into(),
+                age: 8,
+                concept_count: 0,
+            },
+            backend_kind: "stub".into(),
+            main_model: "stub".into(),
+            locale: "en".into(),
+            voice_mode_available: true,
+        }
+    }
+
+    /// User pressed Stop (or a start-error teardown happened) →
+    /// `preserve_toggle = false` → the sticky toggle is durably
+    /// flipped off so the next launch doesn't auto-resume voice mode.
+    #[cfg(feature = "speech")]
+    #[tokio::test]
+    async fn stop_voice_mode_inner_flips_toggle_off_by_default() {
+        use crate::config::GuiConfig;
+        use crate::state::AppState;
+        use tempfile::TempDir;
+
+        let home = TempDir::new().unwrap();
+        let mut cfg = GuiConfig::default();
+        cfg.speech.voice_mode_enabled = true;
+        let state = AppState::new(home.path().to_path_buf(), cfg);
+        *state.voice.lock().await = Some(fake_voice_loop(make_synthetic_session_info()));
+
+        stop_voice_mode_inner(&state, false).await.unwrap();
+
+        assert!(state.voice.lock().await.is_none(), "loop must be cleared");
+        assert!(
+            !state.config.lock().await.speech.voice_mode_enabled,
+            "preserve_toggle=false must flip the sticky toggle off"
+        );
+    }
+
+    /// Session switch → `preserve_toggle = true` → the sticky toggle
+    /// stays at its current value so the frontend can auto-restart
+    /// voice mode under the new locale (closes #102 polished
+    /// follow-up).
+    #[cfg(feature = "speech")]
+    #[tokio::test]
+    async fn stop_voice_mode_inner_preserves_toggle_when_requested() {
+        use crate::config::GuiConfig;
+        use crate::state::AppState;
+        use tempfile::TempDir;
+
+        let home = TempDir::new().unwrap();
+        let mut cfg = GuiConfig::default();
+        cfg.speech.voice_mode_enabled = true;
+        let state = AppState::new(home.path().to_path_buf(), cfg);
+        *state.voice.lock().await = Some(fake_voice_loop(make_synthetic_session_info()));
+
+        stop_voice_mode_inner(&state, true).await.unwrap();
+
+        assert!(state.voice.lock().await.is_none(), "loop must be cleared");
+        assert!(
+            state.config.lock().await.speech.voice_mode_enabled,
+            "preserve_toggle=true must leave the sticky toggle untouched so the frontend's \
+             post-`start_session` `primerRestoreVoiceMode` sees true and auto-restarts"
+        );
     }
 }

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -207,6 +207,19 @@ async function handleSessionReady({ info, shouldReplay }) {
 
   setComposerState("idle");
   refreshSidebar();
+
+  // If voice mode was active before this session switch, re-enter it
+  // under the new locale. The backend's `prepare_for_session_change`
+  // preserves `speech.voice_mode_enabled` across the teardown so the
+  // sticky toggle reads `true` here and voice.js auto-restarts voice
+  // mode against the new session's Whisper + Piper backends. A
+  // sticky toggle of `false` (user explicitly stopped voice mode)
+  // makes this a no-op. (Closes #102 polished follow-up.)
+  if (window.primerRestoreVoiceMode) {
+    window.primerRestoreVoiceMode().catch((err) =>
+      console.warn("primerRestoreVoiceMode failed:", err),
+    );
+  }
 }
 
 /// Wipe the chat surface back to its empty-state shell — used before

--- a/src/crates/primer-gui/ui/voice.js
+++ b/src/crates/primer-gui/ui/voice.js
@@ -19,6 +19,15 @@
     active: false,
     available: false,
     currentVoiceState: null,    // "listen" | "latent_think" | "speak" | null
+    // Guard against concurrent auto-start attempts (e.g. rapid back-to-back
+    // session switches firing `primerRestoreVoiceMode` before the first
+    // call's `start_voice_mode` has resolved and set `state.active = true`).
+    // Without this, a second call would race past the `state.active` check
+    // and invoke `start_voice_mode` a second time, whose step-2 teardown
+    // briefly flips the sticky toggle to `false` on disk before step-8
+    // restores it — a tiny window where a crash leaves the persisted
+    // toggle stale.
+    starting: false,
   };
 
   // Per-state label/hint copy. Populated from get_voice_state_copy on init;
@@ -268,7 +277,39 @@
     STATE_COPY.speak        = { label: c.speak_label,     hint: c.speak_hint };
   }
 
-  // === Sticky-toggle restoration on launch ===
+  // === Sticky-toggle restoration ===
+
+  /// Auto-start voice mode if the sticky toggle is on.
+  ///
+  /// Shared by `restoreOnLaunch` (initial GUI start) and
+  /// `restoreAfterSessionChange` (post-`start_session` /
+  /// `resume_session` re-entry — backend preserves the sticky toggle
+  /// through the teardown so voice mode flows seamlessly into the new
+  /// session under its new locale; closes #102 polished follow-up).
+  ///
+  /// Caller controls the error-message prefix via `contextLabel` so
+  /// the user can tell launch-time auto-resume apart from
+  /// session-switch auto-resume in the error banner.
+  async function tryAutoStartVoiceMode(contextLabel) {
+    if (!state.available || state.active || state.starting) return;
+    const cfg = await invoke("get_settings").catch(() => null);
+    if (!cfg || !cfg.speech || cfg.speech.voice_mode_enabled !== true) return;
+    state.starting = true;
+    try {
+      await invoke("start_voice_mode");
+      setActive(true);
+    } catch (err) {
+      if (err && err.kind === "asset_missing") {
+        await showConsentModal(err.entries);
+      } else if (err && err.kind === "not_built") {
+        // Silent — toggle is already disabled.
+      } else {
+        showError(`${contextLabel}: ${(err && (err.message || JSON.stringify(err))) || String(err)}`);
+      }
+    } finally {
+      state.starting = false;
+    }
+  }
 
   async function restoreOnLaunch() {
     // Read the speech-feature flag from the dedicated capability command,
@@ -286,23 +327,25 @@
       toggle.title = "Voice mode is not built into this binary";
       return;
     }
-    // Read persisted speech.voice_mode_enabled via get_settings.
-    const cfg = await invoke("get_settings").catch(() => null);
-    if (cfg && cfg.speech && cfg.speech.voice_mode_enabled === true) {
-      try {
-        await invoke("start_voice_mode");
-        setActive(true);
-      } catch (err) {
-        if (err && err.kind === "asset_missing") {
-          await showConsentModal(err.entries);
-        } else if (err && err.kind === "not_built") {
-          // Silent — toggle is already disabled.
-        } else {
-          showError(`auto-resume voice mode: ${(err && (err.message || JSON.stringify(err))) || String(err)}`);
-        }
-      }
-    }
+    await tryAutoStartVoiceMode("auto-resume voice mode");
   }
+
+  /// Re-enter voice mode after a session switch when the user had it
+  /// active before the switch. Mirrors `restoreOnLaunch`'s auto-start
+  /// branch — the backend's `prepare_for_session_change` preserves
+  /// `speech.voice_mode_enabled` across the transient teardown so this
+  /// helper sees the still-`true` flag and rebuilds voice mode against
+  /// the new locale's Whisper + Piper backends.
+  async function restoreAfterSessionChange() {
+    if (!state.available) return;
+    await tryAutoStartVoiceMode("restart voice mode after session switch");
+  }
+
+  // Exposed so `app.js` / `picker.js` / `settings.js` can call it after
+  // a successful `start_session` / `resume_session`. Idempotent: a
+  // sticky toggle of `false` (user explicitly stopped voice mode
+  // earlier) makes this a no-op.
+  window.primerRestoreVoiceMode = restoreAfterSessionChange;
 
   // === DOM wiring ===
 


### PR DESCRIPTION
## Summary

Fixes #102. Switching sessions (e.g. de → en) while voice mode was active left the voice loop running with its original locale-bound Whisper + Piper backends until full GUI restart, because `start_session` / `resume_session` only dropped `state.session`, not `state.voice`.

## What changed

**Backend (`session.rs`, `voice.rs`)**

- New `session::prepare_for_session_change(state)` helper. Tears down voice loop first (which also drops `state.session` because the voice responder holds the DM `Arc`), then `close_session_inner` becomes a clean no-op. Used by `start_session` and `resume_session`.
- `voice::stop_voice_mode_inner` gains a `preserve_toggle: bool` param. Real Stop button + start-on-existing teardown pass `false` (flip sticky toggle off durably). The new `prepare_for_session_change` passes `true` so the sticky toggle survives the transient teardown — frontend reads the still-`true` flag and auto-restarts voice mode under the new locale.
- Both inner helpers now take `&AppState` directly instead of `&tauri::State<'_, AppState>`. Deref coercion keeps existing callers compiling and unlocks Tauri-runtime-free unit tests.

**Frontend (`voice.js`, `app.js`)**

- Extracted shared `tryAutoStartVoiceMode(contextLabel)` used by both `restoreOnLaunch` and the new `restoreAfterSessionChange`. The latter is exposed as `window.primerRestoreVoiceMode`.
- `app.js::handleSessionReady` invokes `window.primerRestoreVoiceMode()` so voice mode flows seamlessly into the new session.
- `state.starting` guard in `tryAutoStartVoiceMode` serialises concurrent auto-start attempts (rapid back-to-back session switches). Without it, two parallel `start_voice_mode` invocations would briefly flip the sticky toggle off on disk before restoring it.

## Tests

Three new Rust tests:

- `prepare_for_session_change_clears_text_session` — non-speech build still tears down text session (the pre-refactor behaviour survives the helper indirection).
- `prepare_for_session_change_stops_voice_loop` — speech build tears down voice loop AND preserves `speech.voice_mode_enabled`.
- `session_switch_rebuilds_under_new_locale` — end-to-end witness that a de → en switch + rebuild produces a session configured under en (the *necessary condition* for `start_voice_mode` to rebuild `LoopBackends` against the new locale).

Plus two `voice.rs` tests pinning `stop_voice_mode_inner`'s `preserve_toggle` behaviour both ways.

All 125 primer-gui tests pass under `--features speech`. clippy `-D warnings` clean. fmt clean.

## Test plan

- [x] `cargo test -p primer-gui --features speech` — 125 / 0 / 0
- [x] `cargo test -p primer-gui` (no features) — passes
- [x] `cargo clippy -p primer-gui --features speech --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual smoke test: start GUI under `--features speech`, open a `de` session, toggle voice mode on, switch to an `en` session — Whisper should now transcribe English, Piper should use the English voice, no GUI restart required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)