### PR TITLE
speech(macos26): use RustVec.as_ptr() in feedAudio sample copy (#144)

### DIFF
--- a/src/crates/primer-speech/swift-sources/Macos26PipelineImpl.swift
+++ b/src/crates/primer-speech/swift-sources/Macos26PipelineImpl.swift
@@ -205,6 +205,13 @@ public final class Macos26Pipeline {
         }
         buffer.frameLength = AVAudioFrameCount(count)
 
+        // Contiguous-buffer view into the Rust Vec<f32>. Replaces a per-sample
+        // RustVec.get(index:)! that did a function call + Optional unwrap on
+        // every Float. `samples` is held by ARC for the duration of this call
+        // (it's a function parameter), so the pointer is valid throughout.
+        // Closes issue #144.
+        let srcPtr = samples.as_ptr()
+
         switch analyzerFormat.commonFormat {
         case .pcmFormatFloat32:
             guard let channelData = buffer.floatChannelData else {
@@ -213,9 +220,11 @@ public final class Macos26Pipeline {
                 }
                 return
             }
-            for i in 0..<count {
-                channelData[0][i] = samples.get(index: UInt(i))!
-            }
+            // Direct memcpy from the Rust Vec buffer to the PCM buffer's float
+            // channel. update(from:count:) is the Swift-stdlib memcpy on typed
+            // pointers; same bytes as the old per-element loop, without the
+            // per-sample Optional indirection.
+            channelData[0].update(from: srcPtr, count: count)
         case .pcmFormatInt16:
             guard let channelData = buffer.int16ChannelData else {
                 if feedAudioCount <= 3 {
@@ -226,10 +235,12 @@ public final class Macos26Pipeline {
             // Float32 sample range is [-1.0, 1.0]; clamp then scale to
             // Int16's full range. 32767 (not 32768) so a Float of +1.0
             // round-trips cleanly through the symmetric Int16 range.
+            // Tight pointer-indexed loop replaces the per-sample
+            // RustVec.get(index:)! Optional unwrap.
+            let dstPtr = channelData[0]
             for i in 0..<count {
-                let f = samples.get(index: UInt(i))!
-                let clamped = max(-1.0, min(1.0, f))
-                channelData[0][i] = Int16(clamped * 32767.0)
+                let clamped = max(-1.0, min(1.0, srcPtr[i]))
+                dstPtr[i] = Int16(clamped * 32767.0)
             }
         default:
             if feedAudioCount <= 3 {


### PR DESCRIPTION
## Summary

Closes #144. Tiny performance polish on `feedAudio` in
[`crates/primer-speech/swift-sources/Macos26PipelineImpl.swift`](src/crates/primer-speech/swift-sources/Macos26PipelineImpl.swift) —
swaps the per-sample `RustVec.get(index:)!` (function call + Optional
unwrap on every Float) for a single `samples.as_ptr()` view into the
contiguous Rust Vec buffer.

- `pcmFormatFloat32` branch → `channelData[0].update(from: srcPtr, count: count)` (Swift-stdlib typed memcpy).
- `pcmFormatInt16` branch → keeps the inline clamp+scale loop but indexes the source via raw `srcPtr[i]` instead of the Optional path.

`samples` is a function parameter (RustVec is a class), so ARC retains it for the duration of the call — the pointer is valid throughout.

No correctness change. Pure throughput / energy on the audio hot path: at 16 kHz mono mic with ~512 samples per ~30 ms chunk, this is ~17 k Optional unwraps/sec eliminated. Worth doing before any iOS port where the audio thread is more power-sensitive (the original issue body called this out).

## Verification

Forced a full Swift rebuild via `cargo clean -p primer-speech` so `swiftc` actually re-typechecked the new code, then:

| Command | Expected | Got |
| --- | --- | --- |
| `cargo test --workspace` (default features) | 858/0/3 | **858/0/3** |
| `cargo test -p primer-speech --features macos-native` | 49/0/3 | **49/0/3** |
| `cargo test -p primer-speech --features macos-native-26` | 56/0/3 | **56/0/3** |
| `cargo test -p primer-speech --features voice-loop,macos-native-26 -- macos26_audio_buffer` | 8/0/0 | **8/0/0** |
| `cargo test -p primer-cli --features speech` | 12/0/0 | **12/0/0** |
| `cargo test -p primer-cli --features speech,macos-native` | 12/0/0 | **12/0/0** |
| `cargo test -p primer-cli --features speech,macos-native-26` | 12/0/0 | **12/0/0** |
| `cargo build -p primer-gui --features speech` | clean | **clean** |
| `cargo fmt --all -- --check` | clean | **clean** |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean | **clean** |
| `cargo clippy -p primer-speech --features macos-native --all-targets -- -D warnings` | clean | **clean** |
| `cargo clippy -p primer-speech --features macos-native-26 --all-targets -- -D warnings` | clean | **clean** |
| `cargo clippy -p primer-cli --features speech,macos-native --all-targets -- -D warnings` | clean | **clean** |
| `cargo clippy -p primer-cli --features speech,macos-native-26 --all-targets -- -D warnings` | clean | **clean** |

The macos26 analyzer-orchestration tests (the closest in-tree exercise of the feedAudio path) also pass cleanly (11/0/0). No new Rust-side tests added — the change is behaviourally a pointer-arithmetic restatement of the same Float32 copy and the same Float→clamp→Int16 conversion as before, and we have no Swift-side test harness yet (separately tracked as Task E in the live NEXT_SESSION.md). Real-world A/B with `--measure-ttfa` on long utterances would close the loop on whether the win is measurable on real macOS 26 hardware; deferred.

## Test plan

- [x] Force-rebuild Swift sidecar (`cargo clean -p primer-speech` + `cargo build -p primer-speech --features macos-native-26`) — exercises swiftc on the new code rather than cargo's cached `.a`.
- [x] All 14 verification cells above (workspace, both macOS speech gates, fmt, clippy on six configurations).
- [ ] Manual real-audio smoke on macOS 26 hardware (out of scope for this PR; tracked as a carry-forward gap in the brief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)