### PR TITLE
speech(macos): wire dispatch2 into macos-native-26 feature (#148)

### DIFF
--- a/src/crates/primer-speech/Cargo.toml
+++ b/src/crates/primer-speech/Cargo.toml
@@ -110,6 +110,11 @@ voice-loop = ["silero", "whisper", "piper", "cpal"]
 macos-native = ["dep:objc2", "dep:objc2-foundation", "dep:objc2-avf-audio", "dep:objc2-speech", "dep:block2", "dep:dispatch2"]
 # macOS 26+ STT/VAD via SpeechAnalyzer. Swift sidecar bridged via swift-bridge.
 # Mutually exclusive with macos-native — pick one.
+#
+# `dep:dispatch2` is shared with `macos-native` because `macos/tts.rs` (compiled
+# under `any(macos-native, macos-native-26)` per the CLAUDE.md "macOS-native"
+# bullet) imports `dispatch2::DispatchQueue` unconditionally for the
+# background-thread AVSpeechSynthesizer path. See issue #148.
 macos-native-26 = [
     "dep:swift-bridge",
     "swift-bridge-build",
@@ -117,6 +122,7 @@ macos-native-26 = [
     "dep:objc2-foundation",
     "dep:objc2-avf-audio",
     "dep:block2",
+    "dep:dispatch2",
 ]
 
 [[example]]

--- a/src/crates/primer-speech/build.rs
+++ b/src/crates/primer-speech/build.rs
@@ -20,7 +20,7 @@ fn main() {
 
 #[cfg(feature = "macos-native-26")]
 mod macos_native_26 {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
 
     const SWIFT_LIB_NAME: &str = "Macos26Pipeline";
@@ -54,7 +54,7 @@ mod macos_native_26 {
         );
         std::fs::write(&bridging_header, &bridging_content).expect("write bridging header");
 
-        let lib_path = out_dir.join(format!("lib{}.a", SWIFT_LIB_NAME));
+        let lib_path = out_dir.join(format!("lib{SWIFT_LIB_NAME}.a"));
         let mut cmd = Command::new("swiftc");
         cmd.arg("-emit-library")
             .arg("-static")
@@ -78,7 +78,7 @@ mod macos_native_26 {
 
         // 3. Link directives.
         println!("cargo:rustc-link-search=native={}", out_dir.display());
-        println!("cargo:rustc-link-lib=static={}", SWIFT_LIB_NAME);
+        println!("cargo:rustc-link-lib=static={SWIFT_LIB_NAME}");
         // Swift runtime libraries — required when linking a Swift staticlib.
         println!("cargo:rustc-link-search=native={}", swift_runtime_dir());
         for fw in ["Foundation", "AVFoundation", "CoreMedia", "Speech"] {
@@ -121,9 +121,9 @@ mod macos_native_26 {
     }
 
     // Recursively collect all .swift files under `dir` (including subdirs).
-    fn walk_swift_files_recursive(dir: &PathBuf) -> Vec<PathBuf> {
+    fn walk_swift_files_recursive(dir: &Path) -> Vec<PathBuf> {
         let mut result = Vec::new();
-        fn recurse(dir: &std::path::Path, result: &mut Vec<PathBuf>) {
+        fn recurse(dir: &Path, result: &mut Vec<PathBuf>) {
             let rd = match std::fs::read_dir(dir) {
                 Ok(r) => r,
                 Err(_) => return,

--- a/src/crates/primer-speech/src/macos26/vad.rs
+++ b/src/crates/primer-speech/src/macos26/vad.rs
@@ -73,9 +73,7 @@ impl DerivedVadStateMachine {
         if self.state != State::Speaking {
             return None;
         }
-        let Some(last) = self.last_partial_at else {
-            return None;
-        };
+        let last = self.last_partial_at?;
         if now.duration_since(last) > SPEECH_END_TIMEOUT {
             self.state = State::Idle;
             self.last_partial_at = None;


### PR DESCRIPTION
## Summary

- Add `dep:dispatch2` to the `macos-native-26` feature list in `primer-speech/Cargo.toml`. The `macos/tts.rs` module is cfg-gated on `any(macos-native, macos-native-26)` and imports `dispatch2::DispatchQueue` unconditionally for the background-thread AVSpeechSynthesizer path; without the dep, `--features speech,macos-native-26` (without `macos-native`) failed to build at the import.
- Fixed three pre-existing clippy lints surfaced for the first time now that the macos-native-26 build actually completes:
  - `build.rs` — two `uninlined_format_args` (`format!("lib{}.a", SWIFT_LIB_NAME)` → `format!("lib{SWIFT_LIB_NAME}.a")`, plus the `cargo:rustc-link-lib=static={}` println) and one `ptr_arg` (`&PathBuf` → `&Path` on `walk_swift_files_recursive`).
  - `src/macos26/vad.rs` — `let...else` → `?` (`let last = self.last_partial_at?;`).

Closes #148.

## Test plan

- [x] `cargo build -p primer-speech --features macos-native-26 --no-default-features` — clean (was: `error[E0432]: unresolved import dispatch2`).
- [x] `cargo test -p primer-cli --features speech,macos-native-26` — 12/0/0.
- [x] `cargo test -p primer-speech --features macos-native-26` — 52/0/3.
- [x] `cargo test --workspace` (default features) — 858/0/3 baseline.
- [x] `cargo test -p primer-speech --features macos-native` — 49/0/3 baseline.
- [x] `cargo test -p primer-cli --features speech,macos-native` — 12/0/0 baseline.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p primer-speech --features macos-native --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p primer-speech --features macos-native-26 --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p primer-cli --features speech,macos-native --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p primer-cli --features speech,macos-native-26 --all-targets -- -D warnings` — clean.

## Notes

The fix to `Cargo.toml` is the load-bearing one for #148. The three lint fixes ride along because they're trivial and exist only because the matrix was broken before — clippy never ran against this build. Per the "implement quick fixes inline" pattern in `MEMORY.md`, surfaced lints should be fixed in the same PR rather than become follow-up issues.

The previous brief noted #148 as a recommended early pickup ("truly one-line Cargo.toml fix"). The Cargo.toml change is the one line; the three additional lint fixes were not foreseen, but each is mechanical and individually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)