### PR TITLE
refactor(speech): split backends_common into mod.rs + tests.rs (#163)

### DIFF
--- a/src/crates/primer-speech/src/voice_loop/backends_common/mod.rs
+++ b/src/crates/primer-speech/src/voice_loop/backends_common/mod.rs
@@ -17,11 +17,9 @@
 //! macOS builders don't have to inherit `whisper`/`piper`/`silero`
 //! dependencies they never touch.
 //!
-//! TODO(#163): split this file once the test module grows. Production
-//! helpers are ~400 lines and read well together today; the file pushes
-//! past 500 only because of `#[cfg(test)] mod tests`. Trigger to act:
-//! a second test fixture, a second test module, or any new production
-//! helper that lifts the non-test portion past ~500 lines.
+//! The production helpers read well together and stay under the 500-line
+//! guideline; the `make_on_audio` unit tests live in the sibling
+//! [`tests`] child module (closes #163).
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -434,121 +432,4 @@ pub(super) fn make_drain_hook(
 }
 
 #[cfg(test)]
-mod tests {
-    //! Pure-logic tests for [`make_on_audio`] — these don't open a real
-    //! cpal device, just a vanilla `ringbuf::HeapRb` so the closure
-    //! body's contract (no-op on flush w/o resampling, pushes everything
-    //! straight through w/o resampling, bails when `spk_errored` is set)
-    //! is pinned without an audio-device dep. The resampling branch is
-    //! exercised by the audio-quality smoke at
-    //! `examples/tts_hello.rs` since a meaningful unit test would just
-    //! re-test rubato.
-
-    use super::*;
-    use ringbuf::HeapRb;
-    use ringbuf::traits::{Consumer as _, Observer as _, Split as _};
-    use std::sync::atomic::Ordering;
-
-    /// Bench-style fixture for the [`make_on_audio`] tests. Owning the
-    /// consumer alongside the producer lets each test verify the closure's
-    /// push behaviour by inspecting the ringbuf state directly.
-    struct Fixture {
-        spk_prod: Arc<Mutex<HeapProd<f32>>>,
-        spk_cons: ringbuf::HeapCons<f32>,
-        spk_errored: Arc<AtomicBool>,
-        output_resampler: Arc<Mutex<Option<Resampler>>>,
-    }
-
-    fn setup() -> Fixture {
-        let rb = HeapRb::<f32>::new(4096);
-        let (prod, cons) = rb.split();
-        Fixture {
-            spk_prod: Arc::new(Mutex::new(prod)),
-            spk_cons: cons,
-            spk_errored: Arc::new(AtomicBool::new(false)),
-            output_resampler: Arc::new(Mutex::new(None)),
-        }
-    }
-
-    #[test]
-    fn make_on_audio_without_resampling_pushes_samples_through() {
-        let Fixture {
-            spk_prod,
-            mut spk_cons,
-            spk_errored,
-            output_resampler,
-        } = setup();
-        let mut closure = make_on_audio(
-            spk_prod,
-            spk_errored,
-            output_resampler,
-            OUTPUT_RESAMPLER_CHUNK_IN,
-            /* need_output_resample */ false,
-        );
-
-        let samples: Vec<f32> = (0..16).map(|i| i as f32 * 0.1).collect();
-        closure(samples.clone());
-
-        let mut received = vec![0.0_f32; samples.len()];
-        let n = spk_cons.pop_slice(&mut received);
-        assert_eq!(n, samples.len(), "all input samples reach the speaker");
-        assert_eq!(received, samples, "samples flow through verbatim");
-    }
-
-    #[test]
-    fn make_on_audio_empty_flush_without_resampling_is_a_noop() {
-        let Fixture {
-            spk_prod,
-            spk_cons,
-            spk_errored,
-            output_resampler,
-        } = setup();
-        let mut closure = make_on_audio(
-            spk_prod,
-            spk_errored,
-            output_resampler,
-            OUTPUT_RESAMPLER_CHUNK_IN,
-            /* need_output_resample */ false,
-        );
-
-        // End-of-turn flush sentinel: empty Vec, no resampling. With
-        // no resampler tail to drain, this must not produce any output.
-        closure(Vec::new());
-
-        assert_eq!(
-            spk_cons.occupied_len(),
-            0,
-            "flush w/o resampling must not push samples"
-        );
-    }
-
-    #[test]
-    fn make_on_audio_bails_when_speaker_errored_flag_is_set_before_call() {
-        let Fixture {
-            spk_prod,
-            spk_cons,
-            spk_errored,
-            output_resampler,
-        } = setup();
-        spk_errored.store(true, Ordering::SeqCst);
-
-        let mut closure = make_on_audio(
-            spk_prod,
-            Arc::clone(&spk_errored),
-            output_resampler,
-            OUTPUT_RESAMPLER_CHUNK_IN,
-            /* need_output_resample */ false,
-        );
-
-        let samples: Vec<f32> = (0..32).map(|i| i as f32).collect();
-        closure(samples);
-
-        // push_all_with_bail bails on the very first iteration when
-        // errored is already set — nothing reaches the ringbuf.
-        assert_eq!(
-            spk_cons.occupied_len(),
-            0,
-            "bail before pushing when errored is already set"
-        );
-    }
-}
+mod tests;

--- a/src/crates/primer-speech/src/voice_loop/backends_common/tests.rs
+++ b/src/crates/primer-speech/src/voice_loop/backends_common/tests.rs
@@ -1,0 +1,115 @@
+//! Pure-logic tests for [`super::make_on_audio`] — these don't open a real
+//! cpal device, just a vanilla `ringbuf::HeapRb` so the closure body's
+//! contract (no-op on flush w/o resampling, pushes everything straight
+//! through w/o resampling, bails when `spk_errored` is set) is pinned
+//! without an audio-device dep. The resampling branch is exercised by the
+//! audio-quality smoke at `examples/tts_hello.rs` since a meaningful unit
+//! test would just re-test rubato.
+
+use super::*;
+use ringbuf::HeapRb;
+use ringbuf::traits::{Consumer as _, Observer as _, Split as _};
+use std::sync::atomic::Ordering;
+
+/// Bench-style fixture for the [`super::make_on_audio`] tests. Owning the
+/// consumer alongside the producer lets each test verify the closure's
+/// push behaviour by inspecting the ringbuf state directly.
+struct Fixture {
+    spk_prod: Arc<Mutex<HeapProd<f32>>>,
+    spk_cons: ringbuf::HeapCons<f32>,
+    spk_errored: Arc<AtomicBool>,
+    output_resampler: Arc<Mutex<Option<Resampler>>>,
+}
+
+fn setup() -> Fixture {
+    let rb = HeapRb::<f32>::new(4096);
+    let (prod, cons) = rb.split();
+    Fixture {
+        spk_prod: Arc::new(Mutex::new(prod)),
+        spk_cons: cons,
+        spk_errored: Arc::new(AtomicBool::new(false)),
+        output_resampler: Arc::new(Mutex::new(None)),
+    }
+}
+
+#[test]
+fn make_on_audio_without_resampling_pushes_samples_through() {
+    let Fixture {
+        spk_prod,
+        mut spk_cons,
+        spk_errored,
+        output_resampler,
+    } = setup();
+    let mut closure = make_on_audio(
+        spk_prod,
+        spk_errored,
+        output_resampler,
+        OUTPUT_RESAMPLER_CHUNK_IN,
+        /* need_output_resample */ false,
+    );
+
+    let samples: Vec<f32> = (0..16).map(|i| i as f32 * 0.1).collect();
+    closure(samples.clone());
+
+    let mut received = vec![0.0_f32; samples.len()];
+    let n = spk_cons.pop_slice(&mut received);
+    assert_eq!(n, samples.len(), "all input samples reach the speaker");
+    assert_eq!(received, samples, "samples flow through verbatim");
+}
+
+#[test]
+fn make_on_audio_empty_flush_without_resampling_is_a_noop() {
+    let Fixture {
+        spk_prod,
+        spk_cons,
+        spk_errored,
+        output_resampler,
+    } = setup();
+    let mut closure = make_on_audio(
+        spk_prod,
+        spk_errored,
+        output_resampler,
+        OUTPUT_RESAMPLER_CHUNK_IN,
+        /* need_output_resample */ false,
+    );
+
+    // End-of-turn flush sentinel: empty Vec, no resampling. With
+    // no resampler tail to drain, this must not produce any output.
+    closure(Vec::new());
+
+    assert_eq!(
+        spk_cons.occupied_len(),
+        0,
+        "flush w/o resampling must not push samples"
+    );
+}
+
+#[test]
+fn make_on_audio_bails_when_speaker_errored_flag_is_set_before_call() {
+    let Fixture {
+        spk_prod,
+        spk_cons,
+        spk_errored,
+        output_resampler,
+    } = setup();
+    spk_errored.store(true, Ordering::SeqCst);
+
+    let mut closure = make_on_audio(
+        spk_prod,
+        Arc::clone(&spk_errored),
+        output_resampler,
+        OUTPUT_RESAMPLER_CHUNK_IN,
+        /* need_output_resample */ false,
+    );
+
+    let samples: Vec<f32> = (0..32).map(|i| i as f32).collect();
+    closure(samples);
+
+    // push_all_with_bail bails on the very first iteration when
+    // errored is already set — nothing reaches the ringbuf.
+    assert_eq!(
+        spk_cons.occupied_len(),
+        0,
+        "bail before pushing when errored is already set"
+    );
+}


### PR DESCRIPTION
## What

Splits `crates/primer-speech/src/voice_loop/backends_common.rs` (554 lines, over the 500-line guideline) into a directory module:

- `backends_common/mod.rs` — 435 lines (all production helpers, unchanged)
- `backends_common/tests.rs` — 115 lines (the `make_on_audio` unit tests)

## Why

The file crossed 500 lines **solely because of its `#[cfg(test)] mod tests` block** — exactly what the file's own `TODO(#163)` note flagged ("Production helpers are ~400 lines and read well together today; the file pushes past 500 only because of `#[cfg(test)] mod tests`"). The fix the note signposted is to move the tests out, not to fragment the production helpers. This follows the `foo/{mod,tests}.rs` pattern established last session for `router.rs`.

## Mechanics

- `git mv` preserves history (rename detected at 81% similarity).
- Test paths are **unchanged** (`voice_loop::backends_common::tests::make_on_audio_*`).
- `pub(super)` production items keep the same visibility to the sibling builder modules (`backends`, `backends_macos_native`, `backends_macos_native_26`); only the tests moved to a descendant module, which can always see parent items.
- No production code changed; the only edits beyond the move are the module doc note and correcting the tests' intra-doc links to `super::make_on_audio`.

## Verification

From `src/` with `+1.88`:
- `fmt --all -- --check` — clean
- `clippy -p primer-speech --features voice-loop --all-targets -D warnings` — clean
- `clippy -p primer-speech --features voice-loop,macos-native --all-targets -D warnings` — clean (the macOS consumer)
- The 3 `make_on_audio` tests pass identically to the pre-refactor baseline.

Closes #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)