### PR TITLE
docs(speech): correct quit_phrases_for doc to equality, not word-boundary

### DIFF
--- a/src/crates/primer-speech/src/voice_loop/quit_detect.rs
+++ b/src/crates/primer-speech/src/voice_loop/quit_detect.rs
@@ -6,11 +6,12 @@
 //! normalisation, and the equality check together (with their tests) in
 //! one leaf module keeps `state_machine.rs` focused on the loop itself.
 
-/// Per-locale quit phrases. If heard in the child's transcript, the
-/// session ends. Case-insensitive, word-boundary match (see
-/// [`is_quit_phrase`]). Each locale ships its own set so a child can
-/// quit in the language they speak — without a locale-aware list, the
-/// German voice mode silently lacks any voice-keyword end affordance.
+/// Per-locale quit phrases. If the child's transcript equals one of
+/// these (case-insensitive, after whitespace/punctuation normalisation
+/// — see [`is_quit_phrase`]), the session ends. Each locale ships its
+/// own set so a child can quit in the language they speak — without a
+/// locale-aware list, the German voice mode silently lacks any
+/// voice-keyword end affordance.
 ///
 /// Adding a new locale: append a `(pack_id, &[phrase, ...])` row. The
 /// pack_id must match `Locale::pack_id()` for the corresponding locale.


### PR DESCRIPTION
## What

Follow-up doc fix to PR #266 (already merged as `c345285`). The merge classifier blocked adding this commit to #266 in time, so it ships as its own one-file change.

The `quit_phrases_for` doc comment (moved verbatim into the new `quit_detect.rs` in #266) said *"Case-insensitive, word-boundary match"*, but the actual contract — correctly documented on `is_quit_phrase` itself — is **exact equality after whitespace/punctuation normalisation**. This rewords the comment to match.

## Why

Surfaced during review of #266. A stale doc that contradicts the function's real behaviour ("word-boundary" implies substring/prefix matching, which `is_quit_phrase` deliberately does *not* do — that was the original bug the equality contract fixed).

## Behaviour change

**None.** Doc comment only.

## Verification

- `cargo clippy -p primer-speech --features voice-loop --all-targets -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)