### PR TITLE
speech(macos): add macOS 26 SpeechAnalyzer streaming-STT spike

### DIFF
--- a/spikes/macos26_speech/.gitignore
+++ b/spikes/macos26_speech/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved

--- a/spikes/macos26_speech/Package.swift
+++ b/spikes/macos26_speech/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "macos26_speech",
+    platforms: [.macOS("26.0")],
+    targets: [
+        .executableTarget(
+            name: "macos26_speech",
+            path: "Sources/macos26_speech"
+        )
+    ]
+)

--- a/spikes/macos26_speech/Sources/macos26_speech/main.swift
+++ b/spikes/macos26_speech/Sources/macos26_speech/main.swift
@@ -1,0 +1,148 @@
+// Minimal proof: mic -> SpeechAnalyzer/SpeechTranscriber -> stdout partials + finals.
+// Usage:   swift run macos26_speech [bcp47-locale]
+// Default: en-US. Try de-DE; on first run for a locale, the model downloads.
+// Stop:    Ctrl+C.
+
+import AVFoundation
+import Foundation
+import Speech
+
+@main
+struct Spike {
+    static func main() async {
+        do {
+            try await run()
+        } catch {
+            FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+            exit(1)
+        }
+    }
+
+    static func run() async throws {
+        let localeId = CommandLine.arguments.dropFirst().first ?? "en-US"
+        let locale = Locale(identifier: localeId)
+        log("locale: \(localeId)")
+
+        let transcriber = SpeechTranscriber(
+            locale: locale,
+            preset: .progressiveTranscription
+        )
+        try await ensureModel(for: transcriber, locale: locale)
+
+        // SpeechDetector gates the transcriber so silence skips the model (power saving).
+        // Its Result stream "currently only supports error handling" per Apple docs, so
+        // it's not a source of speech-start/end events — derive those from the transcriber
+        // (first volatile partial after silence = speech-start).
+        let detector = SpeechDetector(
+            detectionOptions: .init(sensitivityLevel: .medium),
+            reportResults: false
+        )
+
+        let analyzer = SpeechAnalyzer(modules: [detector, transcriber])
+        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: [transcriber]
+        ) else {
+            throw SpikeError.noAudioFormat
+        }
+        log("analyzer format: \(analyzerFormat)")
+
+        let (inputSequence, inputBuilder) = AsyncStream<AnalyzerInput>.makeStream()
+
+        let audioEngine = AVAudioEngine()
+        let micFormat = audioEngine.inputNode.outputFormat(forBus: 0)
+        log("mic format: \(micFormat)")
+
+        guard let converter = AVAudioConverter(from: micFormat, to: analyzerFormat) else {
+            throw SpikeError.noConverter
+        }
+
+        audioEngine.inputNode.installTap(
+            onBus: 0,
+            bufferSize: 4096,
+            format: micFormat
+        ) { buffer, _ in
+            let ratio = analyzerFormat.sampleRate / micFormat.sampleRate
+            let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1024
+            guard let out = AVAudioPCMBuffer(
+                pcmFormat: analyzerFormat,
+                frameCapacity: capacity
+            ) else { return }
+
+            var fed = false
+            var convError: NSError?
+            let status = converter.convert(to: out, error: &convError) { _, statusPtr in
+                if fed {
+                    statusPtr.pointee = .noDataNow
+                    return nil
+                }
+                fed = true
+                statusPtr.pointee = .haveData
+                return buffer
+            }
+            if status == .error || convError != nil {
+                logErr("convert: \(String(describing: convError))")
+                return
+            }
+            inputBuilder.yield(AnalyzerInput(buffer: out))
+        }
+
+        try audioEngine.start()
+        try await analyzer.start(inputSequence: inputSequence)
+
+        log("listening — press Ctrl+C to stop")
+        print("---")
+
+        for try await result in transcriber.results {
+            let text = String(result.text.characters)
+            let tag = result.isFinal ? "FINAL " : "part  "
+            print("\(tag) \(text)")
+            fflush(stdout)
+        }
+    }
+
+    static func ensureModel(for transcriber: SpeechTranscriber, locale: Locale) async throws {
+        let bcp47 = locale.identifier(.bcp47)
+        let supported = await SpeechTranscriber.supportedLocales
+        guard supported.contains(where: { $0.identifier(.bcp47) == bcp47 }) else {
+            let avail = supported.map { $0.identifier(.bcp47) }.sorted().joined(separator: ", ")
+            logErr("supported locales: \(avail)")
+            throw SpikeError.localeNotSupported(bcp47)
+        }
+        let installed = await SpeechTranscriber.installedLocales
+        if installed.contains(where: { $0.identifier(.bcp47) == bcp47 }) {
+            log("model for \(bcp47) already installed")
+            return
+        }
+        log("downloading model for \(bcp47) (one-time)...")
+        guard let req = try await AssetInventory.assetInstallationRequest(
+            supporting: [transcriber]
+        ) else {
+            throw SpikeError.noInstallationRequest
+        }
+        try await req.downloadAndInstall()
+        log("download complete")
+    }
+}
+
+enum SpikeError: Error, CustomStringConvertible {
+    case noAudioFormat
+    case noConverter
+    case localeNotSupported(String)
+    case noInstallationRequest
+
+    var description: String {
+        switch self {
+        case .noAudioFormat: return "no compatible analyzer audio format"
+        case .noConverter: return "could not create AVAudioConverter"
+        case .localeNotSupported(let id): return "locale '\(id)' not supported by SpeechTranscriber"
+        case .noInstallationRequest: return "AssetInventory returned no installation request"
+        }
+    }
+}
+
+@inline(__always) private func log(_ msg: String) {
+    FileHandle.standardError.write(Data("[spike] \(msg)\n".utf8))
+}
+@inline(__always) private func logErr(_ msg: String) {
+    FileHandle.standardError.write(Data("[spike:err] \(msg)\n".utf8))
+}


### PR DESCRIPTION
## Summary

- New Swift Package at [`spikes/macos26_speech/`](spikes/macos26_speech/) that drives the macOS 26 `SpeechAnalyzer` / `SpeechTranscriber` / `SpeechDetector` APIs end-to-end (mic → analyzer → streaming partials + finals on stdout).
- Validates whether these APIs can replace the vendored Silero VAD + Whisper STT stack on Tahoe-class machines, behind a future `macos-native-26` feature gate.
- Documents the API surface as it actually exists on the macOS 26.5 SDK (several public guides are wrong about the preset name).

## Why a spike

Research turned up multiple secondary sources with inconsistent API names. Rather than commit a real `macos-native-26` integration on top of guessed signatures, this is the cheapest possible end-to-end harness against the real SDK. It is a throwaway exploration — confined to `spikes/`, not wired into the cargo workspace, and easy to delete once the integration lands.

## Findings recorded in the spike

- **Correct live-streaming preset is `.progressiveTranscription`.** Several articles (substack, dev.to) publish `.progressiveLiveTranscription`; that case does not exist on the macOS 26.5 SDK. The five real presets are `.transcription`, `.transcriptionWithAlternatives`, `.timeIndexedTranscriptionWithAlternatives`, `.progressiveTranscription`, `.timeIndexedProgressiveTranscription`.
- **`SpeechDetector` is a power-saving gate, not an event source.** Apple's docs say its `Result` \"currently only supports error handling from the VAD model.\" Speech-start signal for barge-in must therefore still be derived from the transcriber's first volatile partial after silence, not from a detector callback.
- **`SpeechTranscriber`'s preferred audio format is 16 kHz Int16 mono** — same sample rate Whisper already wants, so the existing `AVAudioConverter` plumbing in `primer-speech` ports over cleanly.
- **30 supported locales** on 26.5, including all `en-*` and `de-*` variants the project ships. **`hi-IN` is still not supported**, so the CLAUDE.md \"Hindi deferred\" stance remains correct on Tahoe.

## How to run

```bash
cd spikes/macos26_speech
swift run macos26_speech            # en-US (model preinstalled on macOS 26)
swift run macos26_speech de-DE      # first run downloads ~model assets
```

After the `listening` banner, speak — you'll see `part   …` lines streaming as words land and `FINAL  …` at utterance boundaries. Ctrl+C to exit. First run triggers Terminal's microphone TCC prompt.

## Test plan

- [ ] `swift build` succeeds on macOS 26.5 SDK (Xcode 17 / Swift 6.3+) ✅ verified locally
- [ ] Launch reaches `listening` banner for `en-US` (model preinstalled) ✅ verified locally
- [ ] Speak into mic and confirm streaming partials arrive before utterance end (interactive — pending reviewer try)
- [ ] Switch to `de-DE`, model downloads on first run, partials work (interactive — pending reviewer try)
- [ ] Confirm unsupported locale (e.g. `hi-IN`) exits cleanly with the supported-list message ✅ verified locally

## Not in scope

- No changes to the cargo workspace, `primer-speech`, or any other crate.
- No barge-in cancellation logic; this only proves the partials stream cleanly.
- No real `macos-native-26` feature gate yet — that lands in a follow-up once we're happy with what we see here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)