### PR TITLE
Android-native voice POC — Plan 1: bridge + on-device capability gate (GO)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,16 @@ jobs:
         # are inherited from the earlier "Export NDK toolchain env" step.
         run: cargo build --target aarch64-linux-android --no-default-features -p primer-gui --features qnn
 
+      - name: Cross-compile primer-gui --features android-native (Tauri mobile)
+        # Drift-guard for the Android-native voice POC (Plan 1): compiles the
+        # JNI speech bridge (`primer-speech/android-native` → jni + ndk-context)
+        # and the `speech_capabilities` diagnostic command into the GUI's
+        # android-mobile dep graph. None of the default/qnn steps above pull
+        # `primer-speech` or the `android` module, so this seam is otherwise
+        # invisible to CI. Lib/cdylib-only — no Gradle, no APK — mirroring the
+        # qnn guard. NDK env vars inherited from "Export NDK toolchain env".
+        run: cargo build --target aarch64-linux-android --no-default-features -p primer-gui --features android-native
+
       - name: Cross-compile primer-qnn-sys
         # The Phase 1.2 Genie/QNN FFI crate is `target_os = "android"`-gated
         # for its real-dlopen path; on every other target `GenieLibrary::open`

--- a/docs/handoffs/2026-06-18-android-voice-capability-gate.md
+++ b/docs/handoffs/2026-06-18-android-voice-capability-gate.md
@@ -77,6 +77,9 @@ NDK_HOME=/opt/homebrew/share/android-ndk ANDROID_HOME=~/Library/Android/sdk \
 ## Note on gate scaffolding
 
 The file-mirror diagnostic (`PrimerSpeech.kt` file write, `MainActivity` direct probe,
-`speech_diag.rs` round-trip recorder, the `app.js` probe) is **temporary `[GATE-SCAFFOLD]`
-code**, to be reverted before the branch merges — Plan 1's permanent surface is the
-`speech_capabilities` Tauri command (a real Settings→Diagnostics trigger lands in Plan 2).
+`speech_diag.rs` round-trip recorder, the `app.js` probe) was **temporary `[GATE-SCAFFOLD]`
+code** used only to capture the on-device result above. **It has been reverted — it is NOT
+in the merged branch.** Plan 1's permanent surface is the `speech_capabilities` Tauri command
+(a real Settings→Diagnostics trigger lands in Plan 2). Note that command is **registered but
+not yet functional on-device**: it panics in `JniSpeechBridge::new()` on `ndk_context`
+(see "Open item carried to Plan 2" above); the Plan 2 `nativeInit` fix makes it live.

--- a/docs/handoffs/2026-06-18-android-voice-capability-gate.md
+++ b/docs/handoffs/2026-06-18-android-voice-capability-gate.md
@@ -1,0 +1,82 @@
+# Android-Native Voice POC — Plan 1 capability gate (on-device result)
+
+**Date:** 2026-06-18
+**Device:** RedMagic 11 Pro (NX809J, NubiaOS, Android 16 / API 36), adb serial `912607710061`
+**Spec:** [docs/superpowers/specs/2026-06-18-android-native-voice-poc-design.md](../superpowers/specs/2026-06-18-android-native-voice-poc-design.md)
+**Plan:** [docs/superpowers/plans/2026-06-18-android-native-voice-bridge-diagnostic.md](../superpowers/plans/2026-06-18-android-native-voice-bridge-diagnostic.md)
+**Branch:** `android-native-voice-poc`
+
+## Verdict: GO ✅
+
+On-device offline STT + an offline en-US TTS voice both exist on the real device.
+The OS-native voice architecture (Plan 1 §1) is validated; **Plan 2 (the voice loop) is unblocked.**
+
+## Evidence
+
+Read off the device from `files/speech_caps.json` (the diagnostic writes a JSON
+mirror to app-internal storage because **logcat is dead on this ROM** — same
+finding as the QNN work; read via `run-as org.theprimer.gui cat files/...`).
+
+- **`on_device_recognition_available: true`** — `SpeechRecognizer.isOnDeviceRecognitionAvailable(ctx)`
+  returns true on the device, confirming the ASI/SODA on-device recognizer at
+  runtime (not just the circumstantial `pm`-recon from the design phase).
+- **Offline en-US TTS voices present** (`network_required:false, not_installed:false`):
+  `en-us-x-sfg-local`, `en-us-x-tpf-local`, `en-us-x-iol-local`, `en-us-x-iom-local`,
+  `en-us-x-iog-local`, `en-us-x-tpc-local`, `en-us-x-tpd-local`, `en-us-x-iob-local`,
+  `en-US-language`, plus several en-AU local voices. `select_offline_voice(voices,"en-US")`
+  returns a real installed offline voice.
+- **The `not_installed` filter is load-bearing:** the engine advertises ~370 voices,
+  the overwhelming majority `not_installed:true` (downloadable, absent). Only the
+  en-US / en-AU set is installed. Without the `not_installed` guard, selection would
+  have returned an uninstalled voice. The guard works as designed.
+
+## Open item carried to Plan 2: the Rust→JNI bridge round-trip
+
+The capability answer above came from the **direct Kotlin path** (`MainActivity` →
+`PrimerSpeech.queryCapabilities()` → file), which is pure Android APIs and needs no
+Rust/JNI. The **Rust→JNI→Kotlin round-trip** (the `speech_capabilities` Tauri command →
+`ndk_context` → `JavaVM` → `find_class` → static call) **fails at runtime** — diagnosed
+via an instrumented scaffold writing INVOKED / ERROR:<msg> / JSON to
+`files/speech_caps_via_rust.json`:
+
+- The file was written as **`INVOKED: calling query_capabilities`** and then **never
+  overwritten** — neither the `Ok(caps)` (JSON) nor the `Err(e)` (ERROR:…) arm ran.
+- So the `app.js` probe DID fire and the Tauri command WAS invoked, but
+  `primer_speech::android::query_capabilities()` **never returned** — it panicked before
+  reaching either match arm.
+- The panic is almost certainly `ndk_context::android_context()` in `JniSpeechBridge::new()`:
+  `ndk_context` **panics if the global context was never initialized**, and the
+  Tauri-mobile runtime does not populate it for our call path. (The identical Kotlin
+  `queryCapabilities` succeeds when called directly from `MainActivity`, so the failure
+  is upstream of the Kotlin call, in the Rust→JNI bootstrap.)
+
+This is exactly the plan's **documented #1 risk** (`ndk_context` population under the
+Tauri-mobile runtime). The capability gate does NOT depend on it (the OS-native APIs are
+reachable from Kotlin directly), but Plan 2's loop wiring does. **Resolution path
+(documented in the plan's Risks), now confirmed necessary — Plan 2 Task 1:** add a
+`#[no_mangle] extern "C"` `nativeInit(JNIEnv, JObject)` exported from Rust and called
+from `MainActivity.onCreate`, caching the `JavaVM` (via `env.get_java_vm()`) in a
+`OnceLock`, and have `JniSpeechBridge::new()` read that cached VM instead of
+`ndk_context`. The Kotlin `PrimerSpeech.init` already caches the Context.
+
+## Reproduce
+
+```bash
+ADB="$HOME/Library/Android/sdk/platform-tools/adb"; D=912607710061
+# build (NDK r29 @ /opt/homebrew/share/android-ndk, JDK 21):
+cd src/crates/primer-gui
+NDK_HOME=/opt/homebrew/share/android-ndk ANDROID_HOME=~/Library/Android/sdk \
+  ~/.cargo/bin/cargo-tauri android build --apk --debug --target aarch64 -- \
+  --no-default-features --features android-native
+"$ADB" -s $D install -r gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk
+"$ADB" -s $D shell am start -n org.theprimer.gui/.MainActivity
+# logcat is DEAD on this ROM — read the result file instead:
+"$ADB" -s $D shell run-as org.theprimer.gui cat files/speech_caps.json
+```
+
+## Note on gate scaffolding
+
+The file-mirror diagnostic (`PrimerSpeech.kt` file write, `MainActivity` direct probe,
+`speech_diag.rs` round-trip recorder, the `app.js` probe) is **temporary `[GATE-SCAFFOLD]`
+code**, to be reverted before the branch merges — Plan 1's permanent surface is the
+`speech_capabilities` Tauri command (a real Settings→Diagnostics trigger lands in Plan 2).

--- a/docs/superpowers/plans/2026-06-18-android-native-voice-bridge-diagnostic.md
+++ b/docs/superpowers/plans/2026-06-18-android-native-voice-bridge-diagnostic.md
@@ -1,0 +1,738 @@
+# Android-Native Voice POC — Plan 1 of 2: Bridge + Capability Diagnostic
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove a Rust↔Kotlin speech bridge inside the existing Tauri-Android APK and answer — on the real RedMagic — whether on-device offline STT (`isOnDeviceRecognitionAvailable`) and an offline en-US TTS voice (`isNetworkConnectionRequired == false`) actually exist. This is the **go/no-go gate** for the whole voice POC.
+
+**Architecture:** A trait-abstracted bridge seam (`AndroidSpeechBridge`) — exactly the pattern `primer-inference::qnn` uses for `GenieLibrary`. All decision logic (capability parsing, offline-voice selection) is pure Rust, host-tested with a mock bridge. The real bridge (`JniSpeechBridge`) is `target_os = "android"`-gated, calls a Kotlin helper (`PrimerSpeech.kt`) over `jni`, and is the only device-only code. A non-Android stub returns `PlatformUnsupported`, so the seam + pure logic compile and test on macOS/Linux CI — just like `primer-qnn-sys`.
+
+**Tech Stack:** Rust (`primer-speech`, `primer-gui`), `jni` crate, Kotlin (Android `SpeechRecognizer` + `TextToSpeech` system APIs), Tauri 2.11 mobile, `serde_json`.
+
+## Global Constraints
+
+- Workspace root is `src/`; every cargo command runs from `src/`. Invoke as `~/.cargo/bin/cargo` (rustup), never Homebrew cargo. Toolchain pin **1.88**, edition 2024.
+- Per-crate `Cargo.toml` uses `.workspace = true`; new deps are pinned in `src/Cargo.toml` `[workspace.dependencies]`.
+- No magic numbers — every numeric goes to a consts module (invariant) or settings (tunable). `[[feedback_no_magic_numbers]]`.
+- Strict offline-first: never select a TTS voice where `isNetworkConnectionRequired() == true`; never fall back to a network recognizer. `[[project_strict_offline_first]]`.
+- The `android-native` feature is **mutually exclusive** with `macos-native` / `macos-native-26` (a `compile_error!`), mirroring the existing macOS XOR in `primer-speech/src/lib.rs`.
+- The real JNI bridge is `#[cfg(target_os = "android")]`; every other target gets a stub returning `PrimerError::Speech(PlatformUnsupported)` — pure logic stays host-compilable (the `primer-qnn-sys` precedent).
+- Android APK build is BM25-only / `--no-default-features` (issue #157); the new feature must cross-compile clean for `aarch64-linux-android`.
+- Desktop `primer-gui` build/test/fmt/clippy must stay byte-identical when `android-native` is off.
+- adb for the device: `~/Library/Android/sdk/platform-tools/adb -s 912607710061`. `/tmp` is not writable under the Android app sandbox — read diagnostics via `run-as` / logcat.
+
+## File Structure
+
+**New files:**
+- `src/crates/primer-speech/src/android/mod.rs` — module root, feature XOR guard, re-exports, `query_capabilities()` entry point + non-Android stub.
+- `src/crates/primer-speech/src/android/capabilities.rs` — `SpeechCapabilities`, `TtsVoiceInfo` types + serde + `select_offline_voice`.
+- `src/crates/primer-speech/src/android/bridge.rs` — `AndroidSpeechBridge` seam trait + `MockBridge` (test-only).
+- `src/crates/primer-speech/src/android/jni_bridge.rs` — `JniSpeechBridge` (real, `#[cfg(target_os = "android")]`).
+- `src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt` — Kotlin helper (`queryCapabilities`, `nativeInit`).
+- `src/crates/primer-gui/src/commands/speech_diag.rs` — the `speech_capabilities` Tauri command.
+
+**Modified files:**
+- `src/Cargo.toml` — add `jni`, `ndk-context` to `[workspace.dependencies]`.
+- `src/crates/primer-speech/Cargo.toml` — `android-native` feature + deps.
+- `src/crates/primer-speech/src/lib.rs` — `pub mod android;` (feature-gated) + extend the XOR `compile_error!`.
+- `src/crates/primer-gui/Cargo.toml` — `android-native` feature.
+- `src/crates/primer-gui/src/commands/mod.rs` — register `speech_capabilities` when feature on.
+- `src/crates/primer-gui/gen/android/app/src/main/AndroidManifest.xml` — `RECORD_AUDIO` permission.
+- `src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/MainActivity.kt` — call `PrimerSpeech.nativeInit(this)`.
+- `.github/workflows/ci.yml` — `android-native` cross-compile drift-guard.
+
+---
+
+### Task 1: `android-native` feature scaffold + module skeleton
+
+**Files:**
+- Modify: `src/Cargo.toml` (`[workspace.dependencies]`)
+- Modify: `src/crates/primer-speech/Cargo.toml`
+- Create: `src/crates/primer-speech/src/android/mod.rs`
+- Modify: `src/crates/primer-speech/src/lib.rs`
+
+**Interfaces:**
+- Produces: cargo feature `primer-speech/android-native`; module `primer_speech::android`; the XOR guard.
+
+- [ ] **Step 1: Add workspace deps**
+
+In `src/Cargo.toml` under `[workspace.dependencies]`:
+
+```toml
+jni = "0.21"
+ndk-context = "0.1"
+```
+
+- [ ] **Step 2: Add the feature + deps to primer-speech**
+
+In `src/crates/primer-speech/Cargo.toml` `[dependencies]`:
+
+```toml
+jni = { workspace = true, optional = true }
+ndk-context = { workspace = true, optional = true }
+```
+
+(`serde_json` is already an optional dep — reuse it.) In `[features]`:
+
+```toml
+# Android-native speech (SpeechRecognizer + TextToSpeech via a Kotlin
+# helper called over JNI). Mutually exclusive with the macOS-native
+# features. The pure logic compiles on every host; only the JNI bridge is
+# target_os="android"-gated, so host CI tests the decision logic.
+android-native = ["dep:jni", "dep:ndk-context", "dep:serde_json"]
+```
+
+- [ ] **Step 3: Create the module skeleton with the platform stub**
+
+`src/crates/primer-speech/src/android/mod.rs`:
+
+```rust
+//! Android-native speech: on-device `SpeechRecognizer` STT + `TextToSpeech`
+//! TTS via a Kotlin helper called over JNI. Plan 1 ships only the capability
+//! diagnostic; the voice loop lands in Plan 2.
+
+mod capabilities;
+pub mod bridge;
+
+pub use capabilities::{select_offline_voice, SpeechCapabilities, TtsVoiceInfo};
+
+#[cfg(target_os = "android")]
+mod jni_bridge;
+
+use primer_core::error::Result;
+
+/// Query the device's speech capabilities. On Android this drives the real
+/// JNI bridge; on every other target it is a platform stub so the crate and
+/// its tests still build host-side.
+#[cfg(target_os = "android")]
+pub fn query_capabilities() -> Result<SpeechCapabilities> {
+    jni_bridge::JniSpeechBridge::new()?.query_capabilities()
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn query_capabilities() -> Result<SpeechCapabilities> {
+    Err(primer_core::error::PrimerError::Speech(
+        "android speech capabilities are only available on android targets".into(),
+    ))
+}
+```
+
+- [ ] **Step 4: Wire the module + XOR guard in lib.rs**
+
+In `src/crates/primer-speech/src/lib.rs`, add near the existing macOS `compile_error!`:
+
+```rust
+#[cfg(all(
+    feature = "android-native",
+    any(feature = "macos-native", feature = "macos-native-26")
+))]
+compile_error!(
+    "android-native is mutually exclusive with macos-native / macos-native-26; \
+     pick one via --features"
+);
+
+#[cfg(feature = "android-native")]
+pub mod android;
+```
+
+- [ ] **Step 5: Verify it builds on host and cross-compiles**
+
+Run from `src/`:
+```bash
+~/.cargo/bin/cargo build -p primer-speech --features android-native
+~/.cargo/bin/cargo build -p primer-speech --features android-native --target aarch64-linux-android
+```
+Expected: both PASS (host uses the stub; android target compiles the `jni_bridge` module which is empty so far — Task 4 fills it; until then `jni_bridge` is created as an empty file so the `mod` resolves). Create `src/crates/primer-speech/src/android/jni_bridge.rs` with just `//! placeholder, filled in Task 4` for now.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Cargo.toml src/crates/primer-speech/Cargo.toml src/crates/primer-speech/src/lib.rs src/crates/primer-speech/src/android/
+git commit -m "feat(speech): android-native feature scaffold + module skeleton"
+```
+
+---
+
+### Task 2: Capability types + serde
+
+**Files:**
+- Create: `src/crates/primer-speech/src/android/capabilities.rs`
+- Test: same file (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `SpeechCapabilities { on_device_recognition_available: bool, recognition_locales: Vec<String>, tts_voices: Vec<TtsVoiceInfo> }`; `TtsVoiceInfo { name: String, locale: String, network_required: bool, not_installed: bool }`. Both `Serialize + Deserialize`. These are the exact JSON shape the Kotlin `queryCapabilities` emits and the `jni_bridge` parses.
+
+- [ ] **Step 1: Write the failing test (serde round-trip from the Kotlin JSON shape)**
+
+In `src/crates/primer-speech/src/android/capabilities.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_kotlin_capabilities_json() {
+        // Exactly the shape PrimerSpeech.queryCapabilities() emits.
+        let json = r#"{
+            "on_device_recognition_available": true,
+            "recognition_locales": [],
+            "tts_voices": [
+                {"name":"en-us-x-sfg#female_1-local","locale":"en-US","network_required":false,"not_installed":false},
+                {"name":"en-us-x-iol-network","locale":"en-US","network_required":true,"not_installed":false}
+            ]
+        }"#;
+        let caps: SpeechCapabilities = serde_json::from_str(json).unwrap();
+        assert!(caps.on_device_recognition_available);
+        assert_eq!(caps.tts_voices.len(), 2);
+        assert!(!caps.tts_voices[0].network_required);
+        assert!(caps.tts_voices[1].network_required);
+    }
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `~/.cargo/bin/cargo test -p primer-speech --features android-native capabilities::tests::parses_kotlin -- --nocapture`
+Expected: FAIL — `SpeechCapabilities` / `TtsVoiceInfo` not defined.
+
+- [ ] **Step 3: Add the types**
+
+At the top of the same file:
+
+```rust
+//! Pure capability types + offline-voice selection. No JNI here — this is
+//! the host-testable decision layer.
+
+use serde::{Deserialize, Serialize};
+
+/// A snapshot of the device's speech capabilities, mirroring the JSON
+/// emitted by `PrimerSpeech.queryCapabilities()`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpeechCapabilities {
+    /// `SpeechRecognizer.isOnDeviceRecognitionAvailable(context)`.
+    pub on_device_recognition_available: bool,
+    /// Best-effort on-device recognition locales (BCP-47). May be empty —
+    /// Android exposes no synchronous accessor; populated only if a later
+    /// async probe lands. Empty is not a failure.
+    pub recognition_locales: Vec<String>,
+    /// Every installed `TextToSpeech` voice with its offline flags.
+    pub tts_voices: Vec<TtsVoiceInfo>,
+}
+
+/// One `android.speech.tts.Voice`, reduced to the fields the offline-first
+/// guard needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TtsVoiceInfo {
+    pub name: String,
+    /// BCP-47 from `Voice.getLocale().toLanguageTag()`, e.g. `en-US`.
+    pub locale: String,
+    /// `Voice.isNetworkConnectionRequired()`.
+    pub network_required: bool,
+    /// `Voice.getFeatures()` contains `KEY_FEATURE_NOT_INSTALLED`.
+    pub not_installed: bool,
+}
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `~/.cargo/bin/cargo test -p primer-speech --features android-native capabilities::tests::parses_kotlin`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/crates/primer-speech/src/android/capabilities.rs
+git commit -m "feat(speech): android capability types + serde"
+```
+
+---
+
+### Task 3: Offline-voice selection (the strict-offline-first guard)
+
+**Files:**
+- Modify: `src/crates/primer-speech/src/android/capabilities.rs`
+- Test: same file
+
+**Interfaces:**
+- Produces: `pub fn select_offline_voice<'a>(voices: &'a [TtsVoiceInfo], bcp47: &str) -> Option<&'a TtsVoiceInfo>` — returns the first installed, non-network voice whose locale matches `bcp47` exactly, else a language-prefix match (`en` ⊂ `en-US`), else `None`. This is the guard the TTS backend (Plan 2) calls; hard-erroring on `None` is the caller's job.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mod tests`:
+
+```rust
+fn v(name: &str, locale: &str, net: bool, missing: bool) -> TtsVoiceInfo {
+    TtsVoiceInfo { name: name.into(), locale: locale.into(), network_required: net, not_installed: missing }
+}
+
+#[test]
+fn picks_offline_exact_locale_and_rejects_network() {
+    let voices = vec![
+        v("net", "en-US", true, false),
+        v("offline", "en-US", false, false),
+    ];
+    assert_eq!(select_offline_voice(&voices, "en-US").unwrap().name, "offline");
+}
+
+#[test]
+fn rejects_not_installed_even_if_offline() {
+    let voices = vec![v("ghost", "en-US", false, true)];
+    assert!(select_offline_voice(&voices, "en-US").is_none());
+}
+
+#[test]
+fn falls_back_to_language_prefix() {
+    let voices = vec![v("gb", "en-GB", false, false)];
+    assert_eq!(select_offline_voice(&voices, "en").unwrap().name, "gb");
+}
+
+#[test]
+fn none_when_only_network_voices() {
+    let voices = vec![v("net", "en-US", true, false)];
+    assert!(select_offline_voice(&voices, "en-US").is_none());
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `~/.cargo/bin/cargo test -p primer-speech --features android-native capabilities::tests`
+Expected: FAIL — `select_offline_voice` not defined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Pick the best fully-offline, installed TTS voice for `bcp47`, or `None`.
+/// Exact-locale match wins; otherwise a language-prefix match (`en` matches
+/// `en-US`). Network-required or not-installed voices are never returned —
+/// `[[project_strict_offline_first]]`.
+pub fn select_offline_voice<'a>(
+    voices: &'a [TtsVoiceInfo],
+    bcp47: &str,
+) -> Option<&'a TtsVoiceInfo> {
+    let usable = |v: &&TtsVoiceInfo| !v.network_required && !v.not_installed;
+    voices
+        .iter()
+        .find(|v| usable(v) && v.locale.eq_ignore_ascii_case(bcp47))
+        .or_else(|| {
+            let lang = bcp47.split('-').next().unwrap_or(bcp47);
+            voices.iter().find(|v| {
+                usable(v) && v.locale.split('-').next().unwrap_or("").eq_ignore_ascii_case(lang)
+            })
+        })
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `~/.cargo/bin/cargo test -p primer-speech --features android-native capabilities::tests`
+Expected: PASS (all 4 new + the round-trip).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/crates/primer-speech/src/android/capabilities.rs
+git commit -m "feat(speech): offline TTS voice selection guard"
+```
+
+---
+
+### Task 4: Bridge seam + the real JNI bridge + Kotlin helper
+
+This is the **integration spike** the spec flags as the primary risk. The pure seam is host-testable; the JNI + Kotlin halves are device-verified. Do the seam first (host, TDD), then the device halves.
+
+**Files:**
+- Create: `src/crates/primer-speech/src/android/bridge.rs`
+- Modify: `src/crates/primer-speech/src/android/jni_bridge.rs` (was a placeholder from Task 1)
+- Create: `src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt`
+- Modify: `src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/MainActivity.kt`
+
+**Interfaces:**
+- Produces: `pub trait AndroidSpeechBridge { fn query_capabilities(&self) -> Result<SpeechCapabilities>; }`; `JniSpeechBridge` implementing it on android; a `MockBridge` for host tests.
+
+- [ ] **Step 1: Write the seam test with a mock (host)**
+
+`src/crates/primer-speech/src/android/bridge.rs`:
+
+```rust
+//! The bridge seam. `query_capabilities()` on the module routes through an
+//! `AndroidSpeechBridge`; the real impl is JNI (android-only), the mock makes
+//! the surrounding logic host-testable — the `primer-inference::qnn`
+//! `GenieLibrary`/`GenieDialog` pattern.
+
+use crate::android::SpeechCapabilities;
+use primer_core::error::Result;
+
+/// Everything Plan 1 needs from the device. Plan 2 extends this trait with
+/// `start_listening` / `speak` / `cancel` / `poll_event`.
+pub trait AndroidSpeechBridge: Send {
+    fn query_capabilities(&self) -> Result<SpeechCapabilities>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::android::TtsVoiceInfo;
+
+    struct MockBridge(SpeechCapabilities);
+    impl AndroidSpeechBridge for MockBridge {
+        fn query_capabilities(&self) -> Result<SpeechCapabilities> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn bridge_returns_capabilities() {
+        let caps = SpeechCapabilities {
+            on_device_recognition_available: true,
+            recognition_locales: vec![],
+            tts_voices: vec![TtsVoiceInfo {
+                name: "offline".into(),
+                locale: "en-US".into(),
+                network_required: false,
+                not_installed: false,
+            }],
+        };
+        let bridge = MockBridge(caps.clone());
+        assert_eq!(bridge.query_capabilities().unwrap(), caps);
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify PASS (seam compiles, mock test green)**
+
+Run: `~/.cargo/bin/cargo test -p primer-speech --features android-native bridge::tests`
+Expected: PASS.
+
+- [ ] **Step 3: Write the Kotlin helper**
+
+`.../org/theprimer/gui/PrimerSpeech.kt`:
+
+```kotlin
+package org.theprimer.gui
+
+import android.content.Context
+import android.speech.SpeechRecognizer
+import android.speech.tts.TextToSpeech
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/** Looper-bound Android speech work, called from Rust over JNI. */
+object PrimerSpeech {
+    // Cached by nativeInit so JNI calls on attached threads can resolve the
+    // app classloader + a real Context (the system classloader on an attached
+    // thread cannot see app classes — the canonical JNI-on-Android gotcha).
+    @Volatile @JvmStatic var appContext: Context? = null
+
+    @JvmStatic
+    fun init(ctx: Context) { appContext = ctx.applicationContext }
+
+    /** Returns the SpeechCapabilities JSON the Rust side parses with serde. */
+    @JvmStatic
+    fun queryCapabilities(): String {
+        val ctx = appContext ?: return """{"error":"no context"}"""
+        val obj = JSONObject()
+        obj.put("on_device_recognition_available",
+            SpeechRecognizer.isOnDeviceRecognitionAvailable(ctx))
+        obj.put("recognition_locales", JSONArray())
+
+        val voicesJson = JSONArray()
+        val latch = CountDownLatch(1)
+        var tts: TextToSpeech? = null
+        tts = TextToSpeech(ctx) { status ->
+            if (status == TextToSpeech.SUCCESS) {
+                runCatching {
+                    for (vo in tts?.voices ?: emptySet()) {
+                        voicesJson.put(JSONObject().apply {
+                            put("name", vo.name)
+                            put("locale", vo.locale.toLanguageTag())
+                            put("network_required", vo.isNetworkConnectionRequired)
+                            put("not_installed",
+                                vo.features?.contains(
+                                    TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED) == true)
+                        })
+                    }
+                }
+            }
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        tts?.shutdown()
+        obj.put("tts_voices", voicesJson)
+        return obj.toString()
+    }
+}
+```
+
+- [ ] **Step 4: Call `init` from the activity**
+
+In `MainActivity.kt`, inside `onCreate` after `super.onCreate(...)`:
+
+```kotlin
+PrimerSpeech.init(this)
+```
+
+- [ ] **Step 5: Write the real JNI bridge (android-gated)**
+
+`src/crates/primer-speech/src/android/jni_bridge.rs`:
+
+```rust
+//! Real `AndroidSpeechBridge` over `jni`. Device-only.
+
+use crate::android::bridge::AndroidSpeechBridge;
+use crate::android::SpeechCapabilities;
+use jni::objects::{JObject, JString};
+use jni::JavaVM;
+use primer_core::error::{PrimerError, Result};
+
+pub struct JniSpeechBridge {
+    vm: JavaVM,
+}
+
+fn jerr(e: impl std::fmt::Display) -> PrimerError {
+    PrimerError::Speech(format!("android speech JNI: {e}"))
+}
+
+impl JniSpeechBridge {
+    pub fn new() -> Result<Self> {
+        // ndk_context is populated by the Tauri-mobile runtime. If Task 4's
+        // on-device smoke shows it is NOT, the fallback is to cache the
+        // JavaVM in a `nativeInit` JNI export called from MainActivity —
+        // see the plan's Risks section.
+        let ctx = ndk_context::android_context();
+        let vm = unsafe { JavaVM::from_raw(ctx.vm().cast()) }.map_err(jerr)?;
+        Ok(Self { vm })
+    }
+}
+
+impl AndroidSpeechBridge for JniSpeechBridge {
+    fn query_capabilities(&self) -> Result<SpeechCapabilities> {
+        let mut env = self.vm.attach_current_thread().map_err(jerr)?;
+        // Resolve PrimerSpeech via the app context's classloader, not the
+        // system one (attached-thread gotcha).
+        let class = env
+            .find_class("org/theprimer/gui/PrimerSpeech")
+            .map_err(jerr)?;
+        let json: JString = env
+            .call_static_method(class, "queryCapabilities", "()Ljava/lang/String;", &[])
+            .and_then(|v| v.l())
+            .map_err(jerr)?
+            .into();
+        let s: String = env.get_string(&json).map_err(jerr)?.into();
+        serde_json::from_str(&s).map_err(jerr)
+    }
+}
+```
+
+- [ ] **Step 6: Cross-compile the android target**
+
+Run from `src/`:
+```bash
+~/.cargo/bin/cargo build -p primer-speech --features android-native --target aarch64-linux-android
+```
+Expected: PASS (the JNI bridge compiles for android; host build still uses the stub).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/crates/primer-speech/src/android/ \
+  src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt \
+  src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/MainActivity.kt
+git commit -m "feat(speech): android JNI speech bridge + Kotlin capability helper"
+```
+
+---
+
+### Task 5: GUI `android-native` feature + `speech_capabilities` command + manifest permission
+
+**Files:**
+- Modify: `src/crates/primer-gui/Cargo.toml`
+- Create: `src/crates/primer-gui/src/commands/speech_diag.rs`
+- Modify: `src/crates/primer-gui/src/commands/mod.rs`
+- Modify: `src/crates/primer-gui/gen/android/app/src/main/AndroidManifest.xml`
+
+**Interfaces:**
+- Consumes: `primer_speech::android::query_capabilities() -> Result<SpeechCapabilities>`.
+- Produces: Tauri command `speech_capabilities() -> Result<SpeechCapabilities, String>`, registered only under `feature = "android-native"`.
+
+- [ ] **Step 1: Add the GUI feature**
+
+In `src/crates/primer-gui/Cargo.toml` `[features]`:
+
+```toml
+# Android-native speech diagnostic + (Plan 2) voice loop. Forwards to
+# primer-speech/android-native. Independent of `speech` (no cpal/whisper/piper).
+android-native = ["dep:primer-speech", "primer-speech/android-native"]
+```
+
+- [ ] **Step 2: Write the command**
+
+`src/crates/primer-gui/src/commands/speech_diag.rs`:
+
+```rust
+//! Android speech-capability diagnostic (Plan 1 go/no-go gate). Surfaced in
+//! Settings → Diagnostics; read back over adb/logcat on the device.
+
+use primer_speech::android::SpeechCapabilities;
+
+#[tauri::command]
+pub async fn speech_capabilities() -> Result<SpeechCapabilities, String> {
+    let caps = primer_speech::android::query_capabilities().map_err(|e| e.to_string())?;
+    // Mirror to logcat so it is readable without a UI round-trip.
+    tracing::info!(target: "primer::speech::diag", ?caps, "speech capabilities");
+    Ok(caps)
+}
+```
+
+- [ ] **Step 3: Register it (feature-gated)**
+
+In `src/crates/primer-gui/src/commands/mod.rs`, add `#[cfg(feature = "android-native")] pub mod speech_diag;` and, in the `register` builder, gate the handler:
+
+```rust
+#[cfg(feature = "android-native")]
+let builder = builder.invoke_handler(/* ...existing handlers... speech_diag::speech_capabilities */);
+```
+
+Follow the existing `commands::register` pattern exactly — if it uses one `generate_handler!`, add `speech_diag::speech_capabilities` to it behind `#[cfg(feature = "android-native")]` using the codebase's established cfg-in-handler-list idiom (check how `qnn`/`speech` handlers are conditionally listed and match it).
+
+- [ ] **Step 4: Add the manifest permission**
+
+In `AndroidManifest.xml`, alongside the existing `<uses-permission android:name="android.permission.INTERNET" />`:
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+```
+
+(Not exercised by the diagnostic — `isOnDeviceRecognitionAvailable` and TTS enumeration need no mic — but staged here for Plan 2; the runtime grant request is a Plan 2 step.)
+
+- [ ] **Step 5: Verify host build (feature off) is unchanged + feature-on compiles**
+
+Run from `src/`:
+```bash
+~/.cargo/bin/cargo build -p primer-gui                         # desktop, default — unchanged
+~/.cargo/bin/cargo build -p primer-gui --features android-native --target aarch64-linux-android --no-default-features
+```
+Expected: both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/crates/primer-gui/Cargo.toml src/crates/primer-gui/src/commands/ \
+  src/crates/primer-gui/gen/android/app/src/main/AndroidManifest.xml
+git commit -m "feat(gui): speech_capabilities diagnostic command (android-native)"
+```
+
+---
+
+### Task 6: CI drift-guard
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `android-cross-compile` job)
+
+**Interfaces:**
+- Produces: a CI step that fails if `primer-gui --features android-native` stops cross-compiling for android.
+
+- [ ] **Step 1: Add the cross-compile step**
+
+In the `android-cross-compile` job, after the existing `--features qnn` GUI step, add:
+
+```yaml
+- name: Cross-compile primer-gui --features android-native (Tauri mobile)
+  run: cargo build --target aarch64-linux-android --no-default-features -p primer-gui --features android-native
+  # Drift-guard for the Android-native voice POC (Plan 1): compiles the
+  # JNI speech bridge + diagnostic command into the android-mobile dep
+  # graph. Lib-only (no Gradle, no APK), mirroring the qnn guard above.
+```
+
+- [ ] **Step 2: Validate the YAML locally**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: android-native cross-compile drift-guard"
+```
+
+---
+
+### Task 7: On-device validation — THE GATE
+
+No host test can answer this; the deliverable is observed device output. Build the APK, install on the RedMagic, invoke the diagnostic, read the result.
+
+**Files:** none (verification only).
+
+**Interfaces:**
+- Consumes: everything above. Produces: a recorded `SpeechCapabilities` from the real device and a go/no-go decision.
+
+- [ ] **Step 1: Build the debug APK with android-native**
+
+From `src/crates/primer-gui`:
+```bash
+NDK_HOME=/opt/homebrew/share/android-ndk \
+  ~/.cargo/bin/cargo-tauri android build --apk --debug --target aarch64 \
+  -- --no-default-features --features android-native
+```
+Expected: a debug APK at `gen/android/app/build/outputs/apk/.../app-*-debug.apk`. (Confirm the exact feature-passthrough syntax `cargo-tauri` 2.11 accepts; if `--` passthrough differs, set the features in the Tauri Android config per the existing qnn build — match how the qnn APK selects features.)
+
+- [ ] **Step 2: Install on the device**
+
+```bash
+ADB="$HOME/Library/Android/sdk/platform-tools/adb"
+"$ADB" -s 912607710061 install -r gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk
+```
+Expected: `Success`. (Adjust the APK path to the actual output.)
+
+- [ ] **Step 3: Launch + drive logcat**
+
+```bash
+"$ADB" -s 912607710061 logcat -c
+"$ADB" -s 912607710061 shell monkey -p org.theprimer.gui -c android.intent.category.LAUNCHER 1
+"$ADB" -s 912607710061 logcat -s primer:* | grep -i "speech capabilities"
+```
+
+- [ ] **Step 4: Invoke the diagnostic and read the result**
+
+Trigger `speech_capabilities` from Settings → Diagnostics in the app (Plan-1 minimal: a button that `invoke("speech_capabilities")` and logs; if no UI hook is wired, call it from the devtools console via `window.__TAURI__.core.invoke("speech_capabilities")`). Read the `primer::speech::diag` logcat line.
+
+Record the JSON. **The gate:**
+- `on_device_recognition_available == true` AND
+- at least one `tts_voices[]` entry with `locale` starting `en` and `network_required == false` and `not_installed == false`.
+
+- [ ] **Step 5: Decide**
+
+- **Both true → GO.** Write a short handoff note (`docs/handoffs/<ts>-android-voice-gate.md`) recording the captured `SpeechCapabilities`, and proceed to brainstorm/write **Plan 2** (the voice loop: extend `AndroidSpeechBridge` with `start_listening`/`speak`/`poll_event`, the recognizer→VadEvent state machine, the cpal-free `LoopBackends` wiring into `start_voice_mode`, mic runtime-permission, airplane-mode acceptance).
+- **Either false → STOP, re-scope.** If on-device recognition is false, fall back to Whisper STT (the spec's option B). If no offline en voice, the fix is a one-time voice install (`adb shell am start -a com.android.settings.TTS_SETTINGS` to install, then re-probe). Record the finding either way.
+
+- [ ] **Step 6: Commit the handoff note**
+
+```bash
+git add docs/handoffs/
+git commit -m "docs: android voice capability gate result (on-device)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (against `2026-06-18-android-native-voice-poc-design.md`):**
+- §3 capability diagnostic → Tasks 2–7. ✅
+- Strict-offline-first TTS guard → Task 3. ✅
+- Kotlin-owns-native-work + Rust adapter bridge → Task 4 (refined from "Tauri plugin" to a Kotlin helper called over `jni`; the spec's principle — Kotlin owns the Looper-bound speech work, Rust adapts — is preserved; rationale in Risks). ✅
+- `android-native` feature + BM25-only android build + desktop-unchanged → Tasks 1, 5. ✅
+- CI drift-guard → Task 6. ✅
+- Go/no-go gate with re-scope branch → Task 7. ✅
+- §1 STT/TTS/VAD voice loop, §5 acceptance (airplane-mode turn) → **deliberately Plan 2** (written after the gate; planning it now would build on an unvalidated bridge). Noted in Task 7 Step 5.
+
+**Placeholder scan:** the only intentional deferrals are the `jni_bridge.rs` empty file in Task 1 (filled in Task 4) and the Plan-2 hand-off — both explicit, not vague. No "TBD"/"add error handling"/"similar to". Two flagged confirmations (cargo-tauri feature-passthrough syntax in Task 7 Step 1; the exact `generate_handler!` cfg idiom in Task 5 Step 3) point at existing codebase patterns to match, not invented APIs.
+
+**Type consistency:** `SpeechCapabilities` / `TtsVoiceInfo` field names are identical across the Rust types (Task 2), the Kotlin JSON keys (Task 4 Step 3), and the JNI parse (Task 4 Step 5). `select_offline_voice` signature matches between Task 3 and the Plan-2 hand-off note. `AndroidSpeechBridge::query_capabilities` matches between seam (Task 4 Step 1) and impl (Task 4 Step 5).
+
+## Risks
+
+- **`ndk_context::android_context()` may not be populated by the Tauri-mobile runtime.** Task 4 Step 5 uses it; if the on-device smoke (Task 7) shows it returns null/garbage, the fallback is a `#[no_mangle] extern "C"` `nativeInit(JNIEnv, JObject)` exported from Rust and called from `MainActivity.onCreate`, caching the `JavaVM` (via `env.get_java_vm()`) in a `OnceLock`. The Kotlin `PrimerSpeech.init` already caches the Context, so only the VM handle needs this path. This is the single biggest unknown and is exactly why Task 7 is a gate, not a formality.
+- **`find_class` on an attached thread can't see app classes** (system classloader). If `find_class("org/theprimer/gui/PrimerSpeech")` fails on-device, resolve `PrimerSpeech` via the cached Context's `getClassLoader().loadClass(...)` instead. Both paths are well-documented JNI-on-Android idioms; Task 7 reveals which the Tauri runtime needs.
+- **`cargo-tauri` feature passthrough.** The exact way to pass `--no-default-features --features android-native` to the Gradle-driven cargo build (Task 7 Step 1) must match how the existing qnn APK selects features; confirm against the qnn build invocation before assuming `--` passthrough works.

--- a/docs/superpowers/specs/2026-06-18-android-native-voice-poc-design.md
+++ b/docs/superpowers/specs/2026-06-18-android-native-voice-poc-design.md
@@ -1,0 +1,170 @@
+# Android-Native Voice POC (RedMagic) — Design
+
+**Date:** 2026-06-18
+**Status:** approved (owner-paired brainstorming)
+**Scope:** First on-device voice round-trip inside the Android APK — OS-native STT + TTS, English only.
+**Phase:** delivers the Phase 2 *and* Phase 3 exit demo ("a child can have the conversation entirely by voice" / "turn on the device and converse with no other equipment").
+
+## Context
+
+The Tauri-Android APK already runs full multi-turn Socratic conversations on the Hexagon NPU
+(`QnnBackend`, ~25 tok/s, stable across turns — PRs #218/#222/#227). What it cannot yet do is
+**talk**: voice mode works on desktop (CLI `--speech` + GUI) via Silero VAD + Whisper STT + Piper
+TTS, but on Android the `speech` feature is off entirely — no cpal, whisper.cpp, Piper, or `ort`
+compiled in.
+
+This POC extends the working APK to a complete voice turn, on-device and offline, on the RedMagic
+11 Pro (NX809J, Android 16 / API 36).
+
+### Why the silicon is not the constraint
+
+The voice loop is strictly **LISTEN → LATENT_THINK → SPEAK** with no barge-in (a deliberate
+pedagogical invariant, `[[project_no_barge_in_pedagogy]]`). That makes the heavy voice stages
+**temporally disjoint from NPU decode**:
+
+- **LISTEN** — STT runs; NPU idle.
+- **LATENT_THINK** — Qwen3-4B on the NPU; voice subsystem idle.
+- **SPEAK** — TTS runs; NPU idle (only streaming-TTS lightly overlaps the token tail).
+
+STT and the LLM never run at the same instant, so voice compute on CPU/GPU does not contend with
+the NPU for thermal/bandwidth budget. On a Snapdragon 8 Elite Gen 5 with 24 GB RAM this is a
+non-event. **The real risk was never compute — it was the software stack on Android.**
+
+### Device recon (read-only adb, 2026-06-18, the actual RedMagic)
+
+`SpeechRecognizer` providers on the device:
+
+```
+com.google.android.as/...AiAiSpeechRecognitionService    ← on-device (SODA / Android System Intelligence)
+com.google.android.tts/...GoogleTTSRecognitionService     ← network fallback
+com.anthropic.claude/.bell.assist.ClaudeRecognitionService
+```
+
+`TextToSpeech` engine providers:
+
+```
+com.google.android.tts/...GoogleTtsService                ← Google TTS (ships offline en-US voices)
+```
+
+`com.google.android.as` (Android System Intelligence) is **installed and enabled**
+(`installed=true`, `enabled=0`=default/enabled, `stopped=false`) and advertises an **on-device**
+`RecognitionService` — the SODA model behind Live Caption / Recorder / Gboard dictation.
+`SpeechRecognizer.createOnDeviceSpeechRecognizer()` binds to it. This is the load-bearing finding:
+**on-device offline STT + TTS is genuinely available on this ROM.**
+
+adb cannot return three facts (they need an in-app API call): the literal
+`isOnDeviceRecognitionAvailable()` boolean, the on-device-supported locale list, and which
+installed TTS voices report `isNetworkConnectionRequired() == false`. These are confirmed by the
+Section 3 diagnostic before the full loop is built.
+
+## Chosen approach
+
+**OS-native primary** — Android on-device `SpeechRecognizer` (ASI/SODA) for STT + Android
+`TextToSpeech` (offline voice) for TTS. Zero `ort`, zero whisper.cpp, zero Piper, zero espeak-ng,
+zero cpal. Architecturally the Android analogue of the existing `macos-native-26` path (the OS owns
+the mic + endpointing; VAD is derived from recognizer events; TTS plays itself).
+
+Rejected / deferred:
+
+- **B — Whisper STT + energy VAD + native TTS** (the prior option-2 plan). Reused more desktop code
+  but bundles a ~466 MB Whisper model and writes an energy VAD. Now the **fallback** for locales
+  ASI on-device doesn't cover (e.g. German), not the primary. Designed here, not built.
+- **C — Silero VAD / Piper TTS on Android** (`ort`). The exact `ort`-on-`aarch64-linux-android`
+  bet (#157) we are avoiding; if `ort` fails to load on-device the whole loop dies. Out.
+- **Pure `jni-rs` from Rust** for the speech APIs (matching the `macos-native` objc2 style).
+  Rejected: the Android speech APIs are callback-heavy and main-thread/Looper-bound; raw JNI means
+  manual thread-attach, GlobalRef listener objects, and a hand-pumped Looper. A Kotlin plugin
+  handles this naturally and is the documented Tauri-mobile native-plugin path.
+
+## Design
+
+### 1. Backend — `StreamingSpeechToText` + `StreamingTextToSpeech` on Android
+
+Add an Android-native speech backend that satisfies the **existing** `primer-core` speech traits,
+so the shared `primer_speech::voice_loop` state machine, the no-barge-in gating, and the GUI's
+`primer://voice/*` events all work unchanged — exactly how `macos-native` plugs in for Apple.
+
+- **STT** wraps `SpeechRecognizer.createOnDeviceSpeechRecognizer()`. `RecognitionListener`
+  partial results → `SpeechStart` + transcript stream; final result / endpoint → `SpeechEnd`. The
+  **VAD is derived** from these events (`macos-native-26` pattern) — no separate VAD, no cpal mic.
+- **TTS** wraps `TextToSpeech`. At init, enumerate voices for the locale and select one where
+  `isNetworkConnectionRequired() == false`; **hard-error if none** (never fall back to a network
+  voice — `[[project_strict_offline_first]]`). `UtteranceProgressListener.onDone` returns the loop
+  to LISTEN. TTS plays through Android's own audio output — **no cpal speaker, no ringbuf-drain
+  machinery** (the most fragile part of the desktop loop is simply absent here).
+
+### 2. Bridge — Kotlin Tauri-mobile plugin
+
+The Java/Kotlin speech plumbing lives in a **Kotlin Tauri-mobile plugin** (the Android analogue of
+the `macos-native-26` Swift sidecar). It owns the main-thread/Looper-bound recognizer + synthesizer
+lifecycle and exposes commands (`startListening`, `stopListening`, `speak`, `cancel`,
+`queryCapabilities`) and events (partial, final, sttError, ttsStart, ttsDone, ttsError). A thin
+Rust adapter translates those into the `StreamingSpeechToText` / `StreamingTextToSpeech` trait
+shapes consumed by `voice_loop`. **This Rust↔Kotlin bridge is the primary implementation risk; the
+plan validates it first** (a minimal "Kotlin command round-trips to Rust and back" smoke before any
+speech logic).
+
+### 3. De-risking first deliverable — in-APK capability diagnostic
+
+Before wiring the loop, ship one Tauri command (surfaced in Settings → Diagnostics, mirroring the
+existing QNN-metrics opt-in) that calls the real APIs and reports:
+
+- `SpeechRecognizer.isOnDeviceRecognitionAvailable(context)`
+- on-device-supported locales (where determinable)
+- installed `TextToSpeech` voices and their `isNetworkConnectionRequired()` flag
+
+Read back over adb (`run-as` / logcat). This converts the last three adb-unanswerable unknowns into
+hard facts and doubles as the "can our app context reach these Java APIs at all" smoke. Its result
+confirms or adjusts Section 1 before the full loop is built. **If `isOnDeviceRecognitionAvailable`
+is false or no offline en-US voice exists, the POC stops here and re-scopes to fallback B** rather
+than building on a false premise.
+
+### 4. Feature gating & build
+
+- New cargo feature (working name `android-native`) on `primer-speech`, propagated through
+  `primer-gui`, that compiles the Android-native backend + the Rust bridge adapter. Off by default;
+  the default Android APK feature set stays BM25-only with no speech (mirrors #157).
+- The Kotlin plugin is part of the `gen/android` Gradle project (committed, like the rest of the
+  Android scaffold).
+- Microphone permission (`RECORD_AUDIO`) added to the Android manifest + runtime-permission request
+  on first voice use.
+
+### 5. Acceptance
+
+On the RedMagic, in the APK, **in airplane mode** (proving fully offline): tap voice mode, speak an
+English question → transcribed on-device by ASI/SODA → answered by the NPU (`QnnBackend`) → spoken
+aloud by `TextToSpeech` → loop returns to LISTEN. One complete voice turn, no other equipment, no
+network. This is simultaneously the Phase 2 and Phase 3 exit demo.
+
+Regression guards (must stay green): desktop `primer-gui` build/test/fmt/clippy unchanged; the
+Android `--features qnn` cross-compile drift-guard unchanged; the new `android-native` feature
+cross-compiles for `aarch64-linux-android` in CI (lib-only, no Gradle, mirroring the existing qnn
+guard).
+
+## Scope
+
+**In scope:** English-only on-device STT (ASI/SODA) + offline TTS, derived VAD, Kotlin bridge
+plugin, capability diagnostic, mic permission, one offline voice turn on-device, the
+`android-native` feature + CI drift-guard.
+
+**Out of scope (deferred increments):** German (and the Whisper + energy-VAD fallback that German
+likely needs), barge-in either direction, Whisper/Piper/Silero/`ort`/cpal on Android, voice-quality
+or latency tuning, the Phase-B "big central ear/mouth" production voice UI
+(`[[project_gui_voice_phased_visual]]` — this POC reuses the existing composer-zone voice widget).
+
+## Risks
+
+- **Rust↔Kotlin bridge complexity.** Primary risk. Mitigation: a minimal round-trip smoke before
+  any speech logic; the capability diagnostic (Section 3) is the first real exercise of it.
+- **On-device STT behaviour quirks.** `SpeechRecognizer` may auto-timeout, cap utterance length, or
+  require re-arming per turn. Acceptable for a turn-based Socratic loop (re-arm in LISTEN); tune in
+  the plan if it bites.
+- **Offline en-US voice not installed.** Possible on a fresh ROM. Detected by the diagnostic;
+  resolution is a one-time voice install (a setup step, not a runtime network dependency — within
+  `[[project_strict_offline_first]]`).
+- **NubiaOS recognizer routing.** The device default `voice_recognition_service` is currently the
+  Google TTS (network) service; `createOnDeviceSpeechRecognizer()` explicitly bypasses the default
+  and targets the on-device ASI service, so the default setting does not gate us. Confirmed by the
+  diagnostic.
+- **Permission/AppOps on this ROM.** NubiaOS may handle `RECORD_AUDIO` runtime grants differently;
+  verify on first device run.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3730,6 +3730,8 @@ dependencies = [
  "cpal",
  "dispatch2",
  "hound",
+ "jni",
+ "ndk-context",
  "objc2",
  "objc2-avf-audio",
  "objc2-foundation",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -119,6 +119,15 @@ minijinja = "2"
 # `=2.0.0-rc.10` ort pin.
 llama-cpp-2 = "0.1.146"
 
+# Android JNI + NDK context — pulled only by primer-speech's `android-native`
+# feature. `jni` provides safe Rust wrappers around the JNI C API so the
+# Kotlin helper can be called from Rust without raw FFI; `ndk-context` resolves
+# the current JavaVM / Activity from within a running Android app (Tauri-Android
+# or a standalone Activity) so `jni::JavaVM::from_raw()` doesn't need a
+# caller-supplied pointer.
+jni = "0.21"
+ndk-context = "0.1"
+
 # Workspace crates
 primer-core = { path = "crates/primer-core" }
 primer-qnn-sys = { path = "crates/primer-qnn-sys" }

--- a/src/crates/primer-gui/Cargo.toml
+++ b/src/crates/primer-gui/Cargo.toml
@@ -146,3 +146,7 @@ supertonic = ["speech", "primer-speech/supertonic"]
 # non-macOS builds. See docs/macos_native_speech.md.
 macos-native = ["primer-speech/macos-native"]
 macos-native-26 = ["primer-speech/macos-native-26"]
+
+# Android-native speech diagnostic (Plan 1) + (Plan 2) voice loop. Forwards
+# to primer-speech/android-native. Independent of `speech` (no cpal/whisper/piper).
+android-native = ["dep:primer-speech", "primer-speech/android-native"]

--- a/src/crates/primer-gui/gen/android/app/src/main/AndroidManifest.xml
+++ b/src/crates/primer-gui/gen/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <!-- AndroidTV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />

--- a/src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/MainActivity.kt
+++ b/src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/MainActivity.kt
@@ -7,5 +7,6 @@ class MainActivity : TauriActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
+    PrimerSpeech.init(this)
   }
 }

--- a/src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt
+++ b/src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt
@@ -1,0 +1,56 @@
+package org.theprimer.gui
+
+import android.content.Context
+import android.speech.SpeechRecognizer
+import android.speech.tts.TextToSpeech
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/** Looper-bound Android speech work, called from Rust over JNI. */
+object PrimerSpeech {
+    // Cached by init() so JNI calls on attached threads can resolve a real
+    // Context (the system classloader on an attached thread cannot see app
+    // classes — the canonical JNI-on-Android gotcha; the cached app Context
+    // gives queryCapabilities what it needs).
+    @Volatile @JvmStatic var appContext: Context? = null
+
+    @JvmStatic
+    fun init(ctx: Context) { appContext = ctx.applicationContext }
+
+    /** Returns the SpeechCapabilities JSON the Rust side parses with serde. */
+    @JvmStatic
+    fun queryCapabilities(): String {
+        val ctx = appContext ?: return """{"on_device_recognition_available":false,"recognition_locales":[],"tts_voices":[]}"""
+        val obj = JSONObject()
+        obj.put("on_device_recognition_available",
+            SpeechRecognizer.isOnDeviceRecognitionAvailable(ctx))
+        obj.put("recognition_locales", JSONArray())
+
+        val voicesJson = JSONArray()
+        val latch = CountDownLatch(1)
+        var tts: TextToSpeech? = null
+        tts = TextToSpeech(ctx) { status ->
+            if (status == TextToSpeech.SUCCESS) {
+                runCatching {
+                    for (vo in tts?.voices ?: emptySet()) {
+                        voicesJson.put(JSONObject().apply {
+                            put("name", vo.name)
+                            put("locale", vo.locale.toLanguageTag())
+                            put("network_required", vo.isNetworkConnectionRequired)
+                            put("not_installed",
+                                vo.features?.contains(
+                                    TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED) == true)
+                        })
+                    }
+                }
+            }
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        tts?.shutdown()
+        obj.put("tts_voices", voicesJson)
+        return obj.toString()
+    }
+}

--- a/src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt
+++ b/src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt
@@ -11,6 +11,11 @@ import java.util.concurrent.TimeUnit
 
 /** Looper-bound Android speech work, called from Rust over JNI. */
 object PrimerSpeech {
+    // How long queryCapabilities waits for the async TextToSpeech engine init
+    // before giving up and returning whatever voices it has (empty on timeout).
+    // A diagnostic-only bound; the real voice loop (Plan 2) does not block.
+    private const val TTS_INIT_TIMEOUT_SECONDS = 5L
+
     // Cached by init() so JNI calls on attached threads can resolve a real
     // Context (the system classloader on an attached thread cannot see app
     // classes — the canonical JNI-on-Android gotcha; the cached app Context
@@ -55,7 +60,7 @@ object PrimerSpeech {
             }
             latch.countDown()
         }
-        latch.await(5, TimeUnit.SECONDS)
+        latch.await(TTS_INIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         tts?.shutdown()
         obj.put("tts_voices", voicesJson)
         return obj.toString()

--- a/src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt
+++ b/src/crates/primer-gui/gen/android/app/src/main/java/org/theprimer/gui/PrimerSpeech.kt
@@ -1,6 +1,7 @@
 package org.theprimer.gui
 
 import android.content.Context
+import android.os.Build
 import android.speech.SpeechRecognizer
 import android.speech.tts.TextToSpeech
 import org.json.JSONArray
@@ -24,8 +25,14 @@ object PrimerSpeech {
     fun queryCapabilities(): String {
         val ctx = appContext ?: return """{"on_device_recognition_available":false,"recognition_locales":[],"tts_voices":[]}"""
         val obj = JSONObject()
-        obj.put("on_device_recognition_available",
-            SpeechRecognizer.isOnDeviceRecognitionAvailable(ctx))
+        // isOnDeviceRecognitionAvailable is API 31+; minSdk is 24, so guard it
+        // (the build-time NewApi lint would otherwise fail the APK build).
+        val onDevice = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            SpeechRecognizer.isOnDeviceRecognitionAvailable(ctx)
+        } else {
+            false
+        }
+        obj.put("on_device_recognition_available", onDevice)
         obj.put("recognition_locales", JSONArray())
 
         val voicesJson = JSONArray()

--- a/src/crates/primer-gui/src/commands/mod.rs
+++ b/src/crates/primer-gui/src/commands/mod.rs
@@ -7,6 +7,8 @@
 
 pub mod session;
 pub mod settings;
+#[cfg(feature = "android-native")]
+pub mod speech_diag;
 pub mod voice;
 
 use tauri::Wry;
@@ -40,5 +42,7 @@ pub fn register(builder: tauri::Builder<Wry>) -> tauri::Builder<Wry> {
         voice::voice_mode_available,
         voice::macos_native_speech_available,
         voice::supertonic_tts_available,
+        #[cfg(feature = "android-native")]
+        speech_diag::speech_capabilities,
     ])
 }

--- a/src/crates/primer-gui/src/commands/speech_diag.rs
+++ b/src/crates/primer-gui/src/commands/speech_diag.rs
@@ -1,0 +1,12 @@
+//! Android speech-capability diagnostic (Plan 1 go/no-go gate). Surfaced via
+//! the frontend; read back over adb/logcat on the device.
+
+use primer_speech::android::SpeechCapabilities;
+
+#[tauri::command]
+pub async fn speech_capabilities() -> Result<SpeechCapabilities, String> {
+    let caps = primer_speech::android::query_capabilities().map_err(|e| e.to_string())?;
+    // Mirror to logcat so it is readable without a UI round-trip on-device.
+    tracing::info!(target: "primer::speech::diag", caps = ?caps, "speech capabilities");
+    Ok(caps)
+}

--- a/src/crates/primer-speech/Cargo.toml
+++ b/src/crates/primer-speech/Cargo.toml
@@ -78,6 +78,12 @@ dispatch2 = { workspace = true, optional = true }
 # async extern "Swift" method bridges.
 swift-bridge = { version = "0.1", features = ["async"], optional = true }
 
+# Android JNI + NDK context — opt-in via `android-native`. `jni` exposes safe
+# Rust wrappers for the JNI C API; `ndk-context` resolves the active JavaVM /
+# Activity so JNI calls can be made without a caller-supplied raw pointer.
+jni = { workspace = true, optional = true }
+ndk-context = { workspace = true, optional = true }
+
 [build-dependencies]
 swift-bridge-build = { version = "0.1", optional = true }
 
@@ -131,6 +137,11 @@ macos-native-26 = [
     "dep:block2",
     "dep:dispatch2",
 ]
+# Android-native speech (SpeechRecognizer + TextToSpeech via a Kotlin
+# helper called over JNI). Mutually exclusive with the macOS-native
+# features. The pure logic compiles on every host; only the JNI bridge is
+# target_os="android"-gated, so host CI tests the decision logic.
+android-native = ["dep:jni", "dep:ndk-context", "dep:serde_json"]
 
 [[example]]
 name = "tts_hello"

--- a/src/crates/primer-speech/src/android/bridge.rs
+++ b/src/crates/primer-speech/src/android/bridge.rs
@@ -1,16 +1,42 @@
-//! Public bridge surface for the Android speech module.
-//!
-//! Re-exports the JNI bridge type on Android targets and exposes a host stub
-//! on all other targets so downstream crates can name `bridge::JniSpeechBridge`
-//! without `cfg` noise at every call site.
+//! The bridge seam. `query_capabilities()` on the module routes through an
+//! `AndroidSpeechBridge`; the real impl is JNI (android-only), the mock makes
+//! the surrounding logic host-testable — the `primer-inference::qnn`
+//! `GenieLibrary`/`GenieDialog` pattern.
 
-#[cfg(target_os = "android")]
-pub use super::jni_bridge::JniSpeechBridge;
+use crate::android::SpeechCapabilities;
+use primer_core::error::Result;
 
-/// Host stub — `JniSpeechBridge` is not available outside of Android targets.
-/// This type exists solely to allow code that names `bridge::JniSpeechBridge`
-/// to compile on non-Android hosts (e.g. CI, developer laptops).
-#[cfg(not(target_os = "android"))]
-pub struct JniSpeechBridge {
-    _private: (),
+/// Everything the diagnostic needs from the device. Plan 2 extends this trait
+/// with `start_listening` / `speak` / `cancel` / `poll_event`.
+pub trait AndroidSpeechBridge: Send {
+    fn query_capabilities(&self) -> Result<SpeechCapabilities>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::android::TtsVoiceInfo;
+
+    struct MockBridge(SpeechCapabilities);
+    impl AndroidSpeechBridge for MockBridge {
+        fn query_capabilities(&self) -> Result<SpeechCapabilities> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn bridge_returns_capabilities() {
+        let caps = SpeechCapabilities {
+            on_device_recognition_available: true,
+            recognition_locales: vec![],
+            tts_voices: vec![TtsVoiceInfo {
+                name: "offline".into(),
+                locale: "en-US".into(),
+                network_required: false,
+                not_installed: false,
+            }],
+        };
+        let bridge = MockBridge(caps.clone());
+        assert_eq!(bridge.query_capabilities().unwrap(), caps);
+    }
 }

--- a/src/crates/primer-speech/src/android/bridge.rs
+++ b/src/crates/primer-speech/src/android/bridge.rs
@@ -1,0 +1,16 @@
+//! Public bridge surface for the Android speech module.
+//!
+//! Re-exports the JNI bridge type on Android targets and exposes a host stub
+//! on all other targets so downstream crates can name `bridge::JniSpeechBridge`
+//! without `cfg` noise at every call site.
+
+#[cfg(target_os = "android")]
+pub use super::jni_bridge::JniSpeechBridge;
+
+/// Host stub — `JniSpeechBridge` is not available outside of Android targets.
+/// This type exists solely to allow code that names `bridge::JniSpeechBridge`
+/// to compile on non-Android hosts (e.g. CI, developer laptops).
+#[cfg(not(target_os = "android"))]
+pub struct JniSpeechBridge {
+    _private: (),
+}

--- a/src/crates/primer-speech/src/android/capabilities.rs
+++ b/src/crates/primer-speech/src/android/capabilities.rs
@@ -1,38 +1,117 @@
-//! Types describing on-device Android speech capabilities.
-//!
-//! `SpeechCapabilities` is the result of querying the Android device for
-//! installed STT recognisers and TTS voices. It is returned by
-//! `android::query_capabilities()` and is the host-visible output of the
-//! JNI bridge.
+//! Pure capability types + offline-voice selection. No JNI here — this is
+//! the host-testable decision layer.
 
-/// A single installed TTS voice available on the Android device.
-#[derive(Debug, Clone)]
-pub struct TtsVoiceInfo {
-    /// BCP-47 locale tag (e.g. `"en-US"`, `"de-DE"`).
-    pub locale: String,
-    /// Human-readable voice name as reported by Android.
-    pub name: String,
-    /// Whether the voice can be used without a network connection.
-    pub is_network_connection_required: bool,
-}
+use serde::{Deserialize, Serialize};
 
-/// Describes the speech capabilities available on the current Android device.
-#[derive(Debug, Clone, Default)]
+/// A snapshot of the device's speech capabilities, mirroring the JSON
+/// emitted by `PrimerSpeech.queryCapabilities()`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SpeechCapabilities {
-    /// Whether an on-device (`EXTRA_PREFER_OFFLINE = true`) STT recogniser is
-    /// available for the requested locale.
-    pub offline_stt_available: bool,
-    /// All TTS voices reported by the default TextToSpeech engine.
+    /// `SpeechRecognizer.isOnDeviceRecognitionAvailable(context)`.
+    pub on_device_recognition_available: bool,
+    /// Best-effort on-device recognition locales (BCP-47). May be empty —
+    /// Android exposes no synchronous accessor; populated only if a later
+    /// async probe lands. Empty is not a failure.
+    pub recognition_locales: Vec<String>,
+    /// Every installed `TextToSpeech` voice with its offline flags.
     pub tts_voices: Vec<TtsVoiceInfo>,
 }
 
-/// Select the best offline voice for `locale` from `caps`, or `None` if no
-/// offline voice is available.
+/// One `android.speech.tts.Voice`, reduced to the fields the offline-first
+/// guard needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TtsVoiceInfo {
+    pub name: String,
+    /// BCP-47 from `Voice.getLocale().toLanguageTag()`, e.g. `en-US`.
+    pub locale: String,
+    /// `Voice.isNetworkConnectionRequired()`.
+    pub network_required: bool,
+    /// `Voice.getFeatures()` contains `KEY_FEATURE_NOT_INSTALLED`.
+    pub not_installed: bool,
+}
+
+/// Pick the best fully-offline, installed TTS voice for `bcp47`, or `None`.
+/// Exact-locale match wins; otherwise a language-prefix match (`en` matches
+/// `en-US`). Network-required or not-installed voices are never returned —
+/// strict offline-first.
 pub fn select_offline_voice<'a>(
-    caps: &'a SpeechCapabilities,
-    locale: &str,
+    voices: &'a [TtsVoiceInfo],
+    bcp47: &str,
 ) -> Option<&'a TtsVoiceInfo> {
-    caps.tts_voices
+    let usable = |v: &&TtsVoiceInfo| !v.network_required && !v.not_installed;
+    voices
         .iter()
-        .find(|v| !v.is_network_connection_required && v.locale.starts_with(locale))
+        .find(|v| usable(v) && v.locale.eq_ignore_ascii_case(bcp47))
+        .or_else(|| {
+            let lang = bcp47.split('-').next().unwrap_or(bcp47);
+            voices.iter().find(|v| {
+                usable(v)
+                    && v.locale
+                        .split('-')
+                        .next()
+                        .unwrap_or("")
+                        .eq_ignore_ascii_case(lang)
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_kotlin_capabilities_json() {
+        let json = r#"{
+            "on_device_recognition_available": true,
+            "recognition_locales": [],
+            "tts_voices": [
+                {"name":"en-us-x-sfg#female_1-local","locale":"en-US","network_required":false,"not_installed":false},
+                {"name":"en-us-x-iol-network","locale":"en-US","network_required":true,"not_installed":false}
+            ]
+        }"#;
+        let caps: SpeechCapabilities = serde_json::from_str(json).unwrap();
+        assert!(caps.on_device_recognition_available);
+        assert_eq!(caps.tts_voices.len(), 2);
+        assert!(!caps.tts_voices[0].network_required);
+        assert!(caps.tts_voices[1].network_required);
+    }
+
+    fn v(name: &str, locale: &str, net: bool, missing: bool) -> TtsVoiceInfo {
+        TtsVoiceInfo {
+            name: name.into(),
+            locale: locale.into(),
+            network_required: net,
+            not_installed: missing,
+        }
+    }
+
+    #[test]
+    fn picks_offline_exact_locale_and_rejects_network() {
+        let voices = vec![
+            v("net", "en-US", true, false),
+            v("offline", "en-US", false, false),
+        ];
+        assert_eq!(
+            select_offline_voice(&voices, "en-US").unwrap().name,
+            "offline"
+        );
+    }
+
+    #[test]
+    fn rejects_not_installed_even_if_offline() {
+        let voices = vec![v("ghost", "en-US", false, true)];
+        assert!(select_offline_voice(&voices, "en-US").is_none());
+    }
+
+    #[test]
+    fn falls_back_to_language_prefix() {
+        let voices = vec![v("gb", "en-GB", false, false)];
+        assert_eq!(select_offline_voice(&voices, "en").unwrap().name, "gb");
+    }
+
+    #[test]
+    fn none_when_only_network_voices() {
+        let voices = vec![v("net", "en-US", true, false)];
+        assert!(select_offline_voice(&voices, "en-US").is_none());
+    }
 }

--- a/src/crates/primer-speech/src/android/capabilities.rs
+++ b/src/crates/primer-speech/src/android/capabilities.rs
@@ -114,4 +114,12 @@ mod tests {
         let voices = vec![v("net", "en-US", true, false)];
         assert!(select_offline_voice(&voices, "en-US").is_none());
     }
+
+    #[test]
+    fn prefix_fallback_rejects_network_voice() {
+        // The only prefix-matching voice is network-required → None, never a
+        // network voice (the offline-first invariant holds in the fallback arm).
+        let voices = vec![v("net-gb", "en-GB", true, false)];
+        assert!(select_offline_voice(&voices, "en").is_none());
+    }
 }

--- a/src/crates/primer-speech/src/android/capabilities.rs
+++ b/src/crates/primer-speech/src/android/capabilities.rs
@@ -1,0 +1,38 @@
+//! Types describing on-device Android speech capabilities.
+//!
+//! `SpeechCapabilities` is the result of querying the Android device for
+//! installed STT recognisers and TTS voices. It is returned by
+//! `android::query_capabilities()` and is the host-visible output of the
+//! JNI bridge.
+
+/// A single installed TTS voice available on the Android device.
+#[derive(Debug, Clone)]
+pub struct TtsVoiceInfo {
+    /// BCP-47 locale tag (e.g. `"en-US"`, `"de-DE"`).
+    pub locale: String,
+    /// Human-readable voice name as reported by Android.
+    pub name: String,
+    /// Whether the voice can be used without a network connection.
+    pub is_network_connection_required: bool,
+}
+
+/// Describes the speech capabilities available on the current Android device.
+#[derive(Debug, Clone, Default)]
+pub struct SpeechCapabilities {
+    /// Whether an on-device (`EXTRA_PREFER_OFFLINE = true`) STT recogniser is
+    /// available for the requested locale.
+    pub offline_stt_available: bool,
+    /// All TTS voices reported by the default TextToSpeech engine.
+    pub tts_voices: Vec<TtsVoiceInfo>,
+}
+
+/// Select the best offline voice for `locale` from `caps`, or `None` if no
+/// offline voice is available.
+pub fn select_offline_voice<'a>(
+    caps: &'a SpeechCapabilities,
+    locale: &str,
+) -> Option<&'a TtsVoiceInfo> {
+    caps.tts_voices
+        .iter()
+        .find(|v| !v.is_network_connection_required && v.locale.starts_with(locale))
+}

--- a/src/crates/primer-speech/src/android/jni_bridge.rs
+++ b/src/crates/primer-speech/src/android/jni_bridge.rs
@@ -4,8 +4,8 @@
 
 use crate::android::bridge::AndroidSpeechBridge;
 use crate::android::capabilities::SpeechCapabilities;
-use jni::objects::JString;
 use jni::JavaVM;
+use jni::objects::JString;
 use primer_core::error::{PrimerError, Result};
 
 pub struct JniSpeechBridge {
@@ -38,12 +38,7 @@ impl AndroidSpeechBridge for JniSpeechBridge {
             .map_err(jerr)?;
         // call_static_method returns JValueOwned; .l() extracts the JObject.
         let obj = env
-            .call_static_method(
-                &class,
-                "queryCapabilities",
-                "()Ljava/lang/String;",
-                &[],
-            )
+            .call_static_method(&class, "queryCapabilities", "()Ljava/lang/String;", &[])
             .map_err(jerr)?
             .l()
             .map_err(jerr)?;

--- a/src/crates/primer-speech/src/android/jni_bridge.rs
+++ b/src/crates/primer-speech/src/android/jni_bridge.rs
@@ -1,27 +1,56 @@
-//! placeholder, filled in Task 4 (real JNI). For now a stub that satisfies
-//! the `AndroidSpeechBridge` seam so `android::query_capabilities` type-checks
-//! on the android target.
+//! Real `AndroidSpeechBridge` over `jni`. Device-only (compiled only for
+//! target_os = "android"). Runtime behaviour is validated on a physical
+//! device; this module only needs to cross-compile here.
 
 use crate::android::bridge::AndroidSpeechBridge;
 use crate::android::capabilities::SpeechCapabilities;
+use jni::objects::JString;
+use jni::JavaVM;
 use primer_core::error::{PrimerError, Result};
 
 pub struct JniSpeechBridge {
-    _private: (),
+    vm: JavaVM,
+}
+
+fn jerr(e: impl std::fmt::Display) -> PrimerError {
+    PrimerError::Speech(format!("android speech JNI: {e}"))
 }
 
 impl JniSpeechBridge {
     pub fn new() -> Result<Self> {
-        Err(PrimerError::Speech(
-            "JniSpeechBridge is not yet implemented (Task 4)".into(),
-        ))
+        // ndk_context is populated by the Tauri-mobile runtime. If the
+        // on-device gate shows it is NOT, the documented fallback is a
+        // `nativeInit` JNI export caching the JavaVM — see the plan's Risks.
+        let ctx = ndk_context::android_context();
+        // SAFETY: ndk_context guarantees the pointer is a valid *mut JavaVM
+        // for the lifetime of the Android process. We wrap it immediately and
+        // never store the raw pointer.
+        let vm = unsafe { JavaVM::from_raw(ctx.vm().cast()) }.map_err(jerr)?;
+        Ok(Self { vm })
     }
 }
 
 impl AndroidSpeechBridge for JniSpeechBridge {
     fn query_capabilities(&self) -> Result<SpeechCapabilities> {
-        Err(PrimerError::Speech(
-            "JniSpeechBridge is not yet implemented (Task 4)".into(),
-        ))
+        let mut env = self.vm.attach_current_thread().map_err(jerr)?;
+        let class = env
+            .find_class("org/theprimer/gui/PrimerSpeech")
+            .map_err(jerr)?;
+        // call_static_method returns JValueOwned; .l() extracts the JObject.
+        let obj = env
+            .call_static_method(
+                &class,
+                "queryCapabilities",
+                "()Ljava/lang/String;",
+                &[],
+            )
+            .map_err(jerr)?
+            .l()
+            .map_err(jerr)?;
+        // Safe: the Java method declares String as its return type.
+        let jstr = JString::from(obj);
+        let java_str = env.get_string(&jstr).map_err(jerr)?;
+        let s: String = java_str.into();
+        serde_json::from_str(&s).map_err(jerr)
     }
 }

--- a/src/crates/primer-speech/src/android/jni_bridge.rs
+++ b/src/crates/primer-speech/src/android/jni_bridge.rs
@@ -1,29 +1,25 @@
-//! placeholder, filled in Task 4
-//!
-//! Minimal scaffold so the `mod jni_bridge` declaration in `android/mod.rs`
-//! resolves and `JniSpeechBridge::new()` type-checks on the android target.
-//! The real implementation lands in Task 4.
+//! placeholder, filled in Task 4 (real JNI). For now a stub that satisfies
+//! the `AndroidSpeechBridge` seam so `android::query_capabilities` type-checks
+//! on the android target.
 
+use crate::android::bridge::AndroidSpeechBridge;
+use crate::android::capabilities::SpeechCapabilities;
 use primer_core::error::{PrimerError, Result};
 
-use super::capabilities::SpeechCapabilities;
-
-/// Scaffold JNI bridge to Android's `SpeechRecognizer` + `TextToSpeech`.
-/// Filled in by Task 4; construction always returns an error until then.
 pub struct JniSpeechBridge {
     _private: (),
 }
 
 impl JniSpeechBridge {
-    /// Construct the bridge. Returns an error until Task 4 implements the body.
     pub fn new() -> Result<Self> {
         Err(PrimerError::Speech(
             "JniSpeechBridge is not yet implemented (Task 4)".into(),
         ))
     }
+}
 
-    /// Query the device's speech capabilities.
-    pub fn query_capabilities(&self) -> Result<SpeechCapabilities> {
+impl AndroidSpeechBridge for JniSpeechBridge {
+    fn query_capabilities(&self) -> Result<SpeechCapabilities> {
         Err(PrimerError::Speech(
             "JniSpeechBridge is not yet implemented (Task 4)".into(),
         ))

--- a/src/crates/primer-speech/src/android/jni_bridge.rs
+++ b/src/crates/primer-speech/src/android/jni_bridge.rs
@@ -1,0 +1,31 @@
+//! placeholder, filled in Task 4
+//!
+//! Minimal scaffold so the `mod jni_bridge` declaration in `android/mod.rs`
+//! resolves and `JniSpeechBridge::new()` type-checks on the android target.
+//! The real implementation lands in Task 4.
+
+use primer_core::error::{PrimerError, Result};
+
+use super::capabilities::SpeechCapabilities;
+
+/// Scaffold JNI bridge to Android's `SpeechRecognizer` + `TextToSpeech`.
+/// Filled in by Task 4; construction always returns an error until then.
+pub struct JniSpeechBridge {
+    _private: (),
+}
+
+impl JniSpeechBridge {
+    /// Construct the bridge. Returns an error until Task 4 implements the body.
+    pub fn new() -> Result<Self> {
+        Err(PrimerError::Speech(
+            "JniSpeechBridge is not yet implemented (Task 4)".into(),
+        ))
+    }
+
+    /// Query the device's speech capabilities.
+    pub fn query_capabilities(&self) -> Result<SpeechCapabilities> {
+        Err(PrimerError::Speech(
+            "JniSpeechBridge is not yet implemented (Task 4)".into(),
+        ))
+    }
+}

--- a/src/crates/primer-speech/src/android/mod.rs
+++ b/src/crates/primer-speech/src/android/mod.rs
@@ -1,0 +1,28 @@
+//! Android-native speech: on-device `SpeechRecognizer` STT + `TextToSpeech`
+//! TTS via a Kotlin helper called over JNI. Plan 1 ships only the capability
+//! diagnostic; the voice loop lands in Plan 2.
+
+mod capabilities;
+pub mod bridge;
+
+pub use capabilities::{select_offline_voice, SpeechCapabilities, TtsVoiceInfo};
+
+#[cfg(target_os = "android")]
+mod jni_bridge;
+
+use primer_core::error::Result;
+
+/// Query the device's speech capabilities. On Android this drives the real
+/// JNI bridge; on every other target it is a platform stub so the crate and
+/// its tests still build host-side.
+#[cfg(target_os = "android")]
+pub fn query_capabilities() -> Result<SpeechCapabilities> {
+    jni_bridge::JniSpeechBridge::new()?.query_capabilities()
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn query_capabilities() -> Result<SpeechCapabilities> {
+    Err(primer_core::error::PrimerError::Speech(
+        "android speech capabilities are only available on android targets".into(),
+    ))
+}

--- a/src/crates/primer-speech/src/android/mod.rs
+++ b/src/crates/primer-speech/src/android/mod.rs
@@ -2,10 +2,10 @@
 //! TTS via a Kotlin helper called over JNI. Plan 1 ships only the capability
 //! diagnostic; the voice loop lands in Plan 2.
 
-mod capabilities;
 pub mod bridge;
+mod capabilities;
 
-pub use capabilities::{select_offline_voice, SpeechCapabilities, TtsVoiceInfo};
+pub use capabilities::{SpeechCapabilities, TtsVoiceInfo, select_offline_voice};
 
 #[cfg(target_os = "android")]
 mod jni_bridge;
@@ -17,6 +17,7 @@ use primer_core::error::Result;
 /// its tests still build host-side.
 #[cfg(target_os = "android")]
 pub fn query_capabilities() -> Result<SpeechCapabilities> {
+    use crate::android::bridge::AndroidSpeechBridge;
     jni_bridge::JniSpeechBridge::new()?.query_capabilities()
 }
 

--- a/src/crates/primer-speech/src/lib.rs
+++ b/src/crates/primer-speech/src/lib.rs
@@ -12,6 +12,15 @@ compile_error!(
      (`macos-native-26` for macOS 26+, `macos-native` for older macOS)"
 );
 
+#[cfg(all(
+    feature = "android-native",
+    any(feature = "macos-native", feature = "macos-native-26")
+))]
+compile_error!(
+    "android-native is mutually exclusive with macos-native / macos-native-26; \
+     pick one via --features"
+);
+
 pub mod locale_defaults;
 pub mod phrase_split;
 pub mod stub;
@@ -70,3 +79,6 @@ pub mod macos;
 // load-bearing one and must reflect actual build support.
 #[cfg(all(target_os = "macos", feature = "macos-native-26"))]
 pub mod macos26;
+
+#[cfg(feature = "android-native")]
+pub mod android;


### PR DESCRIPTION
## What this is

Plan 1 of the Android-native voice POC for the RedMagic: a trait-abstracted Rust↔Kotlin speech bridge plus an on-device capability diagnostic that answers the **go/no-go** question for OS-native voice on the device. This is the foundation for bringing voice mode (LISTEN → THINK on the NPU → SPEAK) into the existing Tauri-Android APK, fully offline.

Design: `docs/superpowers/specs/2026-06-18-android-native-voice-poc-design.md`
Plan: `docs/superpowers/plans/2026-06-18-android-native-voice-bridge-diagnostic.md`

## On-device gate: GO ✅ (RedMagic 11 Pro / NX809J / Android 16)

Read in-APK via a file mirror (logcat is dead on this ROM) + `run-as`:
- **`on_device_recognition_available = true`** — Google ASI/SODA on-device STT, confirmed at runtime.
- **Multiple offline en-US TTS voices installed** (`network_required:false, not_installed:false`). The `not_installed` filter is load-bearing — the engine advertises ~370 voices, almost all `not_installed:true`.

The OS-native architecture (Android `SpeechRecognizer` + `TextToSpeech`, zero `ort`/whisper/piper/cpal) is validated. Plan 2 (the voice loop) is unblocked.

## What's in the branch

- `android-native` cargo feature + `primer_speech::android`: capability types, strict-offline-first `select_offline_voice` (host-TDD'd, incl. the prefix-fallback arm), and an `AndroidSpeechBridge` seam (host-mock-tested — the `primer-inference::qnn` pattern).
- Real JNI bridge (`#[cfg(target_os="android")]`) + Kotlin `PrimerSpeech.kt` (`SpeechRecognizer` + `TextToSpeech` query), API-31 guarded.
- `speech_capabilities` Tauri diagnostic command + `RECORD_AUDIO` manifest permission.
- CI cross-compile drift-guard for `primer-gui --features android-native` (aarch64-linux-android).

Default desktop builds are unaffected (everything is `#[cfg(feature = "android-native")]`; on a default GUI build `primer-speech` isn't even a dependency).

## Carried to Plan 2 (root-caused on-device)

The Rust→JNI bridge round-trip **panics** because `ndk_context` is not populated under the Tauri-mobile runtime (the plan's documented #1 risk — confirmed, not theoretical). The capability gate doesn't depend on it (the OS APIs are reachable from Kotlin directly), but the Plan 2 loop does. **Fix = Plan 2 Task 1:** a `nativeInit` JNI export caching the `JavaVM` (via `env.get_java_vm()`) from `MainActivity`, read by `JniSpeechBridge::new()` instead of `ndk_context`. See `docs/handoffs/2026-06-18-android-voice-capability-gate.md`.

## Verification

- `cargo test -p primer-speech --features android-native` — 7 new + 33 default regression, green.
- `cargo fmt`/`clippy` clean; android-native cross-compiles for `aarch64-linux-android`.
- Final whole-branch review: passed, no must-fix items (3 deferrable Minors noted for Plan 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-up (post-review fixes)

- **Heads-up — the `speech_capabilities` command is registered but not yet functional on-device.** It panics in `JniSpeechBridge::new()` on `ndk_context` (the documented #1 risk, root-caused above). Invoking it on-device today is expected to fail; the **Plan 2 Task 1 `nativeInit` fix** makes it live. Don't expect a result from it in this branch.
- Named the magic 5 s TextToSpeech-init wait in `PrimerSpeech.kt` (`TTS_INIT_TIMEOUT_SECONDS`).
- Corrected the handoff doc's gate-scaffolding note: the `[GATE-SCAFFOLD]` code is **reverted and not in the branch**.
