### PR TITLE
tests: pin resume-locale-inheritance contract end-to-end (closes #87, #116)

### DIFF
--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -1057,6 +1057,108 @@ mod tests {
         );
     }
 
+    /// Regression guard for issue #87. The
+    /// `resume_helper_inherits_persisted_locale_on_mismatch` test pins
+    /// the `ActiveSession.locale` field; this one extends coverage to
+    /// the two downstream consequences the issue calls out:
+    ///   - the resumed `DialogueManager`'s `learner.profile.locale` is
+    ///     the persisted English value (not cfg's German request); and
+    ///   - a concept inserted *after* resume lands tagged with that
+    ///     persisted locale in the session DB.
+    ///
+    /// The stub extractor doesn't actually emit concepts in the
+    /// default test wiring, so this drives `update_turn_concepts`
+    /// directly on the resumed `session_store` — the same surface the
+    /// real spawned extractor task writes through.
+    #[tokio::test]
+    async fn resume_inherits_persisted_locale_end_to_end() {
+        let home = TempDir::new().unwrap();
+
+        // Step 1: build under English, run a turn so a session row
+        // lands on disk, then close.
+        let cfg_en = stub_config_with_persistence(home.path());
+        let active_en = build_active_session(home.path(), &cfg_en).await.unwrap();
+        let dm_en = Arc::clone(&active_en.dialogue_manager);
+        let payload_en = run_turn(&dm_en, "hello", |_, _| {}).await.unwrap();
+        let original_id = payload_en.session_id;
+        dm_en.lock().await.close_session().await;
+        drop(active_en);
+
+        // Step 2: build_active_session_for_resume with cfg.locale = de.
+        // The helper inherits English from the persisted learner row.
+        let mut cfg_de = stub_config_with_persistence(home.path());
+        cfg_de.learner.locale = "de".to_string();
+        let active_resumed = crate::wiring::build_active_session_for_resume(home.path(), &cfg_de)
+            .await
+            .unwrap();
+        assert_eq!(
+            active_resumed.locale,
+            primer_core::i18n::Locale::English,
+            "active session inherits English locale"
+        );
+
+        // Step 3: actually load + resume the persisted session into
+        // the new DM. The resumed DM must report English in its
+        // learner.profile.locale, not the cfg's German.
+        let loaded = active_resumed
+            .session_store
+            .load_session(original_id)
+            .await
+            .unwrap()
+            .expect("the just-persisted session must be loadable");
+        active_resumed
+            .dialogue_manager
+            .lock()
+            .await
+            .resume_session(loaded)
+            .await
+            .unwrap();
+        assert_eq!(
+            active_resumed
+                .dialogue_manager
+                .lock()
+                .await
+                .learner
+                .profile
+                .locale,
+            primer_core::i18n::Locale::English,
+            "resumed DM's learner carries English, not cfg's German"
+        );
+
+        // Step 4: insert a concept against the resumed store. This
+        // exercises the SAME `update_turn_concepts` path the spawned
+        // extractor task uses post-turn, against the SAME store the
+        // GUI handed back. If the in-place locale re-tag from issue
+        // #86 silently broke, the row would land tagged 'de'.
+        active_resumed
+            .session_store
+            .update_turn_concepts(original_id, 0, &["post_resume_concept".into()])
+            .await
+            .unwrap();
+
+        // Drain background tasks so any concurrent extractor writes
+        // are flushed before we re-open from a second connection.
+        active_resumed
+            .dialogue_manager
+            .lock()
+            .await
+            .close_session()
+            .await;
+        drop(active_resumed);
+
+        // Step 5: read the tag back through the primer-storage
+        // cross-crate test seam. Verifies the on-disk artefact without
+        // pulling rusqlite into primer-gui's dev-deps.
+        let session_db = home.path().join("test_session.db");
+        let tag =
+            primer_storage::__concept_language_tag_for_tests(&session_db, "post_resume_concept")
+                .expect("the post-resume concept must exist with a tag");
+        assert_eq!(
+            tag, "en",
+            "concept inserted after resume carries the persisted locale, not cfg's request"
+        );
+    }
+
     #[tokio::test]
     async fn turn_persists_to_session_store() {
         let home = TempDir::new().unwrap();

--- a/src/crates/primer-gui/src/commands/session.rs
+++ b/src/crates/primer-gui/src/commands/session.rs
@@ -1136,8 +1136,13 @@ mod tests {
             .await
             .unwrap();
 
-        // Drain background tasks so any concurrent extractor writes
-        // are flushed before we re-open from a second connection.
+        // Deterministically drain any in-flight extractor / comprehension
+        // tasks before reading the on-disk artefact from a second
+        // connection. `close_session` calls `await_pending_background`
+        // internally — this is a real join on the spawned tasks, not a
+        // sleep, so the read below sees a settled file. Dropping the
+        // active session afterwards releases the SQLite connection so
+        // the read-only test seam can re-open.
         active_resumed
             .dialogue_manager
             .lock()

--- a/src/crates/primer-storage/src/lib.rs
+++ b/src/crates/primer-storage/src/lib.rs
@@ -23,7 +23,9 @@ mod store;
 
 pub use store::SqliteSessionStore;
 
-// `#[doc(hidden)]` test-only re-export. See the function's own doc for
-// the contract — production code must not call this.
+// `#[doc(hidden)]` test-only re-exports. See each function's own doc
+// for the contract — production code must not call these.
+#[doc(hidden)]
+pub use store::__concept_language_tag_for_tests;
 #[doc(hidden)]
 pub use store::__session_store_open_count_for_tests;

--- a/src/crates/primer-storage/src/store/mod.rs
+++ b/src/crates/primer-storage/src/store/mod.rs
@@ -54,6 +54,29 @@ pub fn __session_store_open_count_for_tests() -> usize {
     SESSION_STORE_OPEN_COUNT.with(|c| c.get())
 }
 
+/// Read a concept's `concept_language_tag` from a session DB by name.
+///
+/// **Test-only API.** Used by the GUI's cross-crate end-to-end test
+/// for issue #87 (resume_inherits_persisted_locale_end_to_end) to
+/// inspect the on-disk artefact without pulling rusqlite into the
+/// `primer-gui` crate's dev-deps. Opens a transient read-only
+/// connection on the file at `path`, queries the `concepts` table by
+/// `name`, and returns the tag — or `None` if no such row exists.
+///
+/// Production code must not call this. The `__` prefix and
+/// `#[doc(hidden)]` attribute mark it as not part of the public
+/// surface.
+#[doc(hidden)]
+pub fn __concept_language_tag_for_tests(path: &Path, name: &str) -> Option<String> {
+    let conn = Connection::open(path).ok()?;
+    conn.query_row(
+        "SELECT concept_language_tag FROM concepts WHERE name = ?1",
+        rusqlite::params![name],
+        |r| r.get::<_, String>(0),
+    )
+    .ok()
+}
+
 /// SQLite-backed session store.
 ///
 /// Each store is scoped to a single `Locale`. The application invariant

--- a/src/crates/primer-storage/src/store/mod.rs
+++ b/src/crates/primer-storage/src/store/mod.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use primer_core::error::{PrimerError, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 thread_local! {
     /// Per-OS-thread counter incremented by every
@@ -68,7 +68,11 @@ pub fn __session_store_open_count_for_tests() -> usize {
 /// surface.
 #[doc(hidden)]
 pub fn __concept_language_tag_for_tests(path: &Path, name: &str) -> Option<String> {
-    let conn = Connection::open(path).ok()?;
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
     conn.query_row(
         "SELECT concept_language_tag FROM concepts WHERE name = ?1",
         rusqlite::params![name],

--- a/src/crates/primer-storage/src/store/tests/session_tests.rs
+++ b/src/crates/primer-storage/src/store/tests/session_tests.rs
@@ -2246,6 +2246,61 @@ async fn save_comprehensions_tags_concepts_with_store_locale() {
     }
 }
 
+/// Regression guard for issue #116. PR #115's `set_locale` exists so the
+/// GUI resume path can re-tag the store in place when the persisted
+/// learner's locale differs from `cfg.learner.locale`. The contract this
+/// pins is the *longitudinal* effect: concepts inserted before
+/// `set_locale` keep their original tag, concepts inserted after pick up
+/// the new one. The PR-#115 tests verify the inputs to that invariant
+/// (store.locale() returns the new value; the file isn't re-opened); this
+/// test asserts the on-disk consequence.
+#[tokio::test]
+async fn set_locale_changes_subsequent_concept_tags() {
+    let mut store = open_memory_for_locale(primer_core::i18n::Locale::English);
+    let session = make_two_turn_session();
+    store.save_session(&session).await.unwrap();
+
+    // Insert under English.
+    store
+        .update_turn_concepts(session.id, 0, &["en_concept".into()])
+        .await
+        .unwrap();
+
+    // Re-tag in place — no re-open.
+    let before = __session_store_open_count_for_tests();
+    store.set_locale(primer_core::i18n::Locale::German);
+    assert_eq!(
+        __session_store_open_count_for_tests() - before,
+        0,
+        "set_locale must not re-open the SQLite file"
+    );
+
+    // Insert under German (different concept name so INSERT OR IGNORE
+    // doesn't silently keep the English row).
+    store
+        .update_turn_concepts(session.id, 1, &["de_concept".into()])
+        .await
+        .unwrap();
+
+    let conn = store.conn.lock().unwrap();
+    let mut stmt = conn
+        .prepare("SELECT name, concept_language_tag FROM concepts ORDER BY id")
+        .unwrap();
+    let rows: Vec<(String, String)> = stmt
+        .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    assert_eq!(
+        rows,
+        vec![
+            ("en_concept".to_string(), "en".to_string()),
+            ("de_concept".to_string(), "de".to_string()),
+        ],
+        "pre-set_locale concept stays tagged 'en'; post-set_locale concept tagged 'de'"
+    );
+}
+
 // ─── embedding storage + hybrid retrieval (schema v8) ────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Two narrow regression guards for the locale-inheritance contract PR #115 introduced via `SqliteSessionStore::set_locale`.

- **#116** (`primer-storage`): assert that after `set_locale`, concepts inserted earlier keep their original `concept_language_tag` and concepts inserted later pick up the new one. The PR-#115 tests covered the *inputs* (`store.locale()` returns the new value, the file isn't re-opened); this pins the on-disk consequence at the layer that owns it.
- **#87** (`primer-gui`): end-to-end test that builds + saves an English session, drops the active session, calls `build_active_session_for_resume` with `cfg.locale = de`, and asserts both that the resumed `DialogueManager.learner.profile.locale` is English AND that a concept inserted via the resumed `session_store.update_turn_concepts` lands tagged `en` in the session DB.

The GUI test reads the on-disk tag through a new `__concept_language_tag_for_tests` cross-crate test seam in `primer-storage` (mirrors the existing `__session_store_open_count_for_tests` pattern). Avoids pulling `rusqlite` into `primer-gui`'s dev-deps just to inspect one column.

## Test plan

- [x] `cargo test --workspace` — 837 → 839 passed (+1 in `primer-storage`, +1 in `primer-gui`); 3 ignored unchanged.
- [x] `cargo test -p primer-gui --features speech` — 128 → 129 passed.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo clippy --workspace --all-targets --features primer-gui/speech -- -D warnings` — clean.

Closes #87.
Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)