### PR TITLE
speech(macos26): cache yielded ResultEvent to close nextResult race (#143)

### DIFF
--- a/src/crates/primer-speech/swift-sources/Macos26PipelineImpl.swift
+++ b/src/crates/primer-speech/swift-sources/Macos26PipelineImpl.swift
@@ -53,6 +53,25 @@ public final class Macos26Pipeline {
     // cleanup against the still-running iterator advance.
     private var nextResultTask: Task<ResultEvent?, Error>?
 
+    // Holds the most recent iterator-advance result so it survives the
+    // narrow race tracked as issue #143: the inner Task can complete
+    // (writing pendingResult and clearing nextResultTask via its defer)
+    // in the microsecond gap between Rust dropping the outer awaiting
+    // future and the next select! branch re-entering nextResult(). Before
+    // this cache, the value held only by the dropped Task was unreachable
+    // and the next call spawned a fresh Task that advanced the iterator
+    // past it. With the cache, the next caller drains pendingResult on
+    // entry and never observes the gap.
+    //
+    // Invariant: the inner Task writes pendingResult BEFORE its defer
+    // clears nextResultTask, so a caller arriving in any post-write state
+    // — pendingResult Some, nextResultTask either still Some or already
+    // nil — drains the cached value successfully. End-of-stream (Task
+    // returns nil) and throwing iter.next() both leave pendingResult nil;
+    // the next call spawns a fresh Task, which is the same behaviour as
+    // before this cache was added.
+    private var pendingResult: ResultEvent?
+
     // Diagnostic counter — only used by swiftLog gating in feedAudio.
     private var feedAudioCount: Int = 0
 
@@ -228,38 +247,58 @@ public final class Macos26Pipeline {
     /// Pull the next transcriber result, awaiting if necessary. Returns
     /// nil once the underlying stream completes (analyzer stopped).
     ///
-    /// **Single-flight, not fully cancellation-safe.** The cached Task
-    /// guarantees `iter.next()` is only ever called once at a time —
-    /// that's the property that prevents the
+    /// **Single-flight, cancellation-safe via two-layer cache.** The
+    /// cached Task guarantees `iter.next()` is only ever called once at
+    /// a time — that's the property that prevents the
     /// `AsyncStreamBuffer.swift:508: attempt to await next() on more than
     /// one task` fatal error under `tokio::select!` cancellation. While
     /// the cached Task is still running, a dropped Rust future is
     /// transparently picked up by the next iteration (both await the
     /// same `task.value`).
     ///
-    /// **Known narrow race:** if the cached Task completes during the
-    /// gap between Rust dropping the outer future and the next select!
-    /// branch re-entering this function, the defer below clears the
-    /// cache, and the value held by the completed Task is unreachable —
-    /// the next call spawns a fresh Task that advances the iterator past
-    /// it. The window is microseconds (Task body defer fires immediately
-    /// after the iterator yields); in practice `iter.next()` is much
-    /// slower than a select! ratchet so the cache is almost always still
-    /// in-flight when the next call arrives. Tracked as #143; a robust
-    /// fix would cache the value alongside the Task and drain it on the
-    /// consume path.
+    /// **Issue #143 cache:** the inner Task writes its yielded
+    /// `ResultEvent` into `pendingResult` BEFORE its defer clears
+    /// `nextResultTask`. Any caller arriving after the Task completed —
+    /// including the case where the outer Rust future was dropped in
+    /// the microsecond gap between defer firing and the next select!
+    /// branch entering this function — drains `pendingResult` on entry
+    /// and recovers the value. Before this cache, the value held only
+    /// by the completed Task was unreachable and the next call spawned
+    /// a fresh Task that advanced the iterator past it. End-of-stream
+    /// (`iter.next() == nil`) and throwing `iter.next()` both leave
+    /// `pendingResult` nil — same behaviour as before the cache, since
+    /// re-running `iter.next()` on an exhausted iterator yields nil
+    /// idempotently and re-throwing the same error is correct
+    /// propagation.
     private func nextResult() async throws -> ResultEvent? {
-        if let existing = nextResultTask {
-            return try await existing.value
+        // Layer 1: drain a value left behind by a completed Task whose
+        // outer awaiter was dropped before consuming it. Hits the #143
+        // race window where pendingResult is Some and nextResultTask
+        // has already been cleared by the inner defer.
+        if let cached = pendingResult {
+            pendingResult = nil
+            return cached
         }
+        // Layer 2: a Task is still in flight (typical select!-cancel
+        // case). Await it; the Task body writes pendingResult before
+        // clearing nextResultTask, so a successful advance lands in
+        // pendingResult before our await returns.
+        if let existing = nextResultTask {
+            _ = try await existing.value
+            let drained = pendingResult
+            pendingResult = nil
+            return drained
+        }
+        // Cold path: no cached value, no in-flight Task. Spawn one.
+        //
         // The cleanup of `nextResultTask = nil` lives INSIDE the inner
         // Task body so it runs when the iterator advance actually
         // completes — NOT when the outer wrapper is cancelled by
-        // tokio::select! dropping the future. This eliminates the race
-        // where a cancelled outer wrapper's defer cleared the cached
-        // Task while it was still running, allowing the next call to
-        // create a second concurrent iter.next() and fatal-error in
-        // AsyncStreamBuffer.swift:508.
+        // tokio::select! dropping the future. This eliminates the
+        // earlier race where a cancelled outer wrapper's defer cleared
+        // the cached Task while it was still running, allowing the
+        // next call to create a second concurrent iter.next() and
+        // fatal-error in AsyncStreamBuffer.swift:508.
         let task = Task<ResultEvent?, Error> { [weak self] in
             guard let self = self else { return nil }
             defer { self.nextResultTask = nil }
@@ -275,15 +314,28 @@ public final class Macos26Pipeline {
             self.lastText = text
             let startMs = UInt64(max(0, result.range.start.seconds * 1000))
             let endMs = UInt64(max(0, result.range.end.seconds * 1000))
-            return ResultEvent(
+            let event = ResultEvent(
                 is_final: result.isFinal,
                 range_start_ms: startMs,
                 range_end_ms: endMs,
                 stream_done: false
             )
+            // ORDER MATTERS: write pendingResult BEFORE the defer that
+            // clears nextResultTask fires (defers run on return; this
+            // assignment is part of the body and runs first). A caller
+            // arriving in the microsecond gap between defers and the
+            // outer awaiter being dropped reads Some(event) here and
+            // drains it via the Layer 1 branch. Inverting this — moving
+            // the write into a `defer` AFTER the nextResultTask clear —
+            // would reintroduce the #143 race.
+            self.pendingResult = event
+            return event
         }
         nextResultTask = task
-        return try await task.value
+        _ = try await task.value
+        let drained = pendingResult
+        pendingResult = nil
+        return drained
     }
 
     /// Non-throwing bridge wrapper around nextResult().
@@ -320,6 +372,13 @@ public final class Macos26Pipeline {
     public func stop() async {
         inputContinuation.finish()
         try? await analyzer.finalizeAndFinishThroughEndOfInput()
+        // Clear any value cached by the #143 race-fix so a stop()
+        // followed by a stray nextResult() (e.g. a tokio::select!
+        // still-pending future ratcheting after the consumer loop
+        // chose the stop branch) returns stream_done rather than a
+        // stale pre-stop event. Same intent as the lastText="" clear
+        // in nextResultBridge's end-of-stream path.
+        pendingResult = nil
     }
 }
 

--- a/src/crates/primer-speech/swift-sources/Macos26PipelineImpl.swift
+++ b/src/crates/primer-speech/swift-sources/Macos26PipelineImpl.swift
@@ -253,8 +253,16 @@ public final class Macos26Pipeline {
     /// `AsyncStreamBuffer.swift:508: attempt to await next() on more than
     /// one task` fatal error under `tokio::select!` cancellation. While
     /// the cached Task is still running, a dropped Rust future is
-    /// transparently picked up by the next iteration (both await the
-    /// same `task.value`).
+    /// transparently picked up by the next iteration: both await the
+    /// same `task.value`, the dropped caller's resumption is discarded,
+    /// and the live caller drains `pendingResult` for the yielded
+    /// event. The cache makes the drain single-winner; this is safe
+    /// only because Rust's consumer loop is itself single-flighted
+    /// (`run_consumer_loop` polls one `nextResult` future at a time via
+    /// `tokio::select!`). If a future caller pattern introduced two
+    /// concurrent Rust awaiters of `nextResult`, only one would see
+    /// the event and the other would observe `stream_done` — revisit
+    /// the cache then.
     ///
     /// **Issue #143 cache:** the inner Task writes its yielded
     /// `ResultEvent` into `pendingResult` BEFORE its defer clears
@@ -328,6 +336,20 @@ public final class Macos26Pipeline {
             // drains it via the Layer 1 branch. Inverting this — moving
             // the write into a `defer` AFTER the nextResultTask clear —
             // would reintroduce the #143 race.
+            //
+            // Defensive guard: we should be the only writer that sets
+            // pendingResult to a non-nil value (Layer 1 and Layer 2
+            // drain to nil; stop() writes nil; the cold branch is only
+            // entered when pendingResult is already nil and the task
+            // body cannot run concurrently with itself given current
+            // call paths). If a future change to call paths violates
+            // that invariant, fail fast rather than silently
+            // overwriting a still-undrained event.
+            precondition(
+                self.pendingResult == nil,
+                "Macos26Pipeline.nextResult: pendingResult invariant violated; "
+                + "a prior event would be silently dropped. See issue #143 cache notes."
+            )
             self.pendingResult = event
             return event
         }


### PR DESCRIPTION
## Summary

- Closes #143 — the narrow result-loss race in `Macos26Pipeline.nextResult` cancellation handling, surfaced by the PR #134 round-2 code review.
- Adds a `pendingResult: ResultEvent?` cache on `Macos26Pipeline`. The inner `Task` body writes its yielded event into `pendingResult` **before** the defer clears `nextResultTask`. Two-layer drain on entry to `nextResult()` recovers the value even when the outer Rust awaiter is dropped in the microsecond gap between defers and the next select! branch re-entering.
- `stop()` clears `pendingResult` so a stop-then-stray-nextResult sequence returns stream_done rather than a stale pre-stop event, mirroring the existing `lastText = ""` clear in nextResultBridge's end-of-stream path.

## Why this is cleaner than the issue body's sketch

The issue body sketches a `withCheckedContinuation` pattern. That isn't needed: the existing `await task.value` already gives us the synchronization point we need. The cache merely ensures the value survives the narrow window where the awaiter is dropped after the task completes but before the value is consumed. No new continuation, no new cancellation surface — just one stored Optional and a 3-line drain branch.

## Behaviour under all paths

| Path | pendingResult | nextResultTask | Outcome |
| --- | --- | --- | --- |
| Cold path, happy: spawn → await → drain | None → Some → None | nil → Some → nil | Event delivered ✓ |
| Two simultaneous awaiters (A dropped before Task completes) | None → Some → None | Some → Some → nil | Event delivered to B ✓ |
| #143 race: Task completes between defer + next call | None → **Some persists** → None | Some → nil → nil | Layer-1 drain delivers ✓ |
| End-of-stream | stays None | Some → nil | nil → stream_done sentinel ✓ |
| iter.next() throws | stays None | Some → nil | re-throw via try await ✓ |
| Outer awaiter dropped during throw | stays None | Some → nil | next call retries (same as before) ✓ |

End-of-stream and throwing both leave `pendingResult` nil — observable behaviour identical to before this PR (re-running `iter.next()` on an exhausted iterator yields nil idempotently; re-throwing is correct error propagation).

## Verification — 14-cell matrix (all green)

| Command | Expected | Got |
| --- | --- | --- |
| `cargo test --workspace` (default features) | 858/0/3 | **858/0/3** |
| `cargo test -p primer-speech --features macos-native` | 49/0/3 | **49/0/3** |
| `cargo test -p primer-speech --features macos-native-26` | 56/0/3 | **56/0/3** |
| `cargo test -p primer-speech --features voice-loop,macos-native-26 -- macos26_audio_buffer` | 8/0/0 | **8/0/0** |
| `cargo test -p primer-cli --features speech` | 12/0/0 | **12/0/0** |
| `cargo test -p primer-cli --features speech,macos-native` | 12/0/0 | **12/0/0** |
| `cargo test -p primer-cli --features speech,macos-native-26` | 12/0/0 | **12/0/0** |
| `cargo build -p primer-gui --features speech` | clean | **clean** |
| `cargo fmt --all -- --check` | clean | **clean** |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean | **clean** |
| `cargo clippy -p primer-speech --features macos-native --all-targets -- -D warnings` | clean | **clean** |
| `cargo clippy -p primer-speech --features macos-native-26 --all-targets -- -D warnings` | clean | **clean** |
| `cargo clippy -p primer-cli --features speech,macos-native --all-targets -- -D warnings` | clean | **clean** |
| `cargo clippy -p primer-cli --features speech,macos-native-26 --all-targets -- -D warnings` | clean | **clean** |

The Swift sidecar was force-rebuilt via `cargo clean -p primer-speech` to confirm `swiftc` accepts the new code (no stale `libMacos26Pipeline.a` reuse).

## Honest caveats

- **The fix is structural; no new test added.** The race window is microseconds wide on real macOS 26 hardware and unreachable from Rust unit tests without Swift-side fault injection — and we have no Swift XCTest harness for this sidecar. Adding one is out of scope for this PR. The 56 existing macos-native-26 tests pass, demonstrating the cache layer doesn't break any of the Rust-side invariants or happy-path flow.
- **Real-audio coverage on macOS 26 hardware remains future work** — same caveat as PR #152 (issue #139) and PR #153 (issue #140). A person with a microphone, voice mode active, repeatedly entering / leaving conversation can validate end-to-end that no transcripts are missing.
- The reordering invariant in the Task body (`self.pendingResult = event` BEFORE the return that triggers the defers) is documented inline with an explicit "ORDER MATTERS / inverting this would reintroduce the #143 race" comment. Not enforced by anything mechanical.

## Test plan

- [x] Workspace tests pass on default features
- [x] macos-native gate tests pass (49/0/3)
- [x] macos-native-26 gate tests pass (56/0/3)
- [x] voice-loop+macos-native-26 PendingMicBuffer tests pass (8/0/0)
- [x] primer-cli speech matrix (3 cells) passes
- [x] primer-gui --features speech builds
- [x] rustfmt clean
- [x] clippy `-D warnings` clean across all 5 measured feature combinations
- [x] Swift sidecar rebuilds cleanly after the change (force-rebuilt via `cargo clean -p primer-speech`)
- [ ] **Manual smoke on macOS 26 hardware with a microphone** — not done in this session; recommended before merge if reviewer has the hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)