### PR TITLE
speech: fix supertonic vendor crate build (follow-up to #127)

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1201,7 +1201,7 @@ checksum = "158bd4a909fb7edd96013796d6b6c57660615a90da81811f2a97bf4ea832d6e4"
 dependencies = [
  "anyhow",
  "hf-hub",
- "ndarray 0.16.1",
+ "ndarray",
  "ort",
  "safetensors",
  "serde_json",
@@ -2544,21 +2544,6 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
  "rayon",
 ]
 
@@ -3077,7 +3062,7 @@ version = "2.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
 dependencies = [
- "ndarray 0.16.1",
+ "ndarray",
  "ort-sys",
  "smallvec 2.0.0-alpha.10",
  "tracing",
@@ -3236,7 +3221,7 @@ version = "0.1.9"
 dependencies = [
  "espeak-rs",
  "flume",
- "ndarray 0.16.1",
+ "ndarray",
  "once_cell",
  "ort",
  "rayon",
@@ -4590,7 +4575,7 @@ name = "silero-vad-rust"
 version = "6.2.1"
 dependencies = [
  "anyhow",
- "ndarray 0.16.1",
+ "ndarray",
  "ort",
  "thiserror 2.0.18",
 ]
@@ -4799,7 +4784,7 @@ dependencies = [
  "clap",
  "hound",
  "libc",
- "ndarray 0.17.2",
+ "ndarray",
  "ort",
  "rand 0.8.6",
  "rand_distr",

--- a/src/vendor/supertonic-rs/Cargo.toml
+++ b/src/vendor/supertonic-rs/Cargo.toml
@@ -20,10 +20,10 @@ path = "src/lib.rs"
 # ONNX Runtime — pinned to rc.10 to match the rest of the primer workspace
 # (silero/whisper/piper/fastembed all pin rc.10). Upstream supertonic uses
 # rc.7. The migration touchpoints are documented inline in helper.rs.
-ort = { version = "=2.0.0-rc.10", default-features = false, features = ["download-binaries", "copy-dylibs"] }
+ort = { version = "=2.0.0-rc.10", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "copy-dylibs"] }
 
 # Array processing (like NumPy)
-ndarray = { version = "0.17", features = ["rayon"] }
+ndarray = { version = "0.16", features = ["rayon"] }
 rand = "0.8"
 rand_distr = "0.4"
 

--- a/src/vendor/supertonic-rs/Cargo.toml
+++ b/src/vendor/supertonic-rs/Cargo.toml
@@ -20,9 +20,16 @@ path = "src/lib.rs"
 # ONNX Runtime — pinned to rc.10 to match the rest of the primer workspace
 # (silero/whisper/piper/fastembed all pin rc.10). Upstream supertonic uses
 # rc.7. The migration touchpoints are documented inline in helper.rs.
+# `default-features = false` drops ort's defaults, so `std`, `ndarray`, and
+# `tracing` are re-added explicitly: `std` is required by Session/Value/error
+# types, `ndarray` is required by every `Value::from_array` site in helper.rs,
+# `tracing` matches ort's default and keeps log forwarding working.
 ort = { version = "=2.0.0-rc.10", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "copy-dylibs"] }
 
-# Array processing (like NumPy)
+# Array processing (like NumPy). Pinned to 0.16 because `ort 2.0.0-rc.10` is
+# built against ndarray 0.16 — the `OwnedTensorArrayData` trait bound on
+# `Value::from_array` is keyed to ort's compiled-in ndarray version, so a
+# 0.17 here silently breaks every tensor construction site.
 ndarray = { version = "0.16", features = ["rayon"] }
 rand = "0.8"
 rand_distr = "0.4"


### PR DESCRIPTION
## Summary
- PR #127 merged with the rc.10 migration unverified — the vendor crate at `src/vendor/supertonic-rs/` failed to compile on any host that can complete the `cdn.pyke.io` ort-runtime download (38 errors from `cargo build -p primer-speech --features supertonic`).
- Two-line Cargo.toml fix: restore ort's `std` + `ndarray` + `tracing` features that the original `default-features = false` declaration dropped, and pin `ndarray` to `0.16` to match the version `ort 2.0.0-rc.10` (and silero / piper-rs) build against. The `OwnedTensorArrayData` trait bound on `Value::from_array` is keyed to ort's compiled-in ndarray version, so a `ndarray = "0.17"` declaration silently broke every tensor construction site.
- Smoke example now produces clean 44.1 kHz WAVs in en, de, and hi at RTF ≈ 0.035 on CPU. Validates the multilingual-single-model story #127 set up.

## Test plan
- [x] `cargo build --example tts_supertonic_hello -p primer-speech --features supertonic` finishes clean.
- [x] EN: `--lang en --voice-style F1.json --text "Hello, what would you like to learn about today?"` → 3.65 s of audio in 129 ms (peak=7110, rms=1126 of int16).
- [x] DE: `--lang de --voice-style M1.json --text "Hallo, was möchtest du heute lernen?"` → 3.26 s in 115 ms.
- [x] HI: `--lang hi --voice-style F2.json --text "नमस्ते, आज आप क्या सीखना चाहेंगे?"` → 2.98 s in 114 ms.
- [x] All three played back cleanly via `afplay` on macOS.
- [ ] CI: `cargo test (default features)` should be untouched (no Rust changes, vendor crate only built under explicit `--features supertonic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)