### PR TITLE
speech(macos26): mock-based tests for run_consumer_loop synthetic-final ordering (#140)

### DIFF
--- a/src/crates/primer-speech/src/macos26/analyzer.rs
+++ b/src/crates/primer-speech/src/macos26/analyzer.rs
@@ -11,15 +11,91 @@
 
 #![cfg(all(target_vendor = "apple", feature = "macos-native-26"))]
 
-use std::time::Instant;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
 
-use primer_core::consts::speech::macos26::EVENT_POLL_INTERVAL;
+use primer_core::consts::speech::macos26::{EVENT_POLL_INTERVAL, SPEECH_END_TIMEOUT};
 use primer_core::error::Result;
 use primer_core::speech::{TranscriptSegment, VadEvent};
 use tokio::sync::mpsc;
 
-use crate::macos26::bridge::Macos26Pipeline;
+use crate::macos26::bridge::{Macos26Pipeline, ResultEvent};
 use crate::macos26::vad::DerivedVadStateMachine;
+
+/// Abstraction over the Swift `Macos26Pipeline` so tests can drive
+/// [`run_consumer_loop`] with a scripted mock instead of the live
+/// `SpeechAnalyzer` sidecar (which would otherwise require macOS 26
+/// hardware + a mic).
+///
+/// The shape mirrors the four methods [`run_consumer_loop`] actually
+/// calls on the real pipeline. Returning `Pin<Box<dyn Future + Send>>`
+/// rather than `impl Future + Send` (RPITIT) is deliberate: it keeps the
+/// trait stable across rustc nightly's evolving `async fn in trait`
+/// auto-trait inference and makes the `Send` bound explicit so a
+/// regression in swift-bridge's future-send-ness shows up at the impl
+/// site rather than at `tokio::spawn`.
+///
+/// Production impl: `Macos26Pipeline` (immediately below).
+/// Test impls: see [`tests::ScriptedPipeline`].
+pub(crate) trait PipelineSource: Send {
+    /// Push captured PCM samples into the analyzer.
+    fn feed_audio(&mut self, samples: Vec<f32>);
+
+    /// Await the next analyzer result. The returned future must be
+    /// cancel-safe under `tokio::select!` — a partially-awaited future
+    /// dropped because another arm was ready must not lose the result.
+    /// The Swift side achieves this via a cached single-flighted
+    /// `Task<ResultEvent>` (see `Macos26PipelineImpl.swift`).
+    fn next_result(&mut self) -> Pin<Box<dyn Future<Output = ResultEvent> + Send + '_>>;
+
+    /// Fetch the transcript text associated with the most-recently
+    /// awaited `next_result`. Sync to avoid the swift-bridge 0.1.x
+    /// async-shared-struct-String bug; see `bridge.rs` for context.
+    fn last_result_text(&self) -> String;
+
+    /// Tear down the analyzer pipeline gracefully.
+    fn stop(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+}
+
+impl PipelineSource for Macos26Pipeline {
+    fn feed_audio(&mut self, samples: Vec<f32>) {
+        Macos26Pipeline::feed_audio(self, samples);
+    }
+
+    fn next_result(&mut self) -> Pin<Box<dyn Future<Output = ResultEvent> + Send + '_>> {
+        Box::pin(Macos26Pipeline::next_result(self))
+    }
+
+    fn last_result_text(&self) -> String {
+        Macos26Pipeline::last_result_text(self)
+    }
+
+    fn stop(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(Macos26Pipeline::stop(self))
+    }
+}
+
+/// Tunable timings used by [`run_consumer_loop_with_config`].
+///
+/// The default is `(EVENT_POLL_INTERVAL, SPEECH_END_TIMEOUT)` from
+/// `primer_core::consts::speech::macos26`. Tests shrink both so the
+/// inactivity-derived `SpeechEnd` path fires in tens of milliseconds
+/// instead of the production ~1 s window.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ConsumerConfig {
+    pub tick_interval: Duration,
+    pub inactivity_timeout: Duration,
+}
+
+impl Default for ConsumerConfig {
+    fn default() -> Self {
+        Self {
+            tick_interval: EVENT_POLL_INTERVAL,
+            inactivity_timeout: SPEECH_END_TIMEOUT,
+        }
+    }
+}
 
 /// Message pushed onto the text channel for each transcriber Result.
 /// `ChannelStt` (in voice_loop) consumes these to feed the streaming
@@ -86,15 +162,39 @@ impl PartialBuffer {
 /// chunk; chunk size is up to the producer). `text_tx` and `event_tx`
 /// are the outbound channels consumed by voice_loop.
 pub async fn run_consumer_loop(
-    mut pipeline: Macos26Pipeline,
-    mut audio_rx: mpsc::Receiver<Vec<f32>>,
+    pipeline: Macos26Pipeline,
+    audio_rx: mpsc::Receiver<Vec<f32>>,
     text_tx: mpsc::Sender<TextMessage>,
     event_tx: mpsc::Sender<VadEvent>,
 ) -> Result<()> {
+    run_consumer_loop_with_config(
+        pipeline,
+        audio_rx,
+        text_tx,
+        event_tx,
+        ConsumerConfig::default(),
+    )
+    .await
+}
+
+/// Generic, parameterised inner loop. Identical to [`run_consumer_loop`]
+/// except the pipeline can be any [`PipelineSource`] and the tick /
+/// inactivity timings can be shrunk for fast unit tests.
+///
+/// Production paths call [`run_consumer_loop`] (the thin wrapper above);
+/// tests call this directly with a [`tests::ScriptedPipeline`] and a
+/// short-timeout [`ConsumerConfig`].
+pub(crate) async fn run_consumer_loop_with_config<P: PipelineSource>(
+    mut pipeline: P,
+    mut audio_rx: mpsc::Receiver<Vec<f32>>,
+    text_tx: mpsc::Sender<TextMessage>,
+    event_tx: mpsc::Sender<VadEvent>,
+    cfg: ConsumerConfig,
+) -> Result<()> {
     tracing::info!(target: "primer::speech::macos26", "consumer loop starting");
-    let mut sm = DerivedVadStateMachine::new();
+    let mut sm = DerivedVadStateMachine::with_inactivity_timeout(cfg.inactivity_timeout);
     let mut buf = PartialBuffer::new();
-    let mut tick = tokio::time::interval(EVENT_POLL_INTERVAL);
+    let mut tick = tokio::time::interval(cfg.tick_interval);
     // Skip the immediate first tick that tokio fires at t=0.
     tick.tick().await;
     let mut audio_chunks_received: u64 = 0;
@@ -284,5 +384,254 @@ mod tests {
         assert!(b.take_synthetic_final().is_some());
         // Second take after the buffer was drained returns None.
         assert!(b.take_synthetic_final().is_none());
+    }
+
+    // ── ScriptedPipeline + run_consumer_loop orchestration tests ────────
+    //
+    // Below: a scripted `PipelineSource` impl that lets unit tests drive
+    // `run_consumer_loop_with_config` without the live Swift sidecar.
+    // The shared invariant under test (#140): when SpeechEnd is derived
+    // from the inactivity tick, the buffered synthetic-final
+    // TextMessage must be emitted on `text_tx` BEFORE the SpeechEnd
+    // VadEvent is emitted on `event_tx`. Children's TTS-driven follow-up
+    // turns rely on ChannelStt seeing the transcript moments before the
+    // VAD `SpeechEnd` arrives — invert the order and the dialogue
+    // manager handles a `SpeechEnd` without ever having received the
+    // utterance that triggered it.
+
+    use std::collections::VecDeque;
+
+    /// Mock `PipelineSource` driven by a pre-scripted sequence of
+    /// `(ResultEvent, text)` pairs.
+    ///
+    /// `next_result` pops the next scripted pair and stashes the text
+    /// for the subsequent `last_result_text` call (mirroring the Swift
+    /// side's cached `lastText` field). When the script is empty
+    /// `next_result` hangs forever via `std::future::pending` so the
+    /// `tick.tick()` arm of the consumer's `tokio::select!` becomes the
+    /// only ready branch — driving the inactivity-derived SpeechEnd
+    /// path that this test cluster exists to lock in.
+    struct ScriptedPipeline {
+        script: VecDeque<(ResultEvent, String)>,
+        last_text: String,
+        feed_audio_calls: usize,
+        stop_calls: usize,
+    }
+
+    impl ScriptedPipeline {
+        fn new(script: Vec<(ResultEvent, String)>) -> Self {
+            Self {
+                script: script.into_iter().collect(),
+                last_text: String::new(),
+                feed_audio_calls: 0,
+                stop_calls: 0,
+            }
+        }
+    }
+
+    impl PipelineSource for ScriptedPipeline {
+        fn feed_audio(&mut self, _samples: Vec<f32>) {
+            self.feed_audio_calls += 1;
+        }
+
+        fn next_result(&mut self) -> Pin<Box<dyn Future<Output = ResultEvent> + Send + '_>> {
+            Box::pin(async move {
+                if let Some((event, text)) = self.script.pop_front() {
+                    self.last_text = text;
+                    event
+                } else {
+                    // Hang so the inactivity tick arm wins the select.
+                    std::future::pending().await
+                }
+            })
+        }
+
+        fn last_result_text(&self) -> String {
+            self.last_text.clone()
+        }
+
+        fn stop(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            self.stop_calls += 1;
+            Box::pin(async {})
+        }
+    }
+
+    /// Construct a `ResultEvent` with default ranges. Keeps the test
+    /// bodies focused on the bits that actually matter (`is_final`,
+    /// `stream_done`).
+    fn result_event(is_final: bool, stream_done: bool) -> ResultEvent {
+        ResultEvent {
+            is_final,
+            range_start_ms: 0,
+            range_end_ms: 100,
+            stream_done,
+        }
+    }
+
+    /// Test config: shrink the tick interval and inactivity timeout so
+    /// the inactivity-derived SpeechEnd fires inside ~50 ms wallclock
+    /// rather than the production 1 s window.
+    fn fast_test_config() -> ConsumerConfig {
+        ConsumerConfig {
+            tick_interval: Duration::from_millis(5),
+            inactivity_timeout: Duration::from_millis(30),
+        }
+    }
+
+    /// **Load-bearing regression test for #140.**
+    ///
+    /// When the inactivity tick derives a SpeechEnd, the consumer loop
+    /// must emit the buffered synthetic-final `TextMessage` on `text_tx`
+    /// BEFORE forwarding the `SpeechEnd` `VadEvent` on `event_tx`. A
+    /// future refactor that swaps the order of those two sends inside
+    /// the tick branch would break the contract silently — manual mic
+    /// testing on macOS 26 hardware was previously the only way to
+    /// catch this. This test catches it via a capacity-1 `text_tx`:
+    /// the synthetic-final `send().await` blocks the loop until the
+    /// test drains the volatile partial, so a SpeechEnd that landed on
+    /// `event_rx` *before* the synthetic-final landed on `text_rx` is a
+    /// reorder bug.
+    #[tokio::test]
+    async fn synthetic_final_text_arrives_before_speech_end_vad() {
+        // Script one volatile partial; the script then empties so the
+        // tick arm drives SpeechEnd derivation.
+        let pipeline = ScriptedPipeline::new(vec![(
+            result_event(false, false),
+            "hello world".to_string(),
+        )]);
+
+        let (audio_tx, audio_rx) = mpsc::channel::<Vec<f32>>(8);
+        // Capacity-1 text channel: the synthetic-final `send().await`
+        // will block until we drain the volatile partial. That blocking
+        // is what gives the test deterministic order observation.
+        let (text_tx, mut text_rx) = mpsc::channel::<TextMessage>(1);
+        let (event_tx, mut event_rx) = mpsc::channel::<VadEvent>(8);
+
+        let handle = tokio::spawn(run_consumer_loop_with_config(
+            pipeline,
+            audio_rx,
+            text_tx,
+            event_tx,
+            fast_test_config(),
+        ));
+
+        // Wait long enough for: (1) the volatile partial to be sent →
+        // text_rx fills its single slot, (2) the inactivity timeout
+        // (30 ms) + a tick (5 ms) to elapse so the SpeechEnd branch
+        // attempts to send the synthetic-final.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        // Drain the volatile partial. This MUST succeed — if it
+        // doesn't, the loop never sent it and the rest of the test is
+        // meaningless.
+        let first_text = text_rx
+            .try_recv()
+            .expect("volatile partial should be in text_rx");
+        assert!(
+            !first_text.is_final,
+            "first message is the volatile partial"
+        );
+        assert_eq!(first_text.segment.text, "hello world");
+
+        // SpeechStart should already be present. SpeechEnd MUST NOT be.
+        // If SpeechEnd is observable here, the consumer loop sent it
+        // before the synthetic-final TextMessage — the #140 reorder bug.
+        let start_event = event_rx
+            .try_recv()
+            .expect("SpeechStart should be in event_rx");
+        assert!(
+            matches!(start_event, VadEvent::SpeechStart),
+            "first event must be SpeechStart, got {start_event:?}"
+        );
+        assert!(
+            event_rx.try_recv().is_err(),
+            "#140: SpeechEnd must NOT precede the synthetic-final TextMessage on text_tx"
+        );
+
+        // Now drain the synthetic-final TextMessage. The blocking send
+        // unblocks once we just drained the volatile partial above,
+        // so this should arrive promptly.
+        let synthetic = tokio::time::timeout(Duration::from_millis(200), text_rx.recv())
+            .await
+            .expect("synthetic-final TextMessage never arrived")
+            .expect("text channel closed before synthetic-final");
+        assert!(synthetic.is_final, "synthetic emit must be marked final");
+        assert_eq!(synthetic.segment.text, "hello world");
+
+        // Now (and only now) the consumer loop should proceed to send
+        // SpeechEnd. Wait briefly for it.
+        let end_event = tokio::time::timeout(Duration::from_millis(200), event_rx.recv())
+            .await
+            .expect("SpeechEnd never arrived")
+            .expect("event channel closed before SpeechEnd");
+        assert!(
+            matches!(end_event, VadEvent::SpeechEnd),
+            "second event must be SpeechEnd, got {end_event:?}"
+        );
+
+        // Shut down: closing audio_tx makes audio_rx.recv() return None,
+        // which calls pipeline.stop() and returns Ok.
+        drop(audio_tx);
+        let _ = tokio::time::timeout(Duration::from_millis(200), handle).await;
+    }
+
+    /// Sanity test: a `stream_done=true` sentinel from the pipeline
+    /// terminates the consumer loop cleanly with `Ok(())`. Pins the
+    /// other documented exit path (besides `audio_rx` closing).
+    #[tokio::test]
+    async fn stream_done_sentinel_exits_cleanly() {
+        let pipeline = ScriptedPipeline::new(vec![(result_event(false, true), String::new())]);
+        let (_audio_tx, audio_rx) = mpsc::channel::<Vec<f32>>(8);
+        let (text_tx, _text_rx) = mpsc::channel::<TextMessage>(8);
+        let (event_tx, _event_rx) = mpsc::channel::<VadEvent>(8);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            run_consumer_loop_with_config(
+                pipeline,
+                audio_rx,
+                text_tx,
+                event_tx,
+                fast_test_config(),
+            ),
+        )
+        .await
+        .expect("consumer loop did not exit within 200 ms of stream_done");
+        assert!(
+            result.is_ok(),
+            "stream_done should yield Ok(()), got {result:?}"
+        );
+    }
+
+    /// Sanity test: closing the audio mpsc terminates the consumer
+    /// loop cleanly via the `audio_rx.recv() = None` branch, and the
+    /// pipeline's `stop()` is invoked exactly once. Pins the second
+    /// documented exit path.
+    #[tokio::test]
+    async fn audio_channel_close_exits_cleanly() {
+        let pipeline = ScriptedPipeline::new(vec![]);
+        let (audio_tx, audio_rx) = mpsc::channel::<Vec<f32>>(8);
+        let (text_tx, _text_rx) = mpsc::channel::<TextMessage>(8);
+        let (event_tx, _event_rx) = mpsc::channel::<VadEvent>(8);
+
+        // Close the audio channel before the consumer loop starts.
+        drop(audio_tx);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            run_consumer_loop_with_config(
+                pipeline,
+                audio_rx,
+                text_tx,
+                event_tx,
+                fast_test_config(),
+            ),
+        )
+        .await
+        .expect("consumer loop did not exit within 200 ms of audio close");
+        assert!(
+            result.is_ok(),
+            "audio close should yield Ok(()), got {result:?}"
+        );
     }
 }

--- a/src/crates/primer-speech/src/macos26/analyzer.rs
+++ b/src/crates/primer-speech/src/macos26/analyzer.rs
@@ -414,8 +414,6 @@ mod tests {
     struct ScriptedPipeline {
         script: VecDeque<(ResultEvent, String)>,
         last_text: String,
-        feed_audio_calls: usize,
-        stop_calls: usize,
     }
 
     impl ScriptedPipeline {
@@ -423,16 +421,12 @@ mod tests {
             Self {
                 script: script.into_iter().collect(),
                 last_text: String::new(),
-                feed_audio_calls: 0,
-                stop_calls: 0,
             }
         }
     }
 
     impl PipelineSource for ScriptedPipeline {
-        fn feed_audio(&mut self, _samples: Vec<f32>) {
-            self.feed_audio_calls += 1;
-        }
+        fn feed_audio(&mut self, _samples: Vec<f32>) {}
 
         fn next_result(&mut self) -> Pin<Box<dyn Future<Output = ResultEvent> + Send + '_>> {
             Box::pin(async move {
@@ -441,7 +435,10 @@ mod tests {
                     event
                 } else {
                     // Hang so the inactivity tick arm wins the select.
-                    std::future::pending().await
+                    // Explicit type annotation guards against future
+                    // changes to `ResultEvent`'s shape producing a
+                    // confusing inference error here.
+                    std::future::pending::<ResultEvent>().await
                 }
             })
         }
@@ -451,7 +448,6 @@ mod tests {
         }
 
         fn stop(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-            self.stop_calls += 1;
             Box::pin(async {})
         }
     }
@@ -518,8 +514,10 @@ mod tests {
         // Wait long enough for: (1) the volatile partial to be sent →
         // text_rx fills its single slot, (2) the inactivity timeout
         // (30 ms) + a tick (5 ms) to elapse so the SpeechEnd branch
-        // attempts to send the synthetic-final.
-        tokio::time::sleep(Duration::from_millis(80)).await;
+        // attempts to send the synthetic-final. 150 ms gives ~115 ms of
+        // slack on the ~35 ms minimum so a loaded CI runner doesn't
+        // race the tick firing.
+        tokio::time::sleep(Duration::from_millis(150)).await;
 
         // Drain the volatile partial. This MUST succeed — if it
         // doesn't, the loop never sent it and the rest of the test is
@@ -575,6 +573,93 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_millis(200), handle).await;
     }
 
+    /// **Result-branch end-to-end coverage for #140.**
+    ///
+    /// Locks in the result-branch behavioural envelope across an
+    /// utterance pair: volatile partial → real-final → new volatile +
+    /// tick-derived synthetic. Concrete invariants pinned:
+    ///
+    /// 1. **Volatile partials and real-finals both reach `text_tx`**
+    ///    with the correct `is_final` flag — the result branch's
+    ///    TextMessage construction + send path is exercised.
+    /// 2. **`buf.record(&msg)` runs on every result.** Removing the
+    ///    line (or moving it after a path that exits the loop early)
+    ///    would mean no synthetic-final ever arrives after the third
+    ///    volatile — the trailing `(true, "next")` row drops out.
+    /// 3. **The state machine cleanly re-enters `Speaking` after a
+    ///    real-final**, so a subsequent volatile + tick still produces
+    ///    SpeechStart + SpeechEnd via the inactivity path. The event
+    ///    sequence assertion locks in the alternation.
+    ///
+    /// `PartialBuffer`'s narrow `is_final`-clears-buffer behaviour is
+    /// pinned at the unit-test layer by
+    /// `real_final_clears_buffer_to_prevent_duplicate_synthesis` (a
+    /// few lines above); this orchestration test sits one layer up.
+    #[tokio::test]
+    async fn real_final_clears_buffer_so_next_synthetic_uses_fresh_partial() {
+        let pipeline = ScriptedPipeline::new(vec![
+            (result_event(false, false), "hi".to_string()),
+            (result_event(true, false), "hi world".to_string()),
+            (result_event(false, false), "next".to_string()),
+        ]);
+        let (audio_tx, audio_rx) = mpsc::channel::<Vec<f32>>(8);
+        let (text_tx, mut text_rx) = mpsc::channel::<TextMessage>(16);
+        let (event_tx, mut event_rx) = mpsc::channel::<VadEvent>(16);
+
+        let handle = tokio::spawn(run_consumer_loop_with_config(
+            pipeline,
+            audio_rx,
+            text_tx,
+            event_tx,
+            fast_test_config(),
+        ));
+
+        // Wait for the three scripted results to flow AND the inactivity
+        // timer (30 ms past the "next" partial) to fire its synthetic.
+        // 150 ms covers ~3 result-branch iterations (<5 ms each) + the
+        // 30 ms inactivity window + ~115 ms slack for loaded CI.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Drain text_rx. Expected (in order):
+        //   volatile "hi", real-final "hi world", volatile "next",
+        //   synthetic-final "next" (NOT "hi" — the load-bearing check).
+        let mut texts = Vec::new();
+        while let Ok(msg) = text_rx.try_recv() {
+            texts.push((msg.is_final, msg.segment.text));
+        }
+        assert_eq!(
+            texts,
+            vec![
+                (false, "hi".to_string()),
+                (true, "hi world".to_string()),
+                (false, "next".to_string()),
+                (true, "next".to_string()),
+            ],
+            "#140: buf.record must clear on is_final so the next tick-derived synthetic uses the fresh partial, NOT the stale one"
+        );
+
+        // Drain event_rx. Expected: SpeechStart (from "hi"),
+        // SpeechEnd (from real "hi world"), SpeechStart (from "next"),
+        // SpeechEnd (from inactivity tick after "next").
+        let mut events = Vec::new();
+        while let Ok(ev) = event_rx.try_recv() {
+            events.push(ev);
+        }
+        assert_eq!(
+            events,
+            vec![
+                VadEvent::SpeechStart,
+                VadEvent::SpeechEnd,
+                VadEvent::SpeechStart,
+                VadEvent::SpeechEnd,
+            ],
+            "VadEvent sequence must alternate cleanly across the real-final + restart"
+        );
+
+        drop(audio_tx);
+        let _ = tokio::time::timeout(Duration::from_millis(200), handle).await;
+    }
+
     /// Sanity test: a `stream_done=true` sentinel from the pipeline
     /// terminates the consumer loop cleanly with `Ok(())`. Pins the
     /// other documented exit path (besides `audio_rx` closing).
@@ -604,9 +689,8 @@ mod tests {
     }
 
     /// Sanity test: closing the audio mpsc terminates the consumer
-    /// loop cleanly via the `audio_rx.recv() = None` branch, and the
-    /// pipeline's `stop()` is invoked exactly once. Pins the second
-    /// documented exit path.
+    /// loop cleanly via the `audio_rx.recv() = None` branch. Pins the
+    /// second documented exit path.
     #[tokio::test]
     async fn audio_channel_close_exits_cleanly() {
         let pipeline = ScriptedPipeline::new(vec![]);

--- a/src/crates/primer-speech/src/macos26/vad.rs
+++ b/src/crates/primer-speech/src/macos26/vad.rs
@@ -4,7 +4,7 @@
 
 #![cfg(all(target_vendor = "apple", feature = "macos-native-26"))]
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use primer_core::consts::speech::macos26::{SPEECH_END_TIMEOUT, SPEECH_START_MIN_TEXT_CHARS};
 use primer_core::speech::VadEvent;
@@ -22,13 +22,23 @@ enum State {
 pub struct DerivedVadStateMachine {
     state: State,
     last_partial_at: Option<Instant>,
+    inactivity_timeout: Duration,
 }
 
 impl DerivedVadStateMachine {
     pub fn new() -> Self {
+        Self::with_inactivity_timeout(SPEECH_END_TIMEOUT)
+    }
+
+    /// Build a state machine with a custom inactivity timeout. Useful for
+    /// fast unit tests of orchestration code that drive `tick` end-to-end
+    /// without waiting the full production [`SPEECH_END_TIMEOUT`]
+    /// wallclock window.
+    pub fn with_inactivity_timeout(inactivity_timeout: Duration) -> Self {
         Self {
             state: State::Idle,
             last_partial_at: None,
+            inactivity_timeout,
         }
     }
 
@@ -74,7 +84,7 @@ impl DerivedVadStateMachine {
             return None;
         }
         let last = self.last_partial_at?;
-        if now.duration_since(last) > SPEECH_END_TIMEOUT {
+        if now.duration_since(last) > self.inactivity_timeout {
             self.state = State::Idle;
             self.last_partial_at = None;
             Some(VadEvent::SpeechEnd)
@@ -190,5 +200,23 @@ mod tests {
         assert_eq!(SPEECH_START_MIN_TEXT_CHARS, 1);
         // Sanity: POLL interval is under timeout.
         assert!(EVENT_POLL_INTERVAL < SPEECH_END_TIMEOUT);
+    }
+
+    #[test]
+    fn with_inactivity_timeout_overrides_const_used_by_default_ctor() {
+        // The custom ctor must let callers (mainly fast-running unit tests
+        // of the consumer loop) shrink the inactivity window below
+        // SPEECH_END_TIMEOUT without monkeypatching the global const.
+        let short = Duration::from_millis(50);
+        let mut sm = DerivedVadStateMachine::with_inactivity_timeout(short);
+        assert_eq!(
+            sm.on_result("hi", false, at(0)),
+            Some(VadEvent::SpeechStart)
+        );
+        // Inside the short window: no inactivity event.
+        assert_eq!(sm.tick(at(20)), None);
+        // Past the short window: SpeechEnd. The default-ctor variant
+        // would NOT have fired here (its window is 1000 ms).
+        assert_eq!(sm.tick(at(80)), Some(VadEvent::SpeechEnd));
     }
 }


### PR DESCRIPTION
## Summary

Closes #140. Adds mock-based unit-test coverage for the
`run_consumer_loop` orchestration in `primer-speech/src/macos26/analyzer.rs`
— specifically the synthetic-final-precedes-SpeechEnd invariant
called out in the PR #134 review, plus the result-branch behavioural
envelope across an utterance pair.

- New `PipelineSource` trait abstracts over the Swift `Macos26Pipeline`
  so a scripted mock can drive the consumer loop without a macOS 26 mic
- New `ConsumerConfig { tick_interval, inactivity_timeout }` and
  `DerivedVadStateMachine::with_inactivity_timeout(Duration)` ctor let
  tests shrink the production ~1 s window to tens of milliseconds
- Four new orchestration tests (load-bearing ordering + result-branch
  end-to-end + two exit-path sanity tests) ship at
  `src/crates/primer-speech/src/macos26/analyzer.rs` under
  `#[cfg(test)] mod tests`, alongside the existing `PartialBuffer` tests
- Production wrapper `run_consumer_loop` is unchanged at the call site
  in `backends_macos.rs`; it now delegates to `run_consumer_loop_with_config`

## The load-bearing tests

`synthetic_final_text_arrives_before_speech_end_vad` pins the tick-branch
contract: when `SpeechEnd` is derived from the inactivity tick, the
buffered synthetic-final `TextMessage` must reach `text_tx` BEFORE the
`SpeechEnd` `VadEvent` reaches `event_tx`. A future refactor that swaps
those two sends inside the tick branch will trip the explicit `#140`
assertion immediately.

The test catches the swap deterministically because the text channel is
sized to capacity 1: the synthetic-final `send().await` blocks the
consumer loop until the test drains the volatile partial, so any
`SpeechEnd` that the test sees on `event_rx` *before* it drains
`text_rx` is the reorder bug.

`real_final_clears_buffer_so_next_synthetic_uses_fresh_partial` covers
the result branch: scripts `volatile → real-final → volatile` and then
waits past the inactivity timeout to assert the trailing synthetic uses
the fresh partial (not the stale one) AND the SpeechStart/SpeechEnd
alternation is clean across the real-final boundary. Catches concrete
regressions like `buf.record(&msg)` being removed or skipped — verified
red→green by temporarily deleting the line and watching the assertion
fire.

## TDD red→green verification

For both load-bearing tests, the red step was performed as an in-place
edit of the working tree (no commit). Inverted the two sends in the
tick branch → `synthetic_final_text_arrives_before_speech_end_vad`
fired at the explicit `#140` assertion. Deleted `buf.record(&msg)` in
the result branch → `real_final_clears_buffer_so_next_synthetic_uses_fresh_partial`
fired at its `#140` assertion. Restored both → 22/0/0 green on macos26
module tests.

## What this doesn't cover

The same caveat as PR #152 (issue #139): structural unit-test coverage
locks in the in-Rust state-transition invariant. The full issue #140
acceptance criterion — that a manual mic test on macOS 26 hardware
would never observe a phantom-SpeechEnd-before-transcript regression —
needs a person with a mic and macOS 26 to verify. The Swift-side
analyzer's internal partial state, the rubato resampler, and the cpal
mic ringbuf remain unsourced. A real-audio smoke would catch any
second-order leak.

## Test plan

- [x] `cargo test --workspace` — 858/0/3 baseline preserved
- [x] `cargo test -p primer-speech --features macos-native` — 49/0/3
- [x] `cargo test -p primer-speech --features macos-native-26` — 57/0/3 (was 52; +5 = 4 new orchestration + 1 new vad ctor test)
- [x] `cargo test -p primer-speech --features voice-loop,macos-native-26 --lib -- macos26_audio_buffer` — 8/0/0 (issue #139 regression preserved)
- [x] `cargo test -p primer-cli --features speech` — 12/0/0
- [x] `cargo test -p primer-cli --features speech,macos-native` — 12/0/0
- [x] `cargo test -p primer-cli --features speech,macos-native-26` — 12/0/0
- [x] `cargo build -p primer-gui --features speech` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p primer-speech --features macos-native --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p primer-speech --features macos-native-26 --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p primer-cli --features speech,macos-native --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p primer-cli --features speech,macos-native-26 --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)