### PR TITLE
gui: convert modals to native <dialog> for focus trap (closes #81)

### DIFF
--- a/src/crates/primer-gui/src/lib.rs
+++ b/src/crates/primer-gui/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod commands;
 pub mod config;
 pub mod csp;
+pub mod modal_dialog_contract;
 pub mod paths;
 pub mod state;
 pub mod types;

--- a/src/crates/primer-gui/src/modal_dialog_contract.rs
+++ b/src/crates/primer-gui/src/modal_dialog_contract.rs
@@ -48,6 +48,13 @@ mod tests {
     /// the next ASCII-alphanumeric run — the HTML tag name. Avoids the
     /// failure mode of substring-matching `<dialog` somewhere unrelated
     /// in the file.
+    ///
+    /// **Quoting:** only matches double-quoted `id="…"`. The codebase
+    /// uses double quotes uniformly in HTML; a single-quoted id would
+    /// silently report `None` here. Deliberate YAGNI — adding
+    /// single-quote support invites question of which quoting style is
+    /// canonical, and we'd rather flag unexpected variance than paper
+    /// over it.
     fn tag_for_id<'a>(haystack: &'a str, id: &str) -> Option<&'a str> {
         let needle = format!("id=\"{id}\"");
         let id_pos = haystack.find(&needle)?;
@@ -58,6 +65,50 @@ mod tests {
             .find(|c: char| !c.is_ascii_alphanumeric())
             .unwrap_or(after_lt.len());
         Some(&after_lt[..tag_end])
+    }
+
+    /// Strip `// ... EOL` and `/* ... */` comments from a JS source so
+    /// substring assertions don't false-pass on commented-out code.
+    /// Naive: doesn't track string or regex literals, so `"//"` inside a
+    /// string would still be treated as a comment marker. Adequate for
+    /// the contract assertions here — no UI file embeds `//` inside a
+    /// string that wraps a load-bearing identifier.
+    fn strip_js_comments(src: &str) -> String {
+        let mut out = String::with_capacity(src.len());
+        let mut chars = src.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '/' {
+                match chars.peek() {
+                    Some('*') => {
+                        chars.next();
+                        let mut prev = '\0';
+                        for cc in chars.by_ref() {
+                            if prev == '*' && cc == '/' {
+                                break;
+                            }
+                            prev = cc;
+                        }
+                        continue;
+                    }
+                    // Line comment (handles `//`, `///`, `////…`). Keep
+                    // the trailing newline so the test failure message's
+                    // line numbers stay aligned with the source.
+                    Some('/') => {
+                        chars.next();
+                        for cc in chars.by_ref() {
+                            if cc == '\n' {
+                                out.push('\n');
+                                break;
+                            }
+                        }
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+            out.push(c);
+        }
+        out
     }
 
     #[test]
@@ -90,8 +141,12 @@ mod tests {
 
     #[test]
     fn settings_controller_opens_via_show_modal() {
+        // Strip comments before substring-matching so the test can't
+        // false-pass on a commented-out `.showModal()` reference — e.g.
+        // a stale doc comment left after the call site was reverted.
+        let code = strip_js_comments(SETTINGS_JS);
         assert!(
-            SETTINGS_JS.contains(".showModal()"),
+            code.contains(".showModal()"),
             "ui/settings.js no longer calls .showModal() — the focus \
              trap supplied by the browser only kicks in when the dialog \
              is opened via HTMLDialogElement.showModal(). Toggling \
@@ -102,8 +157,9 @@ mod tests {
 
     #[test]
     fn voice_controller_opens_via_show_modal() {
+        let code = strip_js_comments(VOICE_JS);
         assert!(
-            VOICE_JS.contains(".showModal()"),
+            code.contains(".showModal()"),
             "ui/voice.js no longer calls .showModal() — the focus \
              trap supplied by the browser only kicks in when the dialog \
              is opened via HTMLDialogElement.showModal(). Toggling \
@@ -146,5 +202,39 @@ mod tests {
     fn tag_for_id_returns_none_for_missing_id() {
         let html = r#"<dialog id="present"></dialog>"#;
         assert_eq!(tag_for_id(html, "absent"), None);
+    }
+
+    #[test]
+    fn strip_js_comments_removes_line_comments_but_leaves_calls() {
+        let src = "// dialog.showModal() — stale comment\nreal.showModal();";
+        let stripped = strip_js_comments(src);
+        assert!(stripped.contains(".showModal()"));
+        assert!(!stripped.contains("stale comment"));
+    }
+
+    #[test]
+    fn strip_js_comments_removes_block_comments() {
+        let src = "/* dialog.showModal() lives here */ real.showModal();";
+        let stripped = strip_js_comments(src);
+        assert!(stripped.contains(".showModal()"));
+        assert!(!stripped.contains("lives here"));
+    }
+
+    #[test]
+    fn strip_js_comments_preserves_utf8() {
+        // em-dash is two bytes; ensure char-iteration leaves it intact.
+        let src = "const x = 1; // — note\nconst y = 2;";
+        let stripped = strip_js_comments(src);
+        assert!(stripped.contains("const x = 1;"));
+        assert!(stripped.contains("const y = 2;"));
+        assert!(!stripped.contains("note"));
+    }
+
+    #[test]
+    fn strip_js_comments_handles_triple_slash_doc_comments() {
+        let src = "/// Show the dialog\nfunction f() { dom.modal.showModal(); }";
+        let stripped = strip_js_comments(src);
+        assert!(stripped.contains(".showModal()"));
+        assert!(!stripped.contains("Show the dialog"));
     }
 }

--- a/src/crates/primer-gui/src/modal_dialog_contract.rs
+++ b/src/crates/primer-gui/src/modal_dialog_contract.rs
@@ -1,0 +1,150 @@
+//! Pin the contract that modal dialogs use the native `<dialog>` element
+//! opened via `showModal()`, so the browser supplies focus-trap, Escape,
+//! and inert-background behaviour for free.
+//!
+//! Why a dedicated module instead of inline tests: the contract spans
+//! three static assets (`ui/index.html`, `ui/settings.js`, `ui/voice.js`)
+//! plus the stylesheet. Pinning the shape at the crate level keeps the
+//! contract discoverable (`grep -rn modal_dialog_contract src/`) and
+//! makes the failure mode loud — a future edit that reverts a modal to
+//! the old `<div class="modal-backdrop"><div class="modal">` pattern
+//! breaks `cargo test --workspace` rather than silently regressing
+//! accessibility.
+//!
+//! See issue #81 for the long-form rationale. The settings modal (and
+//! the voice-consent modal that shares its markup pattern) previously
+//! used `<div role="dialog">` toggled via the `hidden` attribute. That
+//! shape required a manual focus trap to prevent Tab from drifting onto
+//! the chat shell behind the dim backdrop. Native `<dialog>` opened with
+//! `HTMLDialogElement.showModal()` traps focus inside the dialog,
+//! Escape-dismisses via a `cancel` event, and renders an inert
+//! `::backdrop` pseudo-element — all UA-provided. The tests below pin
+//! the two load-bearing facts:
+//!   1. Both modal elements are `<dialog>` (not `<div>`).
+//!   2. Both controllers call `.showModal()` (not just `.hidden = false`).
+
+#[cfg(test)]
+mod tests {
+    /// Static-embed the UI assets that carry the contract. `include_str!`
+    /// resolves relative to this source file; the UI lives at the crate
+    /// root under `ui/`.
+    const INDEX_HTML: &str = include_str!("../ui/index.html");
+    const SETTINGS_JS: &str = include_str!("../ui/settings.js");
+    const VOICE_JS: &str = include_str!("../ui/voice.js");
+    const STYLES_CSS: &str = include_str!("../ui/styles.css");
+
+    /// Modal element ids that must be `<dialog>` elements opened via
+    /// `showModal()`. Driven from one list so adding a third modal in
+    /// the future is one edit, not three.
+    const MODAL_DIALOG_IDS: &[&str] = &["settings-modal", "voice-consent-modal"];
+
+    /// Locate the opening tag in `haystack` that carries `id="<id>"` and
+    /// return the tag name (the word after `<`). Returns `None` if no
+    /// such id is found, or if the structure is malformed (no `<` before
+    /// the id). Whitespace-tolerant: works for both `<dialog id="x"`
+    /// and `<dialog\n      id="x"` shapes.
+    ///
+    /// Walks back from the id attribute to the nearest `<`, then grabs
+    /// the next ASCII-alphanumeric run — the HTML tag name. Avoids the
+    /// failure mode of substring-matching `<dialog` somewhere unrelated
+    /// in the file.
+    fn tag_for_id<'a>(haystack: &'a str, id: &str) -> Option<&'a str> {
+        let needle = format!("id=\"{id}\"");
+        let id_pos = haystack.find(&needle)?;
+        let prefix = &haystack[..id_pos];
+        let lt_pos = prefix.rfind('<')?;
+        let after_lt = &haystack[lt_pos + 1..];
+        let tag_end = after_lt
+            .find(|c: char| !c.is_ascii_alphanumeric())
+            .unwrap_or(after_lt.len());
+        Some(&after_lt[..tag_end])
+    }
+
+    #[test]
+    fn every_modal_element_is_a_native_dialog() {
+        for id in MODAL_DIALOG_IDS {
+            let tag = tag_for_id(INDEX_HTML, id)
+                .unwrap_or_else(|| panic!("no element with id=\"{id}\" found in ui/index.html"));
+            assert_eq!(
+                tag, "dialog",
+                "element id=\"{id}\" must be a <dialog> (got <{tag}>); \
+                 see issue #81. Native <dialog> + showModal() supplies \
+                 the focus trap the manual <div role=\"dialog\"> shape \
+                 did not."
+            );
+        }
+    }
+
+    #[test]
+    fn no_legacy_modal_backdrop_wrapper_remains() {
+        // The old shape was `<div class="modal-backdrop">` wrapping each
+        // modal card. `<dialog>` exposes the backdrop via the
+        // `::backdrop` pseudo-element instead, so the wrapper div must
+        // be gone from the HTML.
+        assert!(
+            !INDEX_HTML.contains("modal-backdrop"),
+            "ui/index.html still references `modal-backdrop`; the \
+             native <dialog> migration (#81) removed the wrapper div."
+        );
+    }
+
+    #[test]
+    fn settings_controller_opens_via_show_modal() {
+        assert!(
+            SETTINGS_JS.contains(".showModal()"),
+            "ui/settings.js no longer calls .showModal() — the focus \
+             trap supplied by the browser only kicks in when the dialog \
+             is opened via HTMLDialogElement.showModal(). Toggling \
+             `.hidden` or `.open` directly skips the focus-trap setup. \
+             See issue #81."
+        );
+    }
+
+    #[test]
+    fn voice_controller_opens_via_show_modal() {
+        assert!(
+            VOICE_JS.contains(".showModal()"),
+            "ui/voice.js no longer calls .showModal() — the focus \
+             trap supplied by the browser only kicks in when the dialog \
+             is opened via HTMLDialogElement.showModal(). Toggling \
+             `.hidden` or `.open` directly skips the focus-trap setup. \
+             See issue #81."
+        );
+    }
+
+    #[test]
+    fn stylesheet_declares_native_backdrop_rule() {
+        // The dim background previously came from `.modal-backdrop`'s
+        // `background: color-mix(...)`. With native <dialog>, the same
+        // styling must live on the `::backdrop` pseudo-element. Without
+        // it, the modal opens over a transparent overlay and the user
+        // can't tell the chat shell is inert.
+        assert!(
+            STYLES_CSS.contains("::backdrop"),
+            "ui/styles.css does not declare a `::backdrop` rule. The \
+             native <dialog> migration (#81) moved the dim-overlay \
+             styling from `.modal-backdrop` onto `dialog::backdrop`."
+        );
+    }
+
+    #[test]
+    fn tag_for_id_walks_back_to_the_nearest_opening_bracket() {
+        let html = r#"<section><dialog
+              class="modal"
+              id="x"
+              role="dialog">content</dialog></section>"#;
+        assert_eq!(tag_for_id(html, "x"), Some("dialog"));
+    }
+
+    #[test]
+    fn tag_for_id_distinguishes_dialog_from_div() {
+        let html = r#"<div class="legacy" id="legacy-modal"></div>"#;
+        assert_eq!(tag_for_id(html, "legacy-modal"), Some("div"));
+    }
+
+    #[test]
+    fn tag_for_id_returns_none_for_missing_id() {
+        let html = r#"<dialog id="present"></dialog>"#;
+        assert_eq!(tag_for_id(html, "absent"), None);
+    }
+}

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -269,460 +269,442 @@
       </section>
     </aside>
 
-    <div
-      class="modal-backdrop"
-      id="settings-backdrop"
-      hidden
-      aria-hidden="true"
+    <dialog
+      class="modal"
+      id="settings-modal"
+      aria-labelledby="settings-title"
     >
+      <header class="modal-header">
+        <h2 id="settings-title">Settings</h2>
+        <button
+          type="button"
+          class="modal-close"
+          id="settings-close"
+          aria-label="Close settings"
+          title="Close"
+        >
+          ×
+        </button>
+      </header>
+
       <div
-        class="modal"
-        id="settings-modal"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="settings-title"
-      >
-        <header class="modal-header">
-          <h2 id="settings-title">Settings</h2>
-          <button
-            type="button"
-            class="modal-close"
-            id="settings-close"
-            aria-label="Close settings"
-            title="Close"
-          >
-            ×
-          </button>
-        </header>
+        class="modal-banner"
+        id="settings-banner"
+        role="alert"
+        hidden
+      ></div>
 
-        <div
-          class="modal-banner"
-          id="settings-banner"
-          role="alert"
-          hidden
-        ></div>
+      <form class="modal-body" id="settings-form" novalidate>
+        <details class="settings-group" open>
+          <summary>Learner</summary>
+          <div class="settings-grid">
+            <label class="field">
+              <span>Name</span>
+              <input type="text" id="f-learner-name" required />
+            </label>
+            <label class="field">
+              <span>Age</span>
+              <input type="number" id="f-learner-age" min="0" max="120" />
+            </label>
+            <label class="field">
+              <span>Locale</span>
+              <select id="f-learner-locale">
+                <!-- Options injected from JS via the `list_locales` Tauri
+                     command, so adding a locale pack is a Rust-only edit
+                     (extend `Locale::ALL` in primer-core). -->
+              </select>
+            </label>
+          </div>
+        </details>
 
-        <form class="modal-body" id="settings-form" novalidate>
-          <details class="settings-group" open>
-            <summary>Learner</summary>
-            <div class="settings-grid">
-              <label class="field">
-                <span>Name</span>
-                <input type="text" id="f-learner-name" required />
-              </label>
-              <label class="field">
-                <span>Age</span>
-                <input type="number" id="f-learner-age" min="0" max="120" />
-              </label>
-              <label class="field">
-                <span>Locale</span>
-                <select id="f-learner-locale">
-                  <!-- Options injected from JS via the `list_locales` Tauri
-                       command, so adding a locale pack is a Rust-only edit
-                       (extend `Locale::ALL` in primer-core). -->
-                </select>
-              </label>
-            </div>
-          </details>
+        <details class="settings-group" open>
+          <summary>Inference backend</summary>
+          <div class="settings-grid">
+            <label class="field">
+              <span>Backend</span>
+              <select id="f-backend-kind">
+                <option value="stub">stub (no API key)</option>
+                <option value="cloud">cloud (Anthropic)</option>
+                <option value="ollama">ollama (local)</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Model</span>
+              <input
+                type="text"
+                id="f-backend-model"
+                placeholder="(per-backend default)"
+              />
+            </label>
+            <label class="field" id="f-backend-ollama-url-field">
+              <span>Ollama URL</span>
+              <input
+                type="text"
+                id="f-backend-ollama-url"
+                placeholder="http://localhost:11434"
+              />
+            </label>
+          </div>
 
-          <details class="settings-group" open>
-            <summary>Inference backend</summary>
+          <fieldset class="api-key-fieldset" id="f-api-key-fieldset">
+            <legend>API key (cloud only)</legend>
+            <label class="radio">
+              <input
+                type="radio"
+                name="api-key-source"
+                value="env"
+                id="f-api-key-env"
+              />
+              <span>Read from <code>ANTHROPIC_API_KEY</code> environment variable</span>
+            </label>
+            <label class="radio">
+              <input
+                type="radio"
+                name="api-key-source"
+                value="inline"
+                id="f-api-key-inline"
+              />
+              <span>Store inline in config file (mode 0600)</span>
+            </label>
+            <label class="field field-indent" id="f-api-key-input-field" hidden>
+              <span id="f-api-key-input-label">Anthropic API key</span>
+              <input
+                type="password"
+                id="f-api-key-input"
+                autocomplete="off"
+                spellcheck="false"
+              />
+              <small class="hint muted" id="f-api-key-hint"></small>
+            </label>
+          </fieldset>
+        </details>
+
+        <details class="settings-group">
+          <summary>Classifier subsystem</summary>
+          <div class="subsystem-fields" data-subsystem="classifier">
+            <label class="check">
+              <input type="checkbox" data-field="match-main" checked />
+              <span>Match main backend</span>
+            </label>
             <div class="settings-grid">
               <label class="field">
                 <span>Backend</span>
-                <select id="f-backend-kind">
-                  <option value="stub">stub (no API key)</option>
-                  <option value="cloud">cloud (Anthropic)</option>
-                  <option value="ollama">ollama (local)</option>
+                <select data-field="kind">
+                  <option value="">(match main)</option>
+                  <option value="stub">stub</option>
+                  <option value="cloud">cloud</option>
+                  <option value="ollama">ollama</option>
                 </select>
               </label>
               <label class="field">
                 <span>Model</span>
-                <input
-                  type="text"
-                  id="f-backend-model"
-                  placeholder="(per-backend default)"
-                />
+                <input type="text" data-field="model" placeholder="(match main)" />
               </label>
-              <label class="field" id="f-backend-ollama-url-field">
-                <span>Ollama URL</span>
-                <input
-                  type="text"
-                  id="f-backend-ollama-url"
-                  placeholder="http://localhost:11434"
-                />
+              <label class="field">
+                <span>Timeout (ms)</span>
+                <input type="number" data-field="timeout-ms" min="0" />
               </label>
             </div>
+          </div>
+        </details>
 
-            <fieldset class="api-key-fieldset" id="f-api-key-fieldset">
-              <legend>API key (cloud only)</legend>
-              <label class="radio">
-                <input
-                  type="radio"
-                  name="api-key-source"
-                  value="env"
-                  id="f-api-key-env"
-                />
-                <span>Read from <code>ANTHROPIC_API_KEY</code> environment variable</span>
-              </label>
-              <label class="radio">
-                <input
-                  type="radio"
-                  name="api-key-source"
-                  value="inline"
-                  id="f-api-key-inline"
-                />
-                <span>Store inline in config file (mode 0600)</span>
-              </label>
-              <label class="field field-indent" id="f-api-key-input-field" hidden>
-                <span id="f-api-key-input-label">Anthropic API key</span>
-                <input
-                  type="password"
-                  id="f-api-key-input"
-                  autocomplete="off"
-                  spellcheck="false"
-                />
-                <small class="hint muted" id="f-api-key-hint"></small>
-              </label>
-            </fieldset>
-          </details>
-
-          <details class="settings-group">
-            <summary>Classifier subsystem</summary>
-            <div class="subsystem-fields" data-subsystem="classifier">
-              <label class="check">
-                <input type="checkbox" data-field="match-main" checked />
-                <span>Match main backend</span>
-              </label>
-              <div class="settings-grid">
-                <label class="field">
-                  <span>Backend</span>
-                  <select data-field="kind">
-                    <option value="">(match main)</option>
-                    <option value="stub">stub</option>
-                    <option value="cloud">cloud</option>
-                    <option value="ollama">ollama</option>
-                  </select>
-                </label>
-                <label class="field">
-                  <span>Model</span>
-                  <input type="text" data-field="model" placeholder="(match main)" />
-                </label>
-                <label class="field">
-                  <span>Timeout (ms)</span>
-                  <input type="number" data-field="timeout-ms" min="0" />
-                </label>
-              </div>
-            </div>
-          </details>
-
-          <details class="settings-group">
-            <summary>Extractor subsystem</summary>
-            <div class="subsystem-fields" data-subsystem="extractor">
-              <label class="check">
-                <input type="checkbox" data-field="match-main" checked />
-                <span>Match main backend</span>
-              </label>
-              <div class="settings-grid">
-                <label class="field">
-                  <span>Backend</span>
-                  <select data-field="kind">
-                    <option value="">(match main)</option>
-                    <option value="stub">stub</option>
-                    <option value="cloud">cloud</option>
-                    <option value="ollama">ollama</option>
-                  </select>
-                </label>
-                <label class="field">
-                  <span>Model</span>
-                  <input type="text" data-field="model" placeholder="(match main)" />
-                </label>
-                <label class="field">
-                  <span>Timeout (ms)</span>
-                  <input type="number" data-field="timeout-ms" min="0" />
-                </label>
-              </div>
-            </div>
-          </details>
-
-          <details class="settings-group">
-            <summary>Comprehension subsystem</summary>
-            <div class="subsystem-fields" data-subsystem="comprehension">
-              <label class="check">
-                <input type="checkbox" data-field="match-main" checked />
-                <span>Match main backend</span>
-              </label>
-              <div class="settings-grid">
-                <label class="field">
-                  <span>Backend</span>
-                  <select data-field="kind">
-                    <option value="">(match main)</option>
-                    <option value="stub">stub</option>
-                    <option value="cloud">cloud</option>
-                    <option value="ollama">ollama</option>
-                  </select>
-                </label>
-                <label class="field">
-                  <span>Model</span>
-                  <input type="text" data-field="model" placeholder="(match main)" />
-                </label>
-                <label class="field">
-                  <span>Timeout (ms)</span>
-                  <input type="number" data-field="timeout-ms" min="0" />
-                </label>
-              </div>
-            </div>
-          </details>
-
-          <details class="settings-group">
-            <summary>Embedder (hybrid retrieval)</summary>
+        <details class="settings-group">
+          <summary>Extractor subsystem</summary>
+          <div class="subsystem-fields" data-subsystem="extractor">
+            <label class="check">
+              <input type="checkbox" data-field="match-main" checked />
+              <span>Match main backend</span>
+            </label>
             <div class="settings-grid">
               <label class="field">
                 <span>Backend</span>
-                <select id="f-embedder-kind">
-                  <option value="none">none (BM25 only)</option>
-                  <option value="stub">stub (testing only)</option>
-                  <option value="fastembed">fastembed (local, ~570 MB)</option>
-                  <option value="ollama">ollama (remote)</option>
+                <select data-field="kind">
+                  <option value="">(match main)</option>
+                  <option value="stub">stub</option>
+                  <option value="cloud">cloud</option>
+                  <option value="ollama">ollama</option>
                 </select>
               </label>
               <label class="field">
                 <span>Model</span>
-                <input
-                  type="text"
-                  id="f-embedder-model"
-                  placeholder="(backend default)"
-                />
-              </label>
-              <label class="field" id="f-embedder-ollama-url-field">
-                <span>Ollama URL</span>
-                <input
-                  type="text"
-                  id="f-embedder-ollama-url"
-                  placeholder="http://localhost:11434"
-                />
-              </label>
-            </div>
-            <p class="hint muted">
-              <code>fastembed</code> requires the binary to be built with
-              <code>--features primer-gui/embedding</code>. If unavailable
-              at session start, the backend falls back to BM25 with a warning.
-            </p>
-          </details>
-
-          <details class="settings-group">
-            <summary>Vocabulary &amp; session breaks</summary>
-            <div class="settings-grid">
-              <label class="field">
-                <span>Max vocab hints per prompt</span>
-                <input
-                  type="number"
-                  id="f-vocab-max"
-                  min="0"
-                  placeholder="(default 4)"
-                />
+                <input type="text" data-field="model" placeholder="(match main)" />
               </label>
               <label class="field">
-                <span>Break-suggestion interval (minutes)</span>
-                <input
-                  type="number"
-                  id="f-breaks-after-mins"
-                  min="1"
-                />
+                <span>Timeout (ms)</span>
+                <input type="number" data-field="timeout-ms" min="0" />
               </label>
             </div>
-          </details>
+          </div>
+        </details>
 
-          <details class="settings-group">
-            <summary>Persistence</summary>
+        <details class="settings-group">
+          <summary>Comprehension subsystem</summary>
+          <div class="subsystem-fields" data-subsystem="comprehension">
+            <label class="check">
+              <input type="checkbox" data-field="match-main" checked />
+              <span>Match main backend</span>
+            </label>
             <div class="settings-grid">
-              <label class="field field-full">
-                <span>Session database path</span>
-                <input
-                  type="text"
-                  id="f-persistence-session-db"
-                  placeholder="(default ~/.primer/<slug>.db)"
-                />
+              <label class="field">
+                <span>Backend</span>
+                <select data-field="kind">
+                  <option value="">(match main)</option>
+                  <option value="stub">stub</option>
+                  <option value="cloud">cloud</option>
+                  <option value="ollama">ollama</option>
+                </select>
               </label>
-              <label class="field field-full">
-                <span>Knowledge database path</span>
+              <label class="field">
+                <span>Model</span>
+                <input type="text" data-field="model" placeholder="(match main)" />
+              </label>
+              <label class="field">
+                <span>Timeout (ms)</span>
+                <input type="number" data-field="timeout-ms" min="0" />
+              </label>
+            </div>
+          </div>
+        </details>
+
+        <details class="settings-group">
+          <summary>Embedder (hybrid retrieval)</summary>
+          <div class="settings-grid">
+            <label class="field">
+              <span>Backend</span>
+              <select id="f-embedder-kind">
+                <option value="none">none (BM25 only)</option>
+                <option value="stub">stub (testing only)</option>
+                <option value="fastembed">fastembed (local, ~570 MB)</option>
+                <option value="ollama">ollama (remote)</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Model</span>
+              <input
+                type="text"
+                id="f-embedder-model"
+                placeholder="(backend default)"
+              />
+            </label>
+            <label class="field" id="f-embedder-ollama-url-field">
+              <span>Ollama URL</span>
+              <input
+                type="text"
+                id="f-embedder-ollama-url"
+                placeholder="http://localhost:11434"
+              />
+            </label>
+          </div>
+          <p class="hint muted">
+            <code>fastembed</code> requires the binary to be built with
+            <code>--features primer-gui/embedding</code>. If unavailable
+            at session start, the backend falls back to BM25 with a warning.
+          </p>
+        </details>
+
+        <details class="settings-group">
+          <summary>Vocabulary &amp; session breaks</summary>
+          <div class="settings-grid">
+            <label class="field">
+              <span>Max vocab hints per prompt</span>
+              <input
+                type="number"
+                id="f-vocab-max"
+                min="0"
+                placeholder="(default 4)"
+              />
+            </label>
+            <label class="field">
+              <span>Break-suggestion interval (minutes)</span>
+              <input
+                type="number"
+                id="f-breaks-after-mins"
+                min="1"
+              />
+            </label>
+          </div>
+        </details>
+
+        <details class="settings-group">
+          <summary>Persistence</summary>
+          <div class="settings-grid">
+            <label class="field field-full">
+              <span>Session database path</span>
+              <input
+                type="text"
+                id="f-persistence-session-db"
+                placeholder="(default ~/.primer/<slug>.db)"
+              />
+            </label>
+            <label class="field field-full">
+              <span>Knowledge database path</span>
+              <input
+                type="text"
+                id="f-persistence-knowledge-db"
+                placeholder="(default :memory:)"
+              />
+            </label>
+            <label class="check field-full">
+              <input type="checkbox" id="f-persistence-no-persist" />
+              <span>In-memory only (nothing written to disk)</span>
+            </label>
+          </div>
+        </details>
+
+        <details class="settings-group" id="speech-settings-group">
+          <summary>Speech</summary>
+          <p class="hint muted" id="speech-availability-hint" hidden>
+            Voice mode is not built into this binary. Rebuild with
+            <code>--features primer-gui/speech</code> to enable.
+          </p>
+          <div id="speech-settings-fields">
+            <div class="settings-grid">
+              <label class="field">
+                <span>Mic silence (ms)</span>
                 <input
-                  type="text"
-                  id="f-persistence-knowledge-db"
-                  placeholder="(default :memory:)"
+                  type="number"
+                  id="f-speech-mic-silence-ms"
+                  min="100"
+                  max="3000"
+                  step="50"
+                  placeholder="600"
                 />
               </label>
               <label class="check field-full">
-                <input type="checkbox" id="f-persistence-no-persist" />
-                <span>In-memory only (nothing written to disk)</span>
+                <input type="checkbox" id="f-speech-disable-auto-download" />
+                <span>Don't offer auto-download; require explicit file paths</span>
               </label>
             </div>
-          </details>
-
-          <details class="settings-group" id="speech-settings-group">
-            <summary>Speech</summary>
-            <p class="hint muted" id="speech-availability-hint" hidden>
-              Voice mode is not built into this binary. Rebuild with
-              <code>--features primer-gui/speech</code> to enable.
+            <p class="hint muted">
+              Voice mode auto-downloads the default Whisper + Piper assets for
+              your locale to <code>~/.cache/primer/models/</code> on first launch.
+              Tick the box above to disable the offer (the start-voice-mode
+              command will then surface missing files as a plain error pointing
+              back to this dialog).
             </p>
-            <div id="speech-settings-fields">
-              <div class="settings-grid">
-                <label class="field">
-                  <span>Mic silence (ms)</span>
-                  <input
-                    type="number"
-                    id="f-speech-mic-silence-ms"
-                    min="100"
-                    max="3000"
-                    step="50"
-                    placeholder="600"
-                  />
-                </label>
-                <label class="check field-full">
-                  <input type="checkbox" id="f-speech-disable-auto-download" />
-                  <span>Don't offer auto-download; require explicit file paths</span>
-                </label>
-              </div>
-              <p class="hint muted">
-                Voice mode auto-downloads the default Whisper + Piper assets for
-                your locale to <code>~/.cache/primer/models/</code> on first launch.
-                Tick the box above to disable the offer (the start-voice-mode
-                command will then surface missing files as a plain error pointing
-                back to this dialog).
-              </p>
 
-              <h3 class="settings-subhead">Per-locale overrides</h3>
-              <div id="f-speech-overrides">
-                <!-- One sub-card per locale; rendered from JS using the
-                     `list_locales` Tauri command, so adding a locale pack
-                     is a Rust-only edit (extend `Locale::ALL` in primer-core). -->
-              </div>
+            <h3 class="settings-subhead">Per-locale overrides</h3>
+            <div id="f-speech-overrides">
+              <!-- One sub-card per locale; rendered from JS using the
+                   `list_locales` Tauri command, so adding a locale pack
+                   is a Rust-only edit (extend `Locale::ALL` in primer-core). -->
             </div>
-          </details>
-        </form>
+          </div>
+        </details>
+      </form>
 
-        <footer class="modal-footer">
-          <div class="modal-footer-hint muted" id="settings-active-hint" hidden>
-            A session is active — "Save &amp; start new session" will close it
-            and start a fresh session with the new settings.
-          </div>
-          <div class="modal-footer-actions">
-            <button type="button" class="btn-tertiary" id="settings-cancel">
-              Cancel
-            </button>
-            <button type="button" class="btn-secondary" id="settings-save-next">
-              Save (next session only)
-            </button>
-            <button type="button" class="btn-primary" id="settings-save-restart">
-              Save &amp; start new session
-            </button>
-          </div>
-        </footer>
-      </div>
-    </div>
+      <footer class="modal-footer">
+        <div class="modal-footer-hint muted" id="settings-active-hint" hidden>
+          A session is active — "Save &amp; start new session" will close it
+          and start a fresh session with the new settings.
+        </div>
+        <div class="modal-footer-actions">
+          <button type="button" class="btn-tertiary" id="settings-cancel">
+            Cancel
+          </button>
+          <button type="button" class="btn-secondary" id="settings-save-next">
+            Save (next session only)
+          </button>
+          <button type="button" class="btn-primary" id="settings-save-restart">
+            Save &amp; start new session
+          </button>
+        </div>
+      </footer>
+    </dialog>
 
     <!-- Voice-asset consent modal. Opened by voice.js when start_voice_mode
          returns AssetMissing. The asset rows + total size are filled from
          the StartVoiceModeError::AssetMissing payload at open time; the
          progress section becomes visible only once the Download button has
          been clicked and primer://voice/download_progress events arrive. -->
-    <div
-      class="modal-backdrop"
-      id="voice-consent-backdrop"
-      hidden
-      aria-hidden="true"
+    <dialog
+      class="modal"
+      id="voice-consent-modal"
+      aria-labelledby="voice-consent-title"
     >
-      <div
-        class="modal"
-        id="voice-consent-modal"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="voice-consent-title"
-      >
-        <header class="modal-header">
-          <h2 id="voice-consent-title">Download voice models</h2>
-          <button
-            type="button"
-            class="modal-close"
-            id="voice-consent-close"
-            aria-label="Close"
-            title="Close"
-          >
-            ×
-          </button>
-        </header>
+      <header class="modal-header">
+        <h2 id="voice-consent-title">Download voice models</h2>
+        <button
+          type="button"
+          class="modal-close"
+          id="voice-consent-close"
+          aria-label="Close"
+          title="Close"
+        >
+          ×
+        </button>
+      </header>
 
-        <div class="modal-body">
-          <p>
-            Voice mode needs Whisper (speech-to-text) and Piper
-            (text-to-speech) models for your locale (<span
-              id="voice-consent-locale"
-              >en</span
-            >). Total approximate size:
-            <strong id="voice-consent-total-size">~530 MB</strong>.
-          </p>
-          <p class="hint muted">
-            Files will be downloaded to <code>~/.cache/primer/models/</code>.
-            Source URLs are shown below; close this dialog and use Settings →
-            Speech to point at your own files instead.
-          </p>
+      <div class="modal-body">
+        <p>
+          Voice mode needs Whisper (speech-to-text) and Piper
+          (text-to-speech) models for your locale (<span
+            id="voice-consent-locale"
+            >en</span
+          >). Total approximate size:
+          <strong id="voice-consent-total-size">~530 MB</strong>.
+        </p>
+        <p class="hint muted">
+          Files will be downloaded to <code>~/.cache/primer/models/</code>.
+          Source URLs are shown below; close this dialog and use Settings →
+          Speech to point at your own files instead.
+        </p>
 
-          <table class="asset-list">
-            <thead>
-              <tr>
-                <th>File</th>
-                <th>Size</th>
-                <th>Source</th>
-              </tr>
-            </thead>
-            <tbody id="voice-consent-assets">
-              <!-- Rows rendered from JS based on the AssetMissing payload. -->
-            </tbody>
-          </table>
+        <table class="asset-list">
+          <thead>
+            <tr>
+              <th>File</th>
+              <th>Size</th>
+              <th>Source</th>
+            </tr>
+          </thead>
+          <tbody id="voice-consent-assets">
+            <!-- Rows rendered from JS based on the AssetMissing payload. -->
+          </tbody>
+        </table>
 
-          <div id="voice-consent-progress" hidden>
-            <div class="progress-row" id="voice-consent-progress-row">
-              <span
-                class="progress-label"
-                id="voice-consent-progress-label"
-                >Downloading…</span
-              >
-              <progress
-                id="voice-consent-progress-bar"
-                value="0"
-                max="100"
-              ></progress>
-            </div>
+        <div id="voice-consent-progress" hidden>
+          <div class="progress-row" id="voice-consent-progress-row">
+            <span
+              class="progress-label"
+              id="voice-consent-progress-label"
+              >Downloading…</span
+            >
+            <progress
+              id="voice-consent-progress-bar"
+              value="0"
+              max="100"
+            ></progress>
           </div>
-
-          <div
-            class="error-banner"
-            id="voice-consent-error"
-            role="alert"
-            hidden
-          ></div>
         </div>
 
-        <footer class="modal-footer">
-          <div class="modal-footer-actions">
-            <button
-              type="button"
-              class="btn-tertiary"
-              id="voice-consent-cancel"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              class="btn-primary"
-              id="voice-consent-download"
-            >
-              Download
-            </button>
-          </div>
-        </footer>
+        <div
+          class="error-banner"
+          id="voice-consent-error"
+          role="alert"
+          hidden
+        ></div>
       </div>
-    </div>
+
+      <footer class="modal-footer">
+        <div class="modal-footer-actions">
+          <button
+            type="button"
+            class="btn-tertiary"
+            id="voice-consent-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn-primary"
+            id="voice-consent-download"
+          >
+            Download
+          </button>
+        </div>
+      </footer>
+    </dialog>
 
     <div
       class="toast"

--- a/src/crates/primer-gui/ui/settings.js
+++ b/src/crates/primer-gui/ui/settings.js
@@ -27,7 +27,6 @@ const { invoke } = window.__TAURI__.core;
 const SUBSYSTEMS = ["classifier", "extractor", "comprehension"];
 
 const dom = {
-  backdrop: document.getElementById("settings-backdrop"),
   modal: document.getElementById("settings-modal"),
   close: document.getElementById("settings-close"),
   cancel: document.getElementById("settings-cancel"),
@@ -137,40 +136,54 @@ async function open({ onSessionRestarted } = {}) {
     populateLocaleChoices();
     populate(view);
     dom.activeHint.hidden = sessionInfo === null;
-    dom.backdrop.hidden = false;
-    dom.backdrop.setAttribute("aria-hidden", "false");
-    document.addEventListener("keydown", onEscape);
-    // Focus the first input so keyboard users can start editing.
+    showModal();
+    // Focus the first input so keyboard users can start editing. The
+    // browser's focus-trap on the dialog ensures Tab cycles between
+    // focusable descendants rather than escaping onto the chat shell.
     dom.fields.learnerName.focus();
   } catch (err) {
     showBanner(`Couldn't load settings: ${formatErr(err)}`);
-    dom.backdrop.hidden = false;
-    dom.backdrop.setAttribute("aria-hidden", "false");
+    showModal();
   } finally {
     state.isOpening = false;
   }
 }
 
-function closeModal() {
-  dom.backdrop.hidden = true;
-  dom.backdrop.setAttribute("aria-hidden", "true");
-  document.removeEventListener("keydown", onEscape);
-  state.onSessionRestarted = null;
+/// Open the native <dialog>. Guarded against double-showModal() which
+/// the spec defines as a no-op only when called with the same args, but
+/// some platforms (Tauri webview WebKitGTK 2.40) have reported throws.
+function showModal() {
+  if (!dom.modal.open) dom.modal.showModal();
 }
 
-function onEscape(e) {
-  if (e.key === "Escape" && !state.isSaving) {
-    e.preventDefault();
-    closeModal();
-  }
+function closeModal() {
+  if (dom.modal.open) dom.modal.close();
+  state.onSessionRestarted = null;
 }
 
 function wireDismiss() {
   dom.close.addEventListener("click", closeModal);
   dom.cancel.addEventListener("click", closeModal);
-  // Click on backdrop (but not on the modal card) closes.
-  dom.backdrop.addEventListener("click", (e) => {
-    if (e.target === dom.backdrop && !state.isSaving) closeModal();
+  // Backdrop click closes. Native <dialog> doesn't natively dismiss on
+  // backdrop click, but the click bubbles up with event.target equal to
+  // the dialog element itself (rather than any descendant) when the
+  // user clicks the ::backdrop area. Gating on `!state.isSaving` mirrors
+  // the cancel-button behaviour: in-flight saves shouldn't drop the
+  // modal mid-operation.
+  dom.modal.addEventListener("click", (e) => {
+    if (e.target === dom.modal && !state.isSaving) closeModal();
+  });
+  // The browser fires a `cancel` event on Escape. Prevent it while a
+  // save is in flight so the user can't drop the modal mid-operation
+  // (which previously would have stranded the in-flight invoke).
+  dom.modal.addEventListener("cancel", (e) => {
+    if (state.isSaving) {
+      e.preventDefault();
+      return;
+    }
+    // The dialog will close itself on cancel — clear our callback state
+    // so the close path stays consistent with the explicit-button paths.
+    state.onSessionRestarted = null;
   });
 }
 

--- a/src/crates/primer-gui/ui/settings.js
+++ b/src/crates/primer-gui/ui/settings.js
@@ -156,9 +156,17 @@ function showModal() {
   if (!dom.modal.open) dom.modal.showModal();
 }
 
+/// Teardown shared by every dismissal path (explicit button click,
+/// backdrop click, Escape via the `cancel` event). Anything that has to
+/// run on close-by-any-means lives here so the cancel listener and
+/// closeModal() can never drift apart.
+function clearTransientState() {
+  state.onSessionRestarted = null;
+}
+
 function closeModal() {
   if (dom.modal.open) dom.modal.close();
-  state.onSessionRestarted = null;
+  clearTransientState();
 }
 
 function wireDismiss() {
@@ -176,14 +184,14 @@ function wireDismiss() {
   // The browser fires a `cancel` event on Escape. Prevent it while a
   // save is in flight so the user can't drop the modal mid-operation
   // (which previously would have stranded the in-flight invoke).
+  // Otherwise the UA auto-closes the dialog; we mirror the explicit-
+  // button path by running the same teardown helper.
   dom.modal.addEventListener("cancel", (e) => {
     if (state.isSaving) {
       e.preventDefault();
       return;
     }
-    // The dialog will close itself on cancel — clear our callback state
-    // so the close path stays consistent with the explicit-button paths.
-    state.onSessionRestarted = null;
+    clearTransientState();
   });
 }
 

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -67,8 +67,9 @@
 /* Defensive: ensure the HTML `hidden` attribute actually hides an
    element even when a class rule sets `display: flex` or similar.
    At equal specificity the author rule overrides the UA `[hidden]`
-   rule, which would otherwise leave .modal-backdrop / .picker-screen
-   permanently visible. */
+   rule, which would otherwise leave .picker-screen permanently visible.
+   (The settings + voice-consent modals are <dialog> elements opened via
+   showModal() — see issue #81 — so they're not affected by this rule.) */
 [hidden] {
   display: none !important;
 }
@@ -959,31 +960,38 @@ body.sidebar-collapsed .sidebar {
   background: color-mix(in oklab, var(--accent) 8%, var(--bg));
 }
 
-/* ─── Settings modal ────────────────────────────────────────────── */
+/* ─── Settings + voice-consent modals ──────────────────────────────
+   Both surfaces are native <dialog> elements opened via showModal()
+   (see issue #81). The browser supplies the focus trap and Escape-
+   dismiss; we only need to style the dialog itself and its backdrop
+   pseudo-element. */
 
-.modal-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 100;
-  background: color-mix(in oklab, #000 45%, transparent);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2vh 2vw;
+dialog.modal {
+  /* Reset the UA dialog defaults that fight our flex layout. */
+  padding: 0;
+  margin: auto; /* keeps the dialog centered when shown */
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--surface);
+  color: var(--fg);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  width: min(720px, calc(100vw - 4vw));
+  max-height: 96vh;
+  overflow: hidden;
   -webkit-app-region: no-drag;
 }
 
-.modal {
+/* `display` only applies while the dialog is open — the UA stylesheet
+   sets `display: none` on `dialog:not([open])` and we shouldn't fight
+   that. Switching to flex only when [open] keeps the closed state
+   hidden without `!important`. */
+dialog.modal[open] {
   display: flex;
   flex-direction: column;
-  width: min(720px, 100%);
-  max-height: 96vh;
-  background: var(--surface);
-  color: var(--fg);
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
-  overflow: hidden;
+}
+
+dialog.modal::backdrop {
+  background: color-mix(in oklab, #000 45%, transparent);
 }
 
 .modal-header {

--- a/src/crates/primer-gui/ui/voice.js
+++ b/src/crates/primer-gui/ui/voice.js
@@ -90,8 +90,8 @@
   }
 
   async function showConsentModal(entries) {
-    const backdrop = $("voice-consent-backdrop");
-    if (!backdrop) return;
+    const dialog = $("voice-consent-modal");
+    if (!dialog) return;
     const tbody = $("voice-consent-assets");
     if (tbody) tbody.innerHTML = "";
     let totalMb = 0;
@@ -109,8 +109,7 @@
     }
     const totalEl = $("voice-consent-total-size");
     if (totalEl) totalEl.textContent = totalMb ? `~${totalMb} MB` : "(unknown)";
-    backdrop.hidden = false;
-    backdrop.setAttribute("aria-hidden", "false");
+    if (!dialog.open) dialog.showModal();
 
     // Subscribe to download_progress events for the progress bar.
     let unlistenProgress = null;
@@ -132,15 +131,29 @@
     }
 
     return new Promise((resolve) => {
+      // Listener handle for the dialog's `cancel` event (fired on
+      // Escape). Tracked here so cleanup() can remove it — without
+      // removal the listener leaks across re-opens and the
+      // stop_voice_mode call would fire twice on the second close.
+      let cancelListener = null;
+
       const cleanup = () => {
         if (unlistenProgress) { unlistenProgress(); unlistenProgress = null; }
         if ($("voice-consent-cancel")) $("voice-consent-cancel").onclick = null;
         if ($("voice-consent-close"))  $("voice-consent-close").onclick  = null;
         if ($("voice-consent-download")) $("voice-consent-download").onclick = null;
+        if (cancelListener) {
+          dialog.removeEventListener("cancel", cancelListener);
+          cancelListener = null;
+        }
+      };
+
+      const closeDialog = () => {
+        if (dialog.open) dialog.close();
       };
 
       const onCancel = async () => {
-        backdrop.hidden = true;
+        closeDialog();
         cleanup();
         // Persist voice_mode_enabled=false so the next GUI launch doesn't
         // re-prompt the consent dialog. stop_voice_mode is idempotent and
@@ -173,7 +186,7 @@
           await invoke("download_voice_assets", {
             kinds: entries.map((e) => e.kind),
           });
-          backdrop.hidden = true;
+          closeDialog();
           cleanup();
           // Retry start_voice_mode now that assets are local.
           try {
@@ -210,6 +223,19 @@
       if ($("voice-consent-cancel")) $("voice-consent-cancel").onclick = onCancel;
       if ($("voice-consent-close"))  $("voice-consent-close").onclick  = onCancel;
       if ($("voice-consent-download")) $("voice-consent-download").onclick = onDownload;
+
+      // Native <dialog>.showModal() fires a `cancel` event on Escape
+      // before auto-closing. Block the auto-close and route through
+      // onCancel so stop_voice_mode is called and the promise resolves —
+      // the same path the explicit Cancel button takes. Without this,
+      // Escape would close the dialog without persisting
+      // voice_mode_enabled=false and the modal would re-appear on the
+      // next launch with no way to dismiss it durably.
+      cancelListener = (e) => {
+        e.preventDefault();
+        onCancel();
+      };
+      dialog.addEventListener("cancel", cancelListener);
     });
   }
 

--- a/src/crates/primer-gui/ui/voice.js
+++ b/src/crates/primer-gui/ui/voice.js
@@ -111,6 +111,14 @@
     if (totalEl) totalEl.textContent = totalMb ? `~${totalMb} MB` : "(unknown)";
     if (!dialog.open) dialog.showModal();
 
+    // No backdrop-click dismissal is wired here — deliberate asymmetry
+    // vs the settings modal. The consent decision has side effects
+    // (start a ~530 MB download OR persist voice_mode_enabled=false via
+    // stop_voice_mode), so we require an explicit Cancel/Download click
+    // rather than letting a stray off-target click drop the modal.
+    // Escape still routes through the `cancel` event handler below so
+    // keyboard dismissal stays available.
+
     // Subscribe to download_progress events for the progress bar.
     let unlistenProgress = null;
     const progressBar   = $("voice-consent-progress-bar");


### PR DESCRIPTION
## Summary

Both the settings modal and the voice-asset consent modal were `<div role="dialog">` toggled via the `hidden` attribute. After Tab past the last action button, focus drifted onto the chat shell behind the dim backdrop — both an accessibility gap and a UX surprise.

Swap both surfaces to native `<dialog>` opened via `showModal()`. The browser then supplies the focus trap, Escape-to-cancel, and an inert `::backdrop` pseudo-element for free. The same dim-overlay color the `.modal-backdrop` div previously carried moves onto `dialog.modal::backdrop`; the `.modal` rule is rewritten as `dialog.modal[open]` so the flex layout only kicks in when the UA stylesheet stops hiding the dialog.

**Settings:**
- `closeModal()` now calls `dialog.close()`; `open()` calls `dialog.showModal()`. The manual `keydown` Escape handler is replaced by a `cancel` event listener that `preventDefault`s while a save is in flight.
- Backdrop click still closes — the click bubbles up with `event.target === dialog` when the user clicks the `::backdrop` area, gated on `!isSaving` to match the previous behaviour.

**Voice consent:**
- `showConsentModal()` calls `dialog.showModal()` and closes via `dialog.close()` on cancel/download/error paths.
- Escape now routes through `onCancel` (via the `cancel` event, `preventDefault`'d) so `stop_voice_mode` still fires and the sticky `voice_mode_enabled=false` write persists. Without this the dialog would re-prompt on the next launch.

**Regression test:** new `modal_dialog_contract` module under `primer-gui` pins five facts via `include_str!`'d UI assets:
- both `id="settings-modal"` and `id="voice-consent-modal"` resolve to `<dialog>` tags (not `<div>`)
- `ui/index.html` no longer contains `modal-backdrop`
- `ui/settings.js` and `ui/voice.js` both call `.showModal()`
- `ui/styles.css` declares a `::backdrop` rule

Plus three unit tests for the `tag_for_id` HTML-walker helper. The contract follows the issue-#71 pattern (`include_str!` + cfg-test parser) so a future regression breaks `cargo test --workspace` rather than silently re-introducing the accessibility gap.

## Test plan

- [x] `cargo test --workspace` — 852 passed / 0 failed / 3 ignored (was 842; +8 new `modal_dialog_contract` tests, +2 unaccounted vs prior brief)
- [x] `cargo test -p primer-gui --features speech` — 142 passed
- [x] `cargo test -p primer-cli --features speech` — 12 passed
- [x] `cargo test -p primer-cli --features speech,macos-native` — 12 passed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets --features primer-gui/speech -- -D warnings` — clean
- [ ] Manual GUI smoke (recommended before merge): `cargo run -p primer-gui --features speech`, open Settings, Tab through every field and confirm focus stays inside the dialog (no drift onto the chat shell under the backdrop). Trigger the voice-consent modal if speech assets aren't cached; Tab through Cancel / Download; Esc routes through `onCancel`. Open WebView DevTools and confirm no CSP `Refused to apply inline style` warnings (PR #119 tightened CSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)