### PR TITLE
gui: collapse resume_session into a single session-DB open (closes #86)

### DIFF
--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -104,26 +104,16 @@ pub async fn resume_session(
 
     prepare_for_session_change(&state).await?;
 
-    let mut cfg = state.config.lock().await.clone();
+    let cfg = state.config.lock().await.clone();
 
-    // Probe the session DB to read the learner row's persisted locale
-    // BEFORE building the full active session. If it differs from cfg's,
-    // override cfg.learner.locale for THIS resume so the KB + session
-    // store + prompt pack all line up with the saved data. The user's
-    // persisted gui-config.json is untouched.
-    if let Some(session_locale) = probe_learner_locale(&state.home, &cfg).await? {
-        if session_locale.pack_id() != cfg.learner.locale {
-            tracing::info!(
-                target: "primer_gui::resume",
-                cfg_locale = %cfg.learner.locale,
-                session_locale = session_locale.pack_id(),
-                "resume: inheriting session's saved locale (differs from cfg)"
-            );
-            cfg.learner.locale = session_locale.pack_id().to_string();
-        }
-    }
-
-    let active = wiring::build_active_session(&state.home, &cfg).await?;
+    // Issue #86: `build_active_session_for_resume` opens the session DB
+    // exactly once, reads the persisted learner inline, and silently
+    // inherits the persisted locale on mismatch (the cfg value reflects
+    // what the picker would pass for a NEW session, not what this
+    // resumed session was originally tagged under). The pre-#86 path
+    // opened the DB twice — once for a `probe_learner_locale` helper
+    // and again for `build_active_session`.
+    let active = wiring::build_active_session_for_resume(&state.home, &cfg).await?;
 
     let loaded = active
         .session_store
@@ -593,53 +583,6 @@ async fn prepare_for_session_change(state: &AppState) -> Result<(), String> {
     close_session_inner(state).await
 }
 
-/// Read the persisted learner's locale from disk without constructing
-/// a full active session. Returns `Ok(None)` when there's no on-disk
-/// session DB to probe (fresh install, or `no_persist` is on) — both
-/// cases mean cfg's locale wins by default. Errors bubble up as
-/// user-facing strings so they can land in the resume failure banner.
-///
-/// The store is opened with `Locale::default()` because the probe is a
-/// pure read: `LearnerStore::load_learner` doesn't touch the locale
-/// field at all (it returns whatever's stored in `learners.locale`).
-/// Using a deterministic locale here also keeps `--reembed`-style
-/// concept-tag writes that *do* depend on the store's locale out of
-/// this read-only code path.
-async fn probe_learner_locale(
-    home: &std::path::Path,
-    cfg: &crate::config::GuiConfig,
-) -> Result<Option<primer_core::i18n::Locale>, String> {
-    use primer_core::storage::LearnerStore;
-
-    if cfg.persistence.no_persist {
-        return Ok(None);
-    }
-    let session_path = primer_engine::resolve_session_db_path(
-        cfg.persistence.session_db.clone(),
-        home,
-        &cfg.learner.name,
-        false,
-    );
-    if !session_path.exists() {
-        return Ok(None);
-    }
-    let store = primer_storage::SqliteSessionStore::open_for_locale(
-        &session_path,
-        primer_core::i18n::Locale::default(),
-    )
-    .map_err(|e| {
-        format!(
-            "probe: opening session-db {} for locale read: {e}",
-            session_path.display()
-        )
-    })?;
-    let learner = store
-        .load_learner()
-        .await
-        .map_err(|e| format!("probe: load_learner: {e}"))?;
-    Ok(learner.map(|l| l.profile.locale))
-}
-
 /// Drive one streaming dialogue turn end-to-end.
 ///
 /// Flow:
@@ -1067,16 +1010,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn probe_learner_locale_reads_stored_locale() {
-        // Resume-on-mismatch behaviour: instead of erroring like the CLI,
-        // the GUI probes the persisted learner's locale on disk and uses
-        // THAT for the resume regardless of cfg.learner.locale. This test
-        // exercises the probe helper directly — same pattern the Tauri
-        // command's resume path uses. The companion concept_language_tag
-        // invariant is preserved because the rebuilt ActiveSession opens
-        // the store under the probed (saved) locale, so any newly
-        // extracted concepts in the resumed session land with the
-        // matching tag.
+    async fn resume_helper_inherits_persisted_locale_on_mismatch() {
+        // Resume-on-mismatch behaviour: instead of erroring like the
+        // start_session path, the GUI's resume path silently inherits
+        // the persisted learner's locale (issue #86 collapsed this from
+        // a probe + build_active_session sequence into a single
+        // build_active_session_for_resume call that opens the DB once).
         let home = TempDir::new().unwrap();
 
         // Step 1: build + save under English so the learner row lands
@@ -1088,31 +1027,33 @@ mod tests {
         dm_en.lock().await.close_session().await;
         drop(active_en);
 
-        // Step 2: probe with a cfg that asks for German. The probe
-        // should return English (the stored locale), not German (cfg's
-        // request).
+        // Step 2: resume with a cfg that asks for German. The helper
+        // must inherit English (the stored locale), not German (cfg's
+        // request) — without opening the DB twice.
         let mut cfg_de = stub_config_with_persistence(home.path());
         cfg_de.learner.locale = "de".to_string();
-        let probed = super::probe_learner_locale(home.path(), &cfg_de)
+        let active_resumed = crate::wiring::build_active_session_for_resume(home.path(), &cfg_de)
             .await
             .unwrap();
         assert_eq!(
-            probed,
-            Some(primer_core::i18n::Locale::English),
-            "probe returns the persisted locale, not cfg's"
+            active_resumed.locale,
+            primer_core::i18n::Locale::English,
+            "resume inherits persisted locale, not cfg's"
         );
 
-        // Step 3: a probe on a fresh home with a fresh cfg (no session
-        // DB yet) returns None so the resume path falls through to
-        // cfg's locale.
+        // Step 3: a resume on a fresh home with a fresh cfg (no session
+        // DB yet) falls through to cfg's locale because there's no
+        // inheritance source.
         let fresh = TempDir::new().unwrap();
-        let cfg_fresh = stub_config_with_persistence(fresh.path());
-        let probed_fresh = super::probe_learner_locale(fresh.path(), &cfg_fresh)
+        let mut cfg_fresh = stub_config_with_persistence(fresh.path());
+        cfg_fresh.learner.locale = "de".to_string();
+        let active_fresh = crate::wiring::build_active_session_for_resume(fresh.path(), &cfg_fresh)
             .await
             .unwrap();
-        assert!(
-            probed_fresh.is_none(),
-            "no session DB → probe returns None: got {probed_fresh:?}"
+        assert_eq!(
+            active_fresh.locale,
+            primer_core::i18n::Locale::German,
+            "no persisted learner → cfg's locale wins"
         );
     }
 

--- a/src/crates/primer-gui/src/wiring.rs
+++ b/src/crates/primer-gui/src/wiring.rs
@@ -658,6 +658,17 @@ mod tests {
         // helper with a German cfg — the helper must inherit English
         // from the persisted learner without a second `open_for_locale`
         // call.
+        //
+        // IMPORTANT: this assertion uses a thread-local counter exposed
+        // by `primer_storage::__session_store_open_count_for_tests`. `#[tokio::test]`
+        // defaults to a `current_thread` runtime, so every `await` in
+        // this test resumes on the same OS thread as the `before`/
+        // `after` snapshots — counter deltas are exact. Do NOT switch to
+        // `#[tokio::test(flavor = "multi_thread")]` here: tokio workers
+        // would observe the `open_for_locale` increment on a different
+        // OS thread and this test would silently always read `0`. See
+        // the `__session_store_open_count_for_tests` doc for the full
+        // rationale.
         let home = TempDir::new().unwrap();
         let session_db = home.path().join("resume_open_count.db");
 
@@ -675,11 +686,11 @@ mod tests {
         // English silently and open only once.
         let mut cfg_de = cfg_en.clone();
         cfg_de.learner.locale = "de".to_string();
-        let before = primer_storage::session_store_open_count();
+        let before = primer_storage::__session_store_open_count_for_tests();
         let active = build_active_session_for_resume(home.path(), &cfg_de)
             .await
             .expect("resume build succeeds despite cfg/persisted locale mismatch");
-        let after = primer_storage::session_store_open_count();
+        let after = primer_storage::__session_store_open_count_for_tests();
 
         assert_eq!(
             after - before,

--- a/src/crates/primer-gui/src/wiring.rs
+++ b/src/crates/primer-gui/src/wiring.rs
@@ -34,6 +34,21 @@ use uuid::Uuid;
 use crate::config::{ApiKeySource, GuiConfig};
 use crate::state::{ActiveSession, SessionSnapshot};
 
+/// How `build_active_session*` should treat a locale mismatch between
+/// `cfg.learner.locale` and a learner already persisted on disk.
+///
+/// `start_session` uses [`LocaleStrategy::UseCfg`] (hard-fail on mismatch
+/// — the persisted longitudinal record must not silently accept a new
+/// locale tag). `resume_session` uses
+/// [`LocaleStrategy::InheritFromPersistedLearner`] (silently inherit
+/// the persisted locale; the cfg value is only relevant for new
+/// sessions, never for continuing an existing one).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LocaleStrategy {
+    UseCfg,
+    InheritFromPersistedLearner,
+}
+
 /// Construct everything `DialogueManager::new` would need from a single
 /// `GuiConfig`.
 ///
@@ -51,11 +66,45 @@ pub async fn build_active_session(
     home: &Path,
     config: &GuiConfig,
 ) -> Result<ActiveSession, String> {
+    build_with_strategy(home, config, LocaleStrategy::UseCfg).await
+}
+
+/// Variant of [`build_active_session`] that silently inherits the
+/// persisted learner's locale on mismatch instead of erroring.
+///
+/// Used by the GUI's `resume_session` Tauri command: the user has chosen
+/// a saved session whose locale was set when it was originally created;
+/// the `cfg.learner.locale` value reflects what the picker would use for
+/// a NEW session, not what this resumed session was tagged under. Issue
+/// #86: the previous code path called a separate `probe_learner_locale`
+/// helper that opened the session DB just to read the learner row, then
+/// `build_active_session` opened it again. This helper folds both into
+/// a single open by reading the learner immediately after the first
+/// open and (when needed) re-tagging the store's locale field in place
+/// — the SQLite-file schema is locale-neutral on the session side, so
+/// no re-open is required (see `SqliteSessionStore::set_locale` for the
+/// rationale).
+pub async fn build_active_session_for_resume(
+    home: &Path,
+    config: &GuiConfig,
+) -> Result<ActiveSession, String> {
+    build_with_strategy(home, config, LocaleStrategy::InheritFromPersistedLearner).await
+}
+
+/// Shared body of `build_active_session` and
+/// `build_active_session_for_resume`. The two callers differ only in
+/// how they treat a locale mismatch between `cfg.learner.locale` and
+/// the persisted learner row (see [`LocaleStrategy`]).
+async fn build_with_strategy(
+    home: &Path,
+    config: &GuiConfig,
+    strategy: LocaleStrategy,
+) -> Result<ActiveSession, String> {
     let learner_config = &config.learner;
     let backend_config = &config.backend;
 
-    // ─── Locale ──────────────────────────────────────────────────────
-    let locale = Locale::from_pack_id(&learner_config.locale).ok_or_else(|| {
+    // ─── Locale (from cfg; may be overridden by inherit-on-mismatch) ─
+    let cfg_locale = Locale::from_pack_id(&learner_config.locale).ok_or_else(|| {
         let known: Vec<&str> = Locale::ALL.iter().map(|l| l.pack_id()).collect();
         format!(
             "language {:?} is not a supported locale pack. Known: {:?}",
@@ -92,34 +141,15 @@ pub async fn build_active_session(
         comprehension_model: config.comprehension.model.clone(),
     };
 
-    // ─── Main backend ────────────────────────────────────────────────
+    // ─── Main backend (locale-independent) ───────────────────────────
     let backend = build_backend(&backend_config.kind, main_model.clone(), &params)
         .await
         .map_err(|e| format!("constructing inference backend: {e}"))?;
 
-    // ─── Knowledge base + auto-seed ──────────────────────────────────
-    let knowledge_path = config
-        .persistence
-        .knowledge_db
-        .clone()
-        .unwrap_or_else(|| PathBuf::from(IN_MEMORY));
-    let knowledge = SqliteKnowledgeBase::open_for_locale(&knowledge_path, locale)
-        .map_err(|e| format!("opening knowledge base {}: {e}", knowledge_path.display()))?;
-    if let Some(stats) = primer_kb_load::auto_seed_if_empty(&knowledge, locale)
-        .await
-        .map_err(|e| format!("auto-seeding knowledge base: {e}"))?
-    {
-        tracing::info!(
-            target = "primer-gui::startup",
-            inserted = stats.inserted,
-            sources = stats.sources_seen,
-            "auto-seeded knowledge base for locale {}",
-            locale.pack_id()
-        );
-    }
-    let knowledge = Arc::new(knowledge);
-
-    // ─── Session store ───────────────────────────────────────────────
+    // ─── Session store (open BEFORE KB so we can probe the learner's
+    //     locale and avoid a second open). Opens under cfg_locale; the
+    //     in-place set_locale call below switches the tag field if the
+    //     persisted learner has a different locale.  ──────────────────
     let session_path = resolve_session_db_path(
         config.persistence.session_db.clone(),
         home,
@@ -135,14 +165,17 @@ pub async fn build_active_session(
             }
         }
     }
-    let session_store = Arc::new(
-        SqliteSessionStore::open_for_locale(&session_path, locale)
-            .map_err(|e| format!("opening session-db {}: {e}", session_path.display()))?,
-    );
+    let mut session_store_inner = SqliteSessionStore::open_for_locale(&session_path, cfg_locale)
+        .map_err(|e| format!("opening session-db {}: {e}", session_path.display()))?;
 
-    // ─── Learner model ───────────────────────────────────────────────
-    let learner = match session_store.load_learner().await {
-        Ok(Some(existing)) => {
+    // ─── Learner model + effective locale resolution ─────────────────
+    let persisted = session_store_inner
+        .load_learner()
+        .await
+        .map_err(|e| format!("load_learner failed: {e}"))?;
+
+    let (effective_locale, learner) = match (persisted, strategy) {
+        (Some(existing), LocaleStrategy::UseCfg) => {
             // Hard-fail on locale mismatch. The persisted learner already
             // carries `concept_language_tag` rows under its stored locale;
             // silently adopting a new locale would tag every new concept
@@ -152,32 +185,56 @@ pub async fn build_active_session(
             // discipline, but adapted for the GUI's start-new-session path
             // where the user-actionable resolutions are "revert Settings"
             // or "remove the persisted learner DB file".
-            if existing.profile.locale != locale {
+            if existing.profile.locale != cfg_locale {
                 return Err(format!(
                     "Settings → Locale is {:?} but the persisted learner at {} \
                      was created under locale {:?}. Either revert Settings → Locale \
                      to {:?}, or remove that DB file to start a fresh learner under \
                      {:?}. Silent re-tagging is refused because it would corrupt the \
                      longitudinal concept-language record.",
-                    locale.pack_id(),
+                    cfg_locale.pack_id(),
                     session_path.display(),
                     existing.profile.locale.pack_id(),
                     existing.profile.locale.pack_id(),
-                    locale.pack_id(),
+                    cfg_locale.pack_id(),
                 ));
             }
             let reconciled =
                 reconcile_persisted_learner(existing, &learner_config.name, learner_config.age);
-            if let Err(e) = session_store.save_learner(&reconciled).await {
+            if let Err(e) = session_store_inner.save_learner(&reconciled).await {
                 tracing::warn!("save_learner on session-start failed: {e}");
             }
-            reconciled
+            (cfg_locale, reconciled)
         }
-        Ok(None) => {
+        (Some(existing), LocaleStrategy::InheritFromPersistedLearner) => {
+            // Resume path: silently inherit the persisted locale. The
+            // store was opened under cfg_locale; if they differ, re-tag
+            // the store in place so any newly written concepts in the
+            // resumed session land with the correct
+            // `concept_language_tag`. No second `open_for_locale` call.
+            let persisted_locale = existing.profile.locale;
+            if persisted_locale != cfg_locale {
+                tracing::info!(
+                    target: "primer_gui::resume",
+                    cfg_locale = %cfg_locale.pack_id(),
+                    session_locale = %persisted_locale.pack_id(),
+                    "resume: inheriting persisted learner's locale (cfg differed)"
+                );
+                session_store_inner.set_locale(persisted_locale);
+            }
+            let reconciled =
+                reconcile_persisted_learner(existing, &learner_config.name, learner_config.age);
+            if let Err(e) = session_store_inner.save_learner(&reconciled).await {
+                tracing::warn!("save_learner on session-start failed: {e}");
+            }
+            (persisted_locale, reconciled)
+        }
+        (None, _) => {
             // Truly fresh DB OR v3 DB with sessions but no learners row.
             // Adopt the most-recent session's learner_id so existing
-            // sessions are not orphaned.
-            let id = match session_store.most_recent_session_learner_id().await {
+            // sessions are not orphaned. No inheritance possible — cfg
+            // wins regardless of strategy.
+            let id = match session_store_inner.most_recent_session_learner_id().await {
                 Ok(Some(uuid)) => {
                     tracing::info!("adopted learner_id {uuid} from existing sessions");
                     uuid
@@ -191,14 +248,37 @@ pub async fn build_active_session(
                 }
             };
             let fresh =
-                create_learner_with_id(id, &learner_config.name, learner_config.age, locale);
-            if let Err(e) = session_store.save_learner(&fresh).await {
+                create_learner_with_id(id, &learner_config.name, learner_config.age, cfg_locale);
+            if let Err(e) = session_store_inner.save_learner(&fresh).await {
                 tracing::warn!("save_learner on session-start failed: {e}");
             }
-            fresh
+            (cfg_locale, fresh)
         }
-        Err(e) => return Err(format!("load_learner failed: {e}")),
     };
+
+    let session_store = Arc::new(session_store_inner);
+
+    // ─── Knowledge base + auto-seed (under effective_locale) ─────────
+    let knowledge_path = config
+        .persistence
+        .knowledge_db
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(IN_MEMORY));
+    let knowledge = SqliteKnowledgeBase::open_for_locale(&knowledge_path, effective_locale)
+        .map_err(|e| format!("opening knowledge base {}: {e}", knowledge_path.display()))?;
+    if let Some(stats) = primer_kb_load::auto_seed_if_empty(&knowledge, effective_locale)
+        .await
+        .map_err(|e| format!("auto-seeding knowledge base: {e}"))?
+    {
+        tracing::info!(
+            target = "primer-gui::startup",
+            inserted = stats.inserted,
+            sources = stats.sources_seen,
+            "auto-seeded knowledge base for locale {}",
+            effective_locale.pack_id()
+        );
+    }
+    let knowledge = Arc::new(knowledge);
 
     // ─── Subsystems ──────────────────────────────────────────────────
     let classifier_settings = ClassifierSettings {
@@ -307,7 +387,7 @@ pub async fn build_active_session(
     Ok(ActiveSession {
         dialogue_manager: Arc::new(Mutex::new(dm)),
         snapshot: Arc::new(Mutex::new(initial_snapshot)),
-        locale,
+        locale: effective_locale,
         backend_name: backend_config.kind.clone(),
         main_model,
         session_store: Arc::clone(&session_store) as _,
@@ -568,6 +648,91 @@ mod tests {
             .expect("second open with same locale succeeds");
         let dm = s2.dialogue_manager.lock().await;
         assert_eq!(dm.learner.profile.locale.pack_id(), "de");
+    }
+
+    #[tokio::test]
+    async fn build_active_session_for_resume_opens_session_db_once() {
+        // Acceptance criterion for issue #86: the resume path must open
+        // the session DB exactly once, not twice (probe + build). Sets
+        // up a learner persisted under English, then drives the resume
+        // helper with a German cfg — the helper must inherit English
+        // from the persisted learner without a second `open_for_locale`
+        // call.
+        let home = TempDir::new().unwrap();
+        let session_db = home.path().join("resume_open_count.db");
+
+        let mut cfg_en = GuiConfig::default();
+        cfg_en.learner.name = "Binti".to_string();
+        cfg_en.learner.locale = "en".to_string();
+        cfg_en.persistence.session_db = Some(session_db.clone());
+
+        // First build under English persists the learner row.
+        let _ = build_active_session(home.path(), &cfg_en)
+            .await
+            .expect("seed open succeeds");
+
+        // Resume request asks for German; the helper must inherit
+        // English silently and open only once.
+        let mut cfg_de = cfg_en.clone();
+        cfg_de.learner.locale = "de".to_string();
+        let before = primer_storage::session_store_open_count();
+        let active = build_active_session_for_resume(home.path(), &cfg_de)
+            .await
+            .expect("resume build succeeds despite cfg/persisted locale mismatch");
+        let after = primer_storage::session_store_open_count();
+
+        assert_eq!(
+            after - before,
+            1,
+            "resume must open the session DB exactly once (was 2 with probe_learner_locale)"
+        );
+        assert_eq!(
+            active.locale.pack_id(),
+            "en",
+            "inherited locale wins for the resumed ActiveSession"
+        );
+        let dm = active.dialogue_manager.lock().await;
+        assert_eq!(
+            dm.learner.profile.locale.pack_id(),
+            "en",
+            "learner profile carries the inherited locale"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_active_session_for_resume_uses_cfg_locale_when_no_persisted_learner() {
+        // Fresh DB, no learner row yet: the resume helper must fall
+        // through to cfg's locale (no inheritance source available).
+        let home = TempDir::new().unwrap();
+        let mut cfg = GuiConfig::default();
+        cfg.learner.name = "Fresh".to_string();
+        cfg.learner.locale = "de".to_string();
+        cfg.persistence.session_db = Some(home.path().join("fresh.db"));
+
+        let active = build_active_session_for_resume(home.path(), &cfg)
+            .await
+            .expect("resume build succeeds on a fresh DB");
+        assert_eq!(active.locale.pack_id(), "de", "cfg's locale wins");
+    }
+
+    #[tokio::test]
+    async fn build_active_session_for_resume_matches_cfg_when_locales_agree() {
+        // No mismatch, no inheritance to do — should behave identically
+        // to start_session and not log an inheritance warning.
+        let home = TempDir::new().unwrap();
+        let session_db = home.path().join("agree.db");
+        let mut cfg = GuiConfig::default();
+        cfg.learner.name = "Agree".to_string();
+        cfg.learner.locale = "de".to_string();
+        cfg.persistence.session_db = Some(session_db);
+
+        let _ = build_active_session(home.path(), &cfg)
+            .await
+            .expect("seed open under de succeeds");
+        let active = build_active_session_for_resume(home.path(), &cfg)
+            .await
+            .expect("resume under matching de succeeds");
+        assert_eq!(active.locale.pack_id(), "de");
     }
 
     #[tokio::test]

--- a/src/crates/primer-storage/src/lib.rs
+++ b/src/crates/primer-storage/src/lib.rs
@@ -21,4 +21,9 @@ mod catalog;
 mod schema;
 mod store;
 
-pub use store::{SqliteSessionStore, session_store_open_count};
+pub use store::SqliteSessionStore;
+
+// `#[doc(hidden)]` test-only re-export. See the function's own doc for
+// the contract — production code must not call this.
+#[doc(hidden)]
+pub use store::__session_store_open_count_for_tests;

--- a/src/crates/primer-storage/src/lib.rs
+++ b/src/crates/primer-storage/src/lib.rs
@@ -21,4 +21,4 @@ mod catalog;
 mod schema;
 mod store;
 
-pub use store::SqliteSessionStore;
+pub use store::{SqliteSessionStore, session_store_open_count};

--- a/src/crates/primer-storage/src/store/mod.rs
+++ b/src/crates/primer-storage/src/store/mod.rs
@@ -15,11 +15,33 @@ mod session_load;
 mod session_save;
 mod session_search;
 
+use std::cell::Cell;
 use std::path::Path;
 use std::sync::Mutex;
 
 use primer_core::error::{PrimerError, Result};
 use rusqlite::Connection;
+
+thread_local! {
+    /// Per-OS-thread counter incremented by every
+    /// `SqliteSessionStore::open_for_locale` call.
+    ///
+    /// Visible via [`session_store_open_count`]; used by the GUI's
+    /// `resume_session` test to pin the one-open invariant (issue #86).
+    /// Thread-local — not a process-wide atomic — because `cargo test`
+    /// runs tests in parallel across OS threads and a global counter
+    /// would race. Each `#[tokio::test]` runs on its own OS thread with
+    /// a default `current_thread` runtime, so all opens within one
+    /// test are observed on the same thread.
+    static SESSION_STORE_OPEN_COUNT: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Read the calling thread's session-store open counter. Tests
+/// snapshot this before a flow, then assert the delta after; production
+/// code does not consult it.
+pub fn session_store_open_count() -> usize {
+    SESSION_STORE_OPEN_COUNT.with(|c| c.get())
+}
 
 /// SQLite-backed session store.
 ///
@@ -57,6 +79,7 @@ impl SqliteSessionStore {
     /// newer than this build understands is a hard error rather than a
     /// silent downgrade.
     pub fn open_for_locale(path: &Path, locale: primer_core::i18n::Locale) -> Result<Self> {
+        SESSION_STORE_OPEN_COUNT.with(|c| c.set(c.get() + 1));
         let conn = Connection::open(path)
             .map_err(|e| PrimerError::Storage(format!("open failed: {e}")))?;
 
@@ -147,10 +170,67 @@ impl SqliteSessionStore {
     pub fn locale(&self) -> primer_core::i18n::Locale {
         self.locale
     }
+
+    /// Re-tag the store's locale without re-opening the SQLite file.
+    ///
+    /// Used by the GUI's resume path (issue #86): the store is first
+    /// opened under cfg's locale, the persisted learner row is read to
+    /// determine the effective locale, and — if they differ — this
+    /// updates the locale field so subsequent writes (notably
+    /// `concept_language_tag` inserts) use the persisted value. The
+    /// SQLite-file schema is locale-neutral on this side (one
+    /// `concepts` table across all locales, tagged via a column), so
+    /// the connection itself doesn't need to be re-opened.
+    ///
+    /// Distinct from the KB side, where each locale gets its own
+    /// `passages_<pack>` tables and re-opening is mandatory.
+    pub fn set_locale(&mut self, locale: primer_core::i18n::Locale) {
+        self.locale = locale;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     mod learner_tests;
     mod session_tests;
+
+    use super::*;
+    use primer_core::i18n::Locale;
+    use tempfile::tempdir;
+
+    #[test]
+    fn open_for_locale_increments_counter() {
+        let dir = tempdir().unwrap();
+        let before = session_store_open_count();
+        let _store =
+            SqliteSessionStore::open_for_locale(&dir.path().join("a.db"), Locale::English).unwrap();
+        assert_eq!(
+            session_store_open_count() - before,
+            1,
+            "one increment per open"
+        );
+        let _store2 =
+            SqliteSessionStore::open_for_locale(&dir.path().join("b.db"), Locale::German).unwrap();
+        assert_eq!(
+            session_store_open_count() - before,
+            2,
+            "two opens visible in counter"
+        );
+    }
+
+    #[test]
+    fn set_locale_swaps_in_place_without_reopening() {
+        let dir = tempdir().unwrap();
+        let mut store =
+            SqliteSessionStore::open_for_locale(&dir.path().join("a.db"), Locale::English).unwrap();
+        assert_eq!(store.locale(), Locale::English);
+        let before = session_store_open_count();
+        store.set_locale(Locale::German);
+        assert_eq!(store.locale(), Locale::German);
+        assert_eq!(
+            session_store_open_count() - before,
+            0,
+            "set_locale must not re-open"
+        );
+    }
 }

--- a/src/crates/primer-storage/src/store/mod.rs
+++ b/src/crates/primer-storage/src/store/mod.rs
@@ -26,20 +26,31 @@ thread_local! {
     /// Per-OS-thread counter incremented by every
     /// `SqliteSessionStore::open_for_locale` call.
     ///
-    /// Visible via [`session_store_open_count`]; used by the GUI's
-    /// `resume_session` test to pin the one-open invariant (issue #86).
-    /// Thread-local — not a process-wide atomic — because `cargo test`
-    /// runs tests in parallel across OS threads and a global counter
-    /// would race. Each `#[tokio::test]` runs on its own OS thread with
-    /// a default `current_thread` runtime, so all opens within one
-    /// test are observed on the same thread.
+    /// Visible only via [`__session_store_open_count_for_tests`]; used
+    /// by the GUI's `resume_session` test to pin the one-open invariant
+    /// (issue #86). Thread-local — not a process-wide atomic — because
+    /// `cargo test` runs tests in parallel across OS threads and a
+    /// global counter would race. Each `#[tokio::test]` runs on its own
+    /// OS thread with a default `current_thread` runtime, so all opens
+    /// within one test are observed on the same thread.
     static SESSION_STORE_OPEN_COUNT: Cell<usize> = const { Cell::new(0) };
 }
 
-/// Read the calling thread's session-store open counter. Tests
-/// snapshot this before a flow, then assert the delta after; production
-/// code does not consult it.
-pub fn session_store_open_count() -> usize {
+/// Read the calling thread's session-store open counter.
+///
+/// **Test-only API.** Tests snapshot this before a flow and assert the
+/// delta after; production code must not consult it. The `__` prefix
+/// and `#[doc(hidden)]` attribute mark this as not part of the public
+/// surface — it's `pub` only because the GUI's regression test for
+/// issue #86 lives in a different crate.
+///
+/// The counter is thread-local, so it only behaves predictably inside
+/// `#[tokio::test]` (the default `current_thread` runtime keeps every
+/// `await` on one OS thread). Calling this from a `multi_thread`
+/// runtime or from arbitrary async code will read whatever the
+/// *current* thread happens to have observed, not a process-wide total.
+#[doc(hidden)]
+pub fn __session_store_open_count_for_tests() -> usize {
     SESSION_STORE_OPEN_COUNT.with(|c| c.get())
 }
 
@@ -201,18 +212,18 @@ mod tests {
     #[test]
     fn open_for_locale_increments_counter() {
         let dir = tempdir().unwrap();
-        let before = session_store_open_count();
+        let before = __session_store_open_count_for_tests();
         let _store =
             SqliteSessionStore::open_for_locale(&dir.path().join("a.db"), Locale::English).unwrap();
         assert_eq!(
-            session_store_open_count() - before,
+            __session_store_open_count_for_tests() - before,
             1,
             "one increment per open"
         );
         let _store2 =
             SqliteSessionStore::open_for_locale(&dir.path().join("b.db"), Locale::German).unwrap();
         assert_eq!(
-            session_store_open_count() - before,
+            __session_store_open_count_for_tests() - before,
             2,
             "two opens visible in counter"
         );
@@ -224,11 +235,11 @@ mod tests {
         let mut store =
             SqliteSessionStore::open_for_locale(&dir.path().join("a.db"), Locale::English).unwrap();
         assert_eq!(store.locale(), Locale::English);
-        let before = session_store_open_count();
+        let before = __session_store_open_count_for_tests();
         store.set_locale(Locale::German);
         assert_eq!(store.locale(), Locale::German);
         assert_eq!(
-            session_store_open_count() - before,
+            __session_store_open_count_for_tests() - before,
             0,
             "set_locale must not re-open"
         );


### PR DESCRIPTION
## Summary

The pre-#86 `resume_session` Tauri command opened the session DB twice:

- `probe_learner_locale` opened the DB just to read the persisted learner's locale.
- `wiring::build_active_session` opened it again to construct the real `ActiveSession`.

Both opens ran the idempotent schema migration chain + lookup-table validation. Minor latency cost, redundant work.

This PR collapses both into one open by reordering the wiring construction so the session DB opens first, the learner row is read inline, and (on locale mismatch) the store's locale field is re-tagged in place via a new `SqliteSessionStore::set_locale` method. The session-side schema is locale-neutral (single `concepts` table, locale lives in a column), so no re-open is required — symmetric to the KB side where per-locale `passages_<pack>` tables make re-opening mandatory.

## Surface

- New public `wiring::build_active_session_for_resume(home, cfg)` — the inheritance-on-mismatch variant used by `resume_session`.
- Existing `wiring::build_active_session(home, cfg)` keeps its strict `LocaleStrategy::UseCfg` semantics (start-session path; hard-error on mismatch to preserve the longitudinal `concept_language_tag` discipline from [CLAUDE.md](src/../CLAUDE.md)'s locale-is-per-learner gotcha).
- They share an internal `LocaleStrategy`-parameterised body — one place to maintain, two thin wrappers.
- New `SqliteSessionStore::set_locale(&mut self, Locale)` — re-tag the in-memory store without re-opening the SQLite file.
- New `primer_storage::session_store_open_count()` — test-only thread-local counter exposed for behavioural pinning of the one-open invariant.

## Removed

- `commands/session.rs::probe_learner_locale` (40 lines) — no longer needed; the new helper folds the probe into the build path.
- `probe_learner_locale_reads_stored_locale` test — replaced by `resume_helper_inherits_persisted_locale_on_mismatch` at the public-API level.

## Acceptance (from issue #86 body)

- [x] One DB open per `resume_session` call — verified by `build_active_session_for_resume_opens_session_db_once` asserting the counter delta is exactly 1.
- [x] `probe_learner_locale` removed; locale inheritance still works — `resume_helper_inherits_persisted_locale_on_mismatch`.
- [x] All `primer-gui` tests still green — 88 (default) / 128 (--features speech).

## Why thread-local for the open counter

`cargo test` runs tests in parallel across OS threads. A process-wide `AtomicUsize` would race when parallel tests open session DBs between our `before` and `after` snapshots. `#[tokio::test]` defaults to a `current_thread` runtime, so all opens within a single test happen on the same OS thread — `thread_local!` is the precise tool. Production code does not consult the counter.

## Test plan

- [x] `~/.cargo/bin/cargo test --workspace` — 837 passed / 0 failed / 3 ignored (was 830 / 0 / 3; +5 in primer-gui, +2 in primer-storage).
- [x] `~/.cargo/bin/cargo test -p primer-gui --features speech` — 128 passed / 0 failed.
- [x] `~/.cargo/bin/cargo fmt --all -- --check` — clean.
- [x] `~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `~/.cargo/bin/cargo clippy --workspace --all-targets --features primer-gui/speech -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)