### PR TITLE
ci: skip workflow on docs-only changes (#168)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,47 @@
 name: CI
 
+# Skip the workflow for changes that touch only documentation surfaces.
+# Rationale (closes #168):
+#   - macOS-runner minutes are ~10× the cost of Linux minutes on GitHub's
+#     billing. A docs-only push (README, ROADMAP, CLAUDE.md, NEXT_SESSION.md,
+#     anything under docs/, handoff snapshots) cannot break the build, so
+#     spinning up the macOS feature-combos drift-guard + the Android
+#     cross-compile + the Linux test/clippy jobs is pure waste.
+#   - `**/*.md` is safe today: no Rust test reads a committed `.md` file
+#     (verified via `grep -rn include_str.*\\.md src/`); the only `.md`
+#     references inside tests are tempfile fixtures (e.g.
+#     primer-kb-load/src/lib.rs:510) that synthesise their own files.
+#   - `docs/**` is somewhat redundant with `**/*.md` (most of docs/ is .md)
+#     but defends against future non-md additions there (PDFs, images).
+#   - Data surfaces are deliberately NOT in the ignore list. Anything under
+#     `data/seed/` (corpus JSONL) or `data/ingest/` (Python ingest pipeline)
+#     can change retrieval-quality test expectations and MUST run CI.
+#
+# Branch-protection caveat: if `cargo test (default features)` is wired as
+# a required status check on `main` (still overdue per CLAUDE.md), a
+# docs-only PR would be stuck waiting for a job that never runs. Two known
+# mitigations:
+#   1. "Skipped-but-required" stub job whose name matches the required-check
+#      name and always passes on docs-only paths.
+#   2. Per-job `paths:` allowlists so non-matching jobs get a `skipped`
+#      conclusion (which branch protection accepts as passing).
+# Branch protection is not yet wired, so the simpler workflow-level
+# `paths-ignore` is sufficient today. Revisit at the same time as flipping
+# the branch-protection setting.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds a workflow-level `paths-ignore` filter to the `push` and `pull_request` triggers of `.github/workflows/ci.yml` so docs-only changes don't spin up CI.
- Ignore list: `**/*.md`, `docs/**`, `.gitignore`, `LICENSE`. Data surfaces (`data/seed/`, `data/ingest/`) are deliberately NOT ignored.
- Inline rationale block explains the choice, the verification that no Rust test reads a committed `.md` file, and the branch-protection caveat to revisit if/when branch protection on `main` lands.

## Why

Surfaced during review of #167 (the macOS feature-combos drift-guard). A NEXT_SESSION.md edit or a handoff snapshot at `docs/handoffs/` cannot break the build, but today it spins up:

- `cargo test (default features)` on `ubuntu-latest`
- `cargo check (non-default features)` on `ubuntu-latest`
- `cargo clippy (macOS feature combos)` on `macos-latest` (added in #167)
- `cargo build (aarch64-linux-android)` on `ubuntu-latest`
- The GitHub-default CodeQL Analyze job

macOS-runner minutes are ~10× the cost of Linux minutes on GitHub's billing, so the macOS clippy job is the most expensive piece of waste.

## Verification

- `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"` — parses cleanly.
- `grep -rn 'include_str.*\\.md' src/` — empty. Confirms no Rust test reads a committed `.md` file, so `**/*.md` is safe to ignore.
- `grep -rn '\\.md\"' src/ --include='*.rs'` — only `tempfile` test fixtures (e.g. `primer-kb-load/src/lib.rs:510`) that synthesise their own files.
- This PR itself touches only `.github/workflows/ci.yml` (NOT in the ignore list), so the workflow will run normally on this PR — that's a useful first sanity check that the change doesn't break existing flow.

## Out of scope

- **CodeQL workflow** — the GitHub-default CodeQL Analyze setup is configured outside `.github/workflows/`. Not changed here.
- **Branch protection** — if `cargo test (default features)` is wired as a required status check on `main`, the workflow-level `paths-ignore` will need to be paired with either a skipped-but-required stub job or per-job `paths:` allowlists. Branch protection is still overdue per CLAUDE.md; both decisions revisit together. Documented inline in the YAML comment.
- **`primer-cli --features speech` on Linux** and **`macos-native-26` clippy** drift-guards — separate scope (still tracked under #151).

## Test plan

- [x] YAML parses (`python3 -c \"import yaml; yaml.safe_load(...)\"`).
- [x] Both `push` and `pull_request` paths-ignore lists are identical.
- [x] `branches: [main]` preserved on `push`.
- [ ] This PR's CI run completes normally (the workflow file itself is not in the ignore list).
- [ ] A follow-up docs-only commit on this branch (e.g. an inline rationale tweak to NEXT_SESSION.md) should NOT trigger CI — manual visual check on the Actions tab.

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)