### PR TITLE
fix(qnn): correct Genie FFI to the QAIRT 2.45 API (device-validated)

### DIFF
--- a/src/crates/primer-inference/src/qnn/backend/mod.rs
+++ b/src/crates/primer-inference/src/qnn/backend/mod.rs
@@ -223,8 +223,10 @@ fn fire_smoke_check_query(dialog: &dyn GenieDialog) -> mpsc::UnboundedReceiver<R
 /// Pure inputs/outputs from the caller's perspective: feed in a
 /// receiver, get back `Ok(())` on success or the first `Err` chunk.
 /// Step 1.2.3: a successful smoke check exercises exactly the FFI
-/// sequence (`dialog_set_token_callback` → `dialog_query` →
-/// callback fires → final done chunk) the real conversation will hit.
+/// sequence (`dialog_query` with the token callback → callback fires →
+/// final done chunk) the real conversation will hit. (QAIRT 2.45 folds
+/// callback registration into `dialog_query`; there is no separate
+/// `setTokenCallback` step.)
 async fn drain_smoke_check_receiver(
     mut rx: mpsc::UnboundedReceiver<Result<TokenChunk>>,
 ) -> Result<()> {

--- a/src/crates/primer-inference/src/qnn/genie/mock.rs
+++ b/src/crates/primer-inference/src/qnn/genie/mock.rs
@@ -241,9 +241,8 @@ impl GenieDialog for MockGenieDialog {
 
         // One-shot "smoke-check fails" path: emit one Err and close
         // (no body chunks, no done). Mirrors the real impl's behaviour
-        // when `dialog_set_token_callback` or the smoke-check query
-        // itself surfaces a non-success status before any tokens
-        // arrive.
+        // when the smoke-check `dialog_query` surfaces a non-success
+        // status before any tokens arrive.
         if let Some(err) = self
             .inner
             .query_error

--- a/src/crates/primer-inference/src/qnn/genie/real.rs
+++ b/src/crates/primer-inference/src/qnn/genie/real.rs
@@ -16,7 +16,7 @@ use primer_core::error::Result as PrimerResult;
 use primer_core::inference::TokenChunk;
 use primer_qnn_sys::{
     GENIE_DIALOG_SENTENCE_COMPLETE, GENIE_STATUS_SUCCESS, Genie_Dialog_SentenceCode_t,
-    GenieDialog_Handle_t, GenieDialog_TokenCallback_t, GenieDialogConfig_Handle_t,
+    GenieDialog_Handle_t, GenieDialog_QueryCallback_t, GenieDialogConfig_Handle_t,
     GenieLibrary as RawGenieLibrary, GenieLibraryError,
 };
 
@@ -61,33 +61,41 @@ fn map_library_error(err: GenieLibraryError) -> GenieCallError {
 
 impl GenieLibrary for RealGenieLibrary {
     fn open_dialog(&self, config_path: &Path) -> Result<Box<dyn GenieDialog>, GenieCallError> {
-        // Genie consumes a NUL-terminated C string for the path. We
-        // do not validate file existence here — Genie will surface a
-        // non-success status if the file is missing — but a path
-        // carrying an embedded NUL is caught at this layer because
-        // `CString::new` would refuse it.
-        let path_bytes = config_path
-            .to_str()
-            .ok_or_else(|| GenieCallError::BadConfigPath {
-                detail: format!("{} is not valid UTF-8", config_path.display()),
+        // QAIRT 2.45: `GenieDialogConfig_createFromJson` consumes the JSON
+        // *content* string, NOT a path (confirmed against the 2.45 header
+        // and chatapp_android's `LoadModelConfig`). Read the bundle's
+        // `genie_config.json` and rewrite its relative ctx-bins /
+        // tokenizer / htp-extensions paths to absolute (resolved against
+        // the bundle directory) so Genie locates them regardless of the
+        // process working directory. Passing the bare path here — as the
+        // pre-2.45 scaffold did — makes Genie try to parse the *path
+        // string* as JSON and fail with INVALID_CONFIG.
+        let bundle_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
+        let raw_json =
+            std::fs::read_to_string(config_path).map_err(|e| GenieCallError::BadConfigPath {
+                detail: format!("failed to read {}: {e}", config_path.display()),
             })?;
-        let c_path = CString::new(path_bytes).map_err(|e| GenieCallError::BadConfigPath {
-            detail: format!("embedded NUL byte at position {}", e.nul_position()),
+        let config_json = absolutize_genie_config(&raw_json, bundle_dir)
+            .map_err(|detail| GenieCallError::BadConfigPath { detail })?;
+        let c_config = CString::new(config_json).map_err(|e| GenieCallError::BadConfigPath {
+            detail: format!(
+                "embedded NUL byte in genie config at position {}",
+                e.nul_position()
+            ),
         })?;
 
-        // SAFETY: We pass a valid C-string pointer and an out-pointer
-        // to a stack local. The Genie API contract is that on
-        // `GENIE_STATUS_SUCCESS`, `out_handle` is written with a
-        // non-null `GenieDialogConfig` pointer; on failure, it is
-        // left untouched (we initialise to `null_mut()` so a buggy
-        // backend that ignores the status code still produces a
-        // benign null we can detect). The `*c_path.as_ptr()`
-        // lifetime is bounded by `c_path` which lives until the end
-        // of this block — well after `config_create_from_json`
-        // returns.
+        // SAFETY: We pass a valid C-string pointer (the rewritten JSON
+        // content) and an out-pointer to a stack local. The Genie API
+        // contract is that on `GENIE_STATUS_SUCCESS`, `out_handle` is
+        // written with a non-null `GenieDialogConfig` pointer; on
+        // failure, it is left untouched (we initialise to `null_mut()`
+        // so a buggy backend that ignores the status code still produces
+        // a benign null we can detect). The `c_config.as_ptr()` lifetime
+        // is bounded by `c_config`, which lives until the end of this
+        // block — well after `config_create_from_json` returns.
         let mut cfg_handle: GenieDialogConfig_Handle_t = ptr::null_mut();
         let status =
-            unsafe { (self.raw.config_create_from_json)(c_path.as_ptr(), &mut cfg_handle) };
+            unsafe { (self.raw.config_create_from_json)(c_config.as_ptr(), &mut cfg_handle) };
         if status != GENIE_STATUS_SUCCESS || cfg_handle.is_null() {
             return Err(GenieCallError::NonSuccess {
                 operation: "GenieDialogConfig_createFromJson",
@@ -179,50 +187,32 @@ impl GenieDialog for RealGenieDialog {
         let raw_sender_ptr = Box::into_raw(boxed_sender);
         let user_data = raw_sender_ptr as *mut c_void;
 
-        // SAFETY: `streaming_token_callback` is `unsafe extern "C"`
-        // and we register it on every query, so the most recently
-        // installed `user_data` is always the live
-        // `Box<UnboundedSender<...>>` for the in-flight query. The C
-        // ABI signature matches `GenieDialog_TokenCallback_t`. The
-        // box address is stable across the call because we hold the
-        // raw pointer and don't touch the box until after
-        // `dialog_query` returns.
-        let callback: GenieDialog_TokenCallback_t = streaming_token_callback;
-        let set_status =
-            unsafe { (self.lib.dialog_set_token_callback)(self.dialog, callback, user_data) };
-        if set_status != GENIE_STATUS_SUCCESS {
-            // No callback ever fires — reclaim the box, send a single
-            // error chunk through the now-reclaimed sender, drop.
-            // SAFETY: `raw_sender_ptr` came from `Box::into_raw` above
-            // and no callback has fired, so nothing else holds the
-            // pointer.
-            let sender = unsafe { reclaim_sender_box(raw_sender_ptr) };
-            let err = GenieCallError::NonSuccess {
-                operation: "GenieDialog_setTokenCallback",
-                status: set_status,
-            };
-            let _ = sender.unbounded_send(Err(err.to_primer_error()));
-            return;
-        }
-
-        // Run the (blocking) query. The C-ABI callback fires N times
-        // during this call, each time forwarding a body chunk into
-        // the sender. Genie's documented contract is that callbacks
-        // are dispatched synchronously inside `dialog_query` and not
-        // retained past its return — that's the load-bearing
-        // assumption that lets us reclaim the box below.
+        // 2.45 API: the streaming token callback + its `user_data` are
+        // passed *directly* to `GenieDialog_query` (there is no separate
+        // `setTokenCallback` step — that symbol does not exist in QAIRT
+        // 2.45's `libGenie.so`; this was confirmed by on-device symbol
+        // resolution).
         //
-        // SAFETY: `self.dialog` is a non-null pointer produced by a
-        // successful `GenieDialog_create` and not yet freed. The
-        // prompt pointer is bounded by `c_prompt`. We pass
-        // `null_mut()` for `response_out` because all output flows
-        // through the callback.
+        // SAFETY: `streaming_token_callback` is `unsafe extern "C"` and
+        // its C ABI signature matches `GenieDialog_QueryCallback_t`. The
+        // `user_data` we hand in is the live `Box<UnboundedSender<...>>`
+        // for the in-flight query; its address is stable across the call
+        // because we hold the raw pointer and don't touch the box until
+        // after `dialog_query` returns. Genie's documented contract is
+        // that callbacks are dispatched synchronously inside
+        // `dialog_query` and not retained past its return — that's the
+        // load-bearing assumption that lets us reclaim the box below.
+        // `self.dialog` is a non-null pointer produced by a successful
+        // `GenieDialog_create` and not yet freed; the prompt pointer is
+        // bounded by `c_prompt`.
+        let callback: GenieDialog_QueryCallback_t = streaming_token_callback;
         let query_status = unsafe {
             (self.lib.dialog_query)(
                 self.dialog,
                 c_prompt.as_ptr(),
                 GENIE_DIALOG_SENTENCE_COMPLETE,
-                ptr::null_mut(),
+                callback,
+                user_data,
             )
         };
 
@@ -382,4 +372,240 @@ unsafe extern "C" fn streaming_token_callback(
         text: token.into_owned(),
         done: false,
     }));
+}
+
+/// Rewrite the relative file paths inside a Genie dialog-config JSON to
+/// absolute paths resolved against `bundle_dir`, returning the rewritten
+/// JSON as a string.
+///
+/// QAIRT 2.45's `GenieDialogConfig_createFromJson` consumes the JSON
+/// *content* (see [`RealGenieLibrary::open_dialog`]), and the
+/// AI-Hub-published `genie_config.json` names its per-shard context
+/// binaries, tokenizer, and HTP-extensions file *relative* to the bundle
+/// directory. Handed to Genie as-is, those relative paths would resolve
+/// against the process working directory and fail to load. This mirrors
+/// chatapp_android's `LoadModelConfig`, which rewrites exactly these three
+/// fields:
+///
+/// - `dialog.tokenizer.path` (string)
+/// - `dialog.engine.backend.extensions` (string)
+/// - `dialog.engine.model.binary.ctx-bins[]` (array of strings)
+///
+/// A path that is already absolute is left untouched (so a pre-absolutised
+/// config round-trips unchanged). `ctx-bins` is required — a config missing
+/// it is a broken bundle and yields an `Err`. The optional `tokenizer.path`
+/// and `extensions` fields are rewritten only when present, so a config
+/// that inlines them (or omits them) is tolerated.
+///
+/// Pure function: no FFI, no I/O. Errors are returned as human-readable
+/// strings for the caller to wrap in [`GenieCallError::BadConfigPath`].
+fn absolutize_genie_config(raw_json: &str, bundle_dir: &Path) -> Result<String, String> {
+    use serde_json::Value;
+
+    let mut config: Value = serde_json::from_str(raw_json)
+        .map_err(|e| format!("genie config is not valid JSON: {e}"))?;
+
+    let dialog = config
+        .get_mut("dialog")
+        .ok_or_else(|| "genie config has no `dialog` object".to_string())?;
+
+    // tokenizer.path — optional, rewrite if present.
+    if let Some(path) = dialog
+        .get_mut("tokenizer")
+        .and_then(|t| t.get_mut("path"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_owned())
+    {
+        let abs = absolutize_one(&path, bundle_dir);
+        dialog["tokenizer"]["path"] = Value::String(abs);
+    }
+
+    // engine.backend.extensions — optional, rewrite if present.
+    if let Some(ext) = dialog
+        .get_mut("engine")
+        .and_then(|e| e.get_mut("backend"))
+        .and_then(|b| b.get_mut("extensions"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_owned())
+    {
+        let abs = absolutize_one(&ext, bundle_dir);
+        dialog["engine"]["backend"]["extensions"] = Value::String(abs);
+    }
+
+    // engine.model.binary.ctx-bins[] — REQUIRED; the model can't load
+    // without its context binaries.
+    let ctx_bins = dialog
+        .get_mut("engine")
+        .and_then(|e| e.get_mut("model"))
+        .and_then(|m| m.get_mut("binary"))
+        .and_then(|b| b.get_mut("ctx-bins"))
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| {
+            "genie config has no `dialog.engine.model.binary.ctx-bins` array".to_string()
+        })?;
+    if ctx_bins.is_empty() {
+        return Err("genie config `ctx-bins` array is empty".to_string());
+    }
+    for bin in ctx_bins.iter_mut() {
+        let rel = bin
+            .as_str()
+            .ok_or_else(|| "a `ctx-bins` entry is not a string".to_string())?;
+        *bin = Value::String(absolutize_one(rel, bundle_dir));
+    }
+
+    Ok(config.to_string())
+}
+
+/// Resolve a single config path against `bundle_dir`: absolute paths pass
+/// through unchanged; relative paths are joined onto `bundle_dir`. The
+/// result is rendered with `Path::display`, which is lossless for the
+/// UTF-8 paths a genie config carries.
+fn absolutize_one(path: &str, bundle_dir: &Path) -> String {
+    let p = Path::new(path);
+    if p.is_absolute() {
+        path.to_owned()
+    } else {
+        bundle_dir.join(p).display().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    fn sample_config() -> String {
+        json!({
+            "dialog": {
+                "tokenizer": { "path": "tokenizer.json" },
+                "engine": {
+                    "backend": { "type": "QnnHtp", "extensions": "htp_backend_ext_config.json" },
+                    "model": {
+                        "binary": {
+                            "ctx-bins": [
+                                "model_part_1_of_2.bin",
+                                "model_part_2_of_2.bin"
+                            ]
+                        }
+                    }
+                }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn absolutizes_relative_paths_against_bundle_dir() {
+        let out =
+            absolutize_genie_config(&sample_config(), Path::new("/data/local/tmp/bundle")).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v["dialog"]["tokenizer"]["path"],
+            json!("/data/local/tmp/bundle/tokenizer.json")
+        );
+        assert_eq!(
+            v["dialog"]["engine"]["backend"]["extensions"],
+            json!("/data/local/tmp/bundle/htp_backend_ext_config.json")
+        );
+        assert_eq!(
+            v["dialog"]["engine"]["model"]["binary"]["ctx-bins"],
+            json!([
+                "/data/local/tmp/bundle/model_part_1_of_2.bin",
+                "/data/local/tmp/bundle/model_part_2_of_2.bin"
+            ])
+        );
+    }
+
+    #[test]
+    fn leaves_absolute_paths_unchanged() {
+        let cfg = json!({
+            "dialog": {
+                "tokenizer": { "path": "/abs/tokenizer.json" },
+                "engine": {
+                    "backend": { "extensions": "/abs/htp.json" },
+                    "model": { "binary": { "ctx-bins": ["/abs/part1.bin"] } }
+                }
+            }
+        })
+        .to_string();
+        let out = absolutize_genie_config(&cfg, Path::new("/data/local/tmp/bundle")).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v["dialog"]["tokenizer"]["path"],
+            json!("/abs/tokenizer.json")
+        );
+        assert_eq!(
+            v["dialog"]["engine"]["backend"]["extensions"],
+            json!("/abs/htp.json")
+        );
+        assert_eq!(
+            v["dialog"]["engine"]["model"]["binary"]["ctx-bins"],
+            json!(["/abs/part1.bin"])
+        );
+    }
+
+    #[test]
+    fn preserves_other_config_fields() {
+        // Non-path fields (context size, sampler, etc.) must survive the
+        // rewrite untouched — the rewrite only changes the three known
+        // path-bearing fields.
+        let cfg = json!({
+            "dialog": {
+                "context": { "size": 4096, "n-vocab": 151936 },
+                "tokenizer": { "path": "tokenizer.json" },
+                "engine": {
+                    "n-threads": 3,
+                    "backend": { "type": "QnnHtp", "extensions": "htp.json", "poll": true },
+                    "model": { "binary": { "ctx-bins": ["a.bin"] } }
+                }
+            }
+        })
+        .to_string();
+        let out = absolutize_genie_config(&cfg, Path::new("/b")).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["dialog"]["context"]["size"], json!(4096));
+        assert_eq!(v["dialog"]["context"]["n-vocab"], json!(151936));
+        assert_eq!(v["dialog"]["engine"]["n-threads"], json!(3));
+        assert_eq!(v["dialog"]["engine"]["backend"]["poll"], json!(true));
+        assert_eq!(v["dialog"]["engine"]["backend"]["type"], json!("QnnHtp"));
+    }
+
+    #[test]
+    fn tolerates_missing_optional_fields() {
+        // A config with ctx-bins but no tokenizer/extensions is still
+        // rewritten successfully (only the required ctx-bins matter).
+        let cfg = json!({
+            "dialog": {
+                "engine": { "model": { "binary": { "ctx-bins": ["a.bin"] } } }
+            }
+        })
+        .to_string();
+        let out = absolutize_genie_config(&cfg, Path::new("/b")).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v["dialog"]["engine"]["model"]["binary"]["ctx-bins"],
+            json!(["/b/a.bin"])
+        );
+    }
+
+    #[test]
+    fn errors_on_invalid_json() {
+        let err = absolutize_genie_config("{not json", Path::new("/b")).unwrap_err();
+        assert!(err.contains("not valid JSON"), "got: {err}");
+    }
+
+    #[test]
+    fn errors_on_missing_ctx_bins() {
+        let cfg = json!({ "dialog": { "tokenizer": { "path": "t.json" } } }).to_string();
+        let err = absolutize_genie_config(&cfg, Path::new("/b")).unwrap_err();
+        assert!(err.contains("ctx-bins"), "got: {err}");
+    }
+
+    #[test]
+    fn errors_on_empty_ctx_bins() {
+        let cfg = json!({ "dialog": { "engine": { "model": { "binary": { "ctx-bins": [] } } } } })
+            .to_string();
+        let err = absolutize_genie_config(&cfg, Path::new("/b")).unwrap_err();
+        assert!(err.contains("empty"), "got: {err}");
+    }
 }

--- a/src/crates/primer-qnn-sys/src/bindings.rs
+++ b/src/crates/primer-qnn-sys/src/bindings.rs
@@ -8,7 +8,7 @@
 //!    1.2.0 of the plan installs the SDK on a dev box and validates the
 //!    chatapp_android consumer; until that lands and the licence question is
 //!    resolved, vendored headers + `bindgen` are deferred.
-//! 2. The Genie surface the Primer needs is tiny — six functions, three
+//! 2. The Genie surface the Primer needs is tiny — five functions, three
 //!    opaque handle types, one status enum — small enough that hand-rolled
 //!    declarations are easier to audit than `bindgen` output. The Phase 1.2
 //!    plan's risk register explicitly approves this path:
@@ -23,13 +23,25 @@
 //! ## Reference
 //!
 //! Mirrors the Genie API surface documented in:
-//!   - QAIRT 2.29+ `include/Genie/GenieDialog.h`
-//!   - QAIRT 2.29+ `include/Genie/GenieDialogConfig.h`
-//!   - QAIRT 2.29+ `include/Genie/GenieCommon.h`
+//!   - QAIRT 2.45 `include/Genie/GenieDialog.h`
+//!   - QAIRT 2.45 `include/Genie/GenieCommon.h`
 //!
 //! All declarations match the upstream header signatures verbatim; type
 //! aliases are chosen for readability on the Rust side, and the opaque
 //! handle types follow the standard "extern type via empty enum" pattern.
+//!
+//! ## 2.45 API note (device-validated 2026-06-10)
+//!
+//! These declarations were corrected against the QAIRT **Community 2.45**
+//! headers after on-device validation of the Primer's [`crate::GenieLibrary`]
+//! against the chatapp_android v79 bundle surfaced a symbol-resolution
+//! failure: the pre-2.45 scaffold expected a separate
+//! `GenieDialog_setTokenCallback` entry point, but 2.45's `libGenie.so`
+//! does not export it. In 2.45 the streaming token callback is passed
+//! **directly to [`GenieDialog_query`]** as the `callback` + `userData`
+//! parameters (see [`GenieDialog_QueryCallback_t`] and
+//! [`GenieDialog_query_fn`]). The Primer therefore resolves **five**
+//! symbols, not six — `setTokenCallback` is gone.
 
 #![allow(non_camel_case_types)]
 
@@ -89,8 +101,18 @@ pub const GENIE_DIALOG_SENTENCE_COMPLETE: Genie_Dialog_SentenceCode_t = 0;
 // Token callback signature
 // ---------------------------------------------------------------------------
 
-/// Streaming token callback invoked by `GenieDialog_query` for each
-/// generated token (or token chunk, depending on the exporter).
+/// Streaming token callback passed **directly to [`GenieDialog_query_fn`]**
+/// (2.45 API) and invoked for each generated token (or token chunk,
+/// depending on the exporter).
+///
+/// Upstream name: `GenieDialog_QueryCallback_t`. The C ABI signature in
+/// QAIRT 2.45 `GenieDialog.h` is:
+///
+/// ```c
+/// typedef void (*GenieDialog_QueryCallback_t)(const char* response,
+///                                             const GenieDialog_SentenceCode_t sentenceCode,
+///                                             const void* userData);
+/// ```
 ///
 /// Arguments:
 /// - `response_str`: null-terminated UTF-8 token text. Lifetime is bounded
@@ -98,20 +120,23 @@ pub const GENIE_DIALOG_SENTENCE_COMPLETE: Genie_Dialog_SentenceCode_t = 0;
 ///   intends to retain the text beyond return.
 /// - `sentence_code`: matches the `Genie_Dialog_SentenceCode_t` passed to
 ///   `GenieDialog_query`. Currently informational.
-/// - `user_data`: opaque pointer the caller registered via
-///   `GenieDialog_setTokenCallback`. The Primer uses this to forward the
-///   token into a `futures::channel::mpsc::UnboundedSender` (Phase 1.2
-///   design §3 — *"`generate_stream` flow"*).
+/// - `user_data`: the opaque `userData` pointer the caller passed to
+///   `GenieDialog_query` alongside this callback. The Primer uses it to
+///   forward the token into a `futures::channel::mpsc::UnboundedSender`
+///   (Phase 1.2 design §3 — *"`generate_stream` flow"*).
 ///
-/// The C ABI signature is `void (*)(const char*, int32_t, void*)`.
+/// The header types `userData` as `const void*`; we mirror it as
+/// `*mut c_void` for symmetry with the call-site (Genie only ever hands
+/// back the exact pointer we supplied, so const-ness on the callback side
+/// is not ABI-relevant for a pointer-sized argument).
 ///
 /// We treat the callback as non-nullable (bare `unsafe extern "C" fn` rather
 /// than `Option<unsafe extern "C" fn ...>`) because the Primer always
-/// registers a real callback — there is no use case for clearing it. If a
-/// future QAIRT release documents `NULL` as a callback-clear sentinel and
-/// the safe wrapper needs that behaviour, swap this alias for the `Option`
+/// supplies a real callback — there is no use case for a null one. If a
+/// future QAIRT release documents `NULL` as a no-callback sentinel and the
+/// safe wrapper needs that behaviour, swap this alias for the `Option`
 /// form; nullability is the only ABI-relevant difference.
-pub type GenieDialog_TokenCallback_t = unsafe extern "C" fn(
+pub type GenieDialog_QueryCallback_t = unsafe extern "C" fn(
     response_str: *const c_char,
     sentence_code: Genie_Dialog_SentenceCode_t,
     user_data: *mut c_void,
@@ -138,27 +163,32 @@ pub type GenieDialog_create_fn = unsafe extern "C" fn(
     out_dialog: *mut GenieDialog_Handle_t,
 ) -> Genie_Status_t;
 
-/// `GenieDialog_setTokenCallback(dialog_handle, callback, user_data) -> status`
-pub type GenieDialog_setTokenCallback_fn = unsafe extern "C" fn(
-    dialog: GenieDialog_Handle_t,
-    callback: GenieDialog_TokenCallback_t,
-    user_data: *mut c_void,
-) -> Genie_Status_t;
-
-/// `GenieDialog_query(dialog_handle, prompt, sentence_code, response_out) -> status`
+/// `GenieDialog_query(dialog_handle, prompt, sentence_code, callback, user_data) -> status`
 ///
-/// Blocking. The token callback (registered separately via
-/// `GenieDialog_setTokenCallback`) fires once per token until generation
-/// completes; this function returns only after end-of-generation.
+/// Blocking. The `callback` fires once per token (or token chunk) until
+/// generation completes; this function returns only after
+/// end-of-generation. `user_data` is forwarded verbatim to every callback
+/// invocation.
 ///
-/// `response_out` is a Genie-internal sink the upstream API uses when no
-/// callback is registered. The Primer always registers a callback, so it
-/// passes a null pointer here.
+/// 2.45 ABI (QAIRT `GenieDialog.h`):
+///
+/// ```c
+/// Genie_Status_t GenieDialog_query(const GenieDialog_Handle_t dialogHandle,
+///                                  const char* queryStr,
+///                                  const GenieDialog_SentenceCode_t sentenceCode,
+///                                  const GenieDialog_QueryCallback_t callback,
+///                                  const void* userData);
+/// ```
+///
+/// This replaced the pre-2.45 two-call shape (`setTokenCallback` then a
+/// 4-arg `query` with a Genie-internal response sink); 2.45 folds the
+/// callback registration into the query call itself.
 pub type GenieDialog_query_fn = unsafe extern "C" fn(
     dialog: GenieDialog_Handle_t,
     prompt: *const c_char,
     sentence_code: Genie_Dialog_SentenceCode_t,
-    response_out: *mut c_void,
+    callback: GenieDialog_QueryCallback_t,
+    user_data: *mut c_void,
 ) -> Genie_Status_t;
 
 /// `GenieDialog_free(handle) -> status`
@@ -176,9 +206,6 @@ pub const SYM_GENIE_DIALOG_CONFIG_FREE: &[u8] = b"GenieDialogConfig_free\0";
 
 /// `libGenie.so` symbol for `GenieDialog_create`.
 pub const SYM_GENIE_DIALOG_CREATE: &[u8] = b"GenieDialog_create\0";
-
-/// `libGenie.so` symbol for `GenieDialog_setTokenCallback`.
-pub const SYM_GENIE_DIALOG_SET_TOKEN_CALLBACK: &[u8] = b"GenieDialog_setTokenCallback\0";
 
 /// `libGenie.so` symbol for `GenieDialog_query`.
 pub const SYM_GENIE_DIALOG_QUERY: &[u8] = b"GenieDialog_query\0";
@@ -223,7 +250,6 @@ mod tests {
             SYM_GENIE_DIALOG_CONFIG_CREATE_FROM_JSON,
             SYM_GENIE_DIALOG_CONFIG_FREE,
             SYM_GENIE_DIALOG_CREATE,
-            SYM_GENIE_DIALOG_SET_TOKEN_CALLBACK,
             SYM_GENIE_DIALOG_QUERY,
             SYM_GENIE_DIALOG_FREE,
         ] {

--- a/src/crates/primer-qnn-sys/src/lib.rs
+++ b/src/crates/primer-qnn-sys/src/lib.rs
@@ -129,17 +129,19 @@ pub struct GenieLibrary {
     pub config_free: GenieDialogConfig_free_fn,
     /// `GenieDialog_create` entry point.
     pub dialog_create: GenieDialog_create_fn,
-    /// `GenieDialog_setTokenCallback` entry point.
-    pub dialog_set_token_callback: GenieDialog_setTokenCallback_fn,
-    /// `GenieDialog_query` entry point.
+    /// `GenieDialog_query` entry point. In QAIRT 2.45 this call also
+    /// registers the streaming token callback (see [`GenieDialog_query_fn`]);
+    /// there is no separate `setTokenCallback` symbol.
     pub dialog_query: GenieDialog_query_fn,
     /// `GenieDialog_free` entry point.
     pub dialog_free: GenieDialog_free_fn,
 }
 
 impl GenieLibrary {
-    /// Open `libGenie.so` from `qairt_lib_dir` and resolve the six
-    /// entry points the Primer needs.
+    /// Open `libGenie.so` from `qairt_lib_dir` and resolve the five
+    /// entry points the Primer needs (QAIRT 2.45 — `setTokenCallback` was
+    /// removed; the token callback is now a parameter of
+    /// `GenieDialog_query`).
     ///
     /// On `target_os = "android"`:
     /// - Probes `qairt_lib_dir.join(LIBGENIE_BASENAME)`.
@@ -202,11 +204,6 @@ impl GenieLibrary {
             SYM_GENIE_DIALOG_CREATE,
             "GenieDialog_create",
         )?;
-        let dialog_set_token_callback = resolve_symbol::<GenieDialog_setTokenCallback_fn>(
-            &library,
-            SYM_GENIE_DIALOG_SET_TOKEN_CALLBACK,
-            "GenieDialog_setTokenCallback",
-        )?;
         let dialog_query = resolve_symbol::<GenieDialog_query_fn>(
             &library,
             SYM_GENIE_DIALOG_QUERY,
@@ -223,7 +220,6 @@ impl GenieLibrary {
             config_create_from_json,
             config_free,
             dialog_create,
-            dialog_set_token_callback,
             dialog_query,
             dialog_free,
         })


### PR DESCRIPTION
## Summary

On-device validation of the Primer's **own** `QnnBackend` (RedMagic 11 Pro / SM8850, against the chatapp_android v79 Qwen3‑4B bundle) surfaced **three** bugs in the real-library path that no host/mock test could catch — `primer-qnn-sys` was written against a **pre‑2.45 Genie API**. All three are fixed here, confirmed against the authoritative **QAIRT Community 2.45** headers (`GenieDialog.h` / `GenieCommon.h`) and chatapp_android's `GenieWrapper.cpp`. With the fixes the backend drives the real `libGenie.so` all the way through HTP **device creation** on hardware.

This is the Phase 1.2 step 1.2.0 follow-through: step 1.2.0 (#212) validated the Genie *pipeline* via the chatapp proxy; this PR validates the Primer's `primer-inference::qnn` code itself on the device.

## The three fixes

1. **`GenieDialog_query` callback ABI** (`primer-qnn-sys`). QAIRT 2.45 has **no `GenieDialog_setTokenCallback`** symbol — the streaming token callback + `userData` are passed **directly to `GenieDialog_query`**. Dropped the `setTokenCallback` type/field/symbol/resolution; gave `query_fn` the 5‑arg `(handle, queryStr, sentenceCode, callback, userData)` shape; renamed the callback type to `GenieDialog_QueryCallback_t` to match the header. *This was the literal symbol-missing error the device threw first.*

2. **`createFromJson` takes JSON content, not a path** (`real.rs`). The 2.45 header documents the arg as *"A configuration string"*; the chatapp passes `config.dump()`. `open_dialog` now reads the file and passes the **content**. (The old path-passing made Genie try to parse the path string as JSON → `INVALID_CONFIG`.)

3. **Relative bundle paths must be absolutized** (`real.rs`). Mirroring the chatapp's `LoadModelConfig`, the new **pure** helper `absolutize_genie_config` rewrites `dialog.tokenizer.path`, `dialog.engine.backend.extensions`, and `dialog.engine.model.binary.ctx-bins[]` to absolute paths against the bundle dir, so Genie resolves them regardless of cwd. **7 host unit tests** cover relative / absolute / missing-optional / required-missing / empty / invalid-JSON cases.

## Verification

- **Host:** `primer-qnn-sys` (4 tests) + `primer-inference --features qnn` (213 tests, incl. the 7 new `absolutize_genie_config` tests) pass; `fmt` + `clippy -D warnings` clean on both crates; default `cargo test --workspace` unaffected (0 failures — the changes are entirely behind the `qnn` feature).
- **Cross-compile:** clean for `aarch64-linux-android` with `--features qnn`.
- **On-device (RedMagic 11 Pro / SM8850):** with the fixes, a bare `adb shell` (uid 2000) binary progresses past dlopen → symbol resolution → `createFromJson` → config parse → backend-extensions load, then fails only at `GenieDialog_create` / `"Failed to create device: 14001"` because the **`shell` uid cannot open `/dev/fastrpc-cdsp`** (`system:system 0664` → shell gets read-only; the HTP backend needs more). `soc_model` 69→87 does not change this. The chatapp succeeds because it runs as an **app uid**.

## Remaining (out of scope — deployment, not code)

An actual on-device token needs an **app-uid runtime** (Termux — installed on the device — or the eventual Tauri-Android APK), because the DSP/fastrpc node is not reachable from the `shell` uid. That's a deployment boundary; the standalone-phone product ships as an app anyway. The Primer's `QnnBackend` **code** is validated correct to the DSP boundary by this PR.

Also note (deployment artifact, not code): a full QNN runtime needs `libQnnHtpNetRunExtensions.so` alongside `libGenie.so` + the V79 skel/stub — the chatapp APK omits it; it comes from the QAIRT SDK `lib/aarch64-android/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)