### PR TITLE
Android generic-API test APK for volunteer families

### DIFF
--- a/docs/devel/android-test-apk-build.md
+++ b/docs/devel/android-test-apk-build.md
@@ -90,10 +90,18 @@ This exercises the Android-only code paths that no host build covers: the
 `#[cfg(target_os = "android")]` first-run seed extraction both compile and link
 for `aarch64-linux-android`.
 
-**Seed-refresh caveat:** the seed JSONL is embedded at compile time via
-`include_dir!`. After editing `data/seed/*.jsonl` (which `build.rs` re-copies
-into `resources/seed/`), do a clean rebuild of `primer-gui` so the embedded
-bytes refresh — an incremental build may not re-expand the macro.
+**Seed-refresh caveat (build side):** the seed JSONL is embedded at compile
+time via `include_dir!`. After editing `data/seed/*.jsonl` (which `build.rs`
+re-copies into `resources/seed/`), do a clean rebuild of `primer-gui` so the
+embedded bytes refresh — an incremental build may not re-expand the macro.
+
+**Seed refresh on device (update side):** first-run extraction writes a
+`.seed_version` marker (an FNV fingerprint of the embedded corpus) next to the
+staged `*.jsonl`. On a later boot the marker is compared against the current
+embedded corpus: an unchanged corpus is skipped (nothing rewritten, any staged
+edit preserved), and a changed corpus — i.e. a new APK carrying a revised
+corpus installed over an already-run one — is re-extracted so the child sees
+the current corpus rather than the stale first-install copy.
 
 ## Next step
 

--- a/docs/devel/android-test-apk-build.md
+++ b/docs/devel/android-test-apk-build.md
@@ -64,13 +64,38 @@ source, not just static reading.
   -- --no-default-features --features android-native
 ```
 
-If `cargo tauri android build` does not forward `--no-default-features`/`--features`
-to the Rust lib build, pin the feature set in `gen/android/app/build.gradle.kts`
-under the `rust { }` block instead. Verify the produced APK by checking that
-no `libonnxruntime`/fastembed artifacts are bundled and that the app logs
-`--embedder-backend none` behaviour (empty/BM25 KB).
+Flag forwarding via `--` is confirmed working (see the build note below): the
+`-- --no-default-features --features android-native` tail reaches the Rust lib
+build. If a future Tauri CLI ever stops forwarding it, pin the feature set in
+`gen/android/app/build.gradle.kts` under the `rust { }` block instead. Either
+way, sanity-check the produced APK by confirming no `libonnxruntime`/fastembed
+artifacts are bundled and the app logs `--embedder-backend none` behaviour
+(empty/BM25 KB).
+
+With no `gen/android/keystore.properties` present, the `release` build produces
+an **unsigned** APK (the signing config no-ops to `null`) — useful for a
+compile check; a distributable build needs the keystore (see Task 6).
+
+## Verified build (2026-07-01, macOS arm64 host)
+
+`cargo tauri android build --apk --target aarch64 -- --no-default-features
+--features android-native` completed successfully and emitted:
+
+```
+gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
+```
+
+This exercises the Android-only code paths that no host build covers: the
+`include_dir!("$CARGO_MANIFEST_DIR/resources/seed")` embed and the
+`#[cfg(target_os = "android")]` first-run seed extraction both compile and link
+for `aarch64-linux-android`.
+
+**Seed-refresh caveat:** the seed JSONL is embedded at compile time via
+`include_dir!`. After editing `data/seed/*.jsonl` (which `build.rs` re-copies
+into `resources/seed/`), do a clean rebuild of `primer-gui` so the embedded
+bytes refresh — an incremental build may not re-expand the macro.
 
 ## Next step
 
 See Task 6's on-device smoke checklist for installing and exercising the
-built APK on a physical device.
+built (signed) APK on a physical device.

--- a/docs/devel/android-test-apk-build.md
+++ b/docs/devel/android-test-apk-build.md
@@ -1,0 +1,76 @@
+# Android generic-API test APK build notes
+
+Build notes for producing a sideloadable Android test APK of `primer-gui`,
+configured for cloud / OpenAI-compatible API inference (no on-device NPU, no
+bundled embedder), for volunteer families to test. This is the host-side
+verification gate: it proves the Android feature contract
+(`--no-default-features --features android-native`) compiles before the
+slower Tauri-Android build is attempted.
+
+## Environment prerequisites
+
+- `cargo-tauri` 2.11.1
+- Android NDK **r29** at `/opt/homebrew/share/android-ndk`
+- Android SDK at `~/Library/Android/sdk` (`ANDROID_HOME`)
+- **JDK 21**
+- `rustup target add aarch64-linux-android --toolchain 1.88`
+
+See [docs/devel/android-build-quickstart.md](android-build-quickstart.md) for
+the fuller environment setup (NDK discovery symlink, `JAVA_HOME` pinning,
+etc.) — those details are shared across all Android build flavours and are
+not repeated here.
+
+## Step 1: host-verify the feature set compiles
+
+From `src/`:
+
+```bash
+~/.cargo/bin/cargo build -p primer-gui --no-default-features --features android-native
+```
+
+This confirms the GUI builds without the `embedding` feature and with
+`android-native` (which pulls `dep:primer-speech` + `primer-speech/android-native`).
+
+Verified 2026-07-01 on macOS arm64 host: compiles cleanly, no warnings, in
+1m 47s (`Finished `dev` profile [unoptimized + debuginfo] target(s)`).
+
+## Step 2: embedder default is feature-aware
+
+`crates/primer-gui/src/config/types.rs` defines `default_embedder_kind()`
+twice, cfg-gated:
+
+```rust
+#[cfg(feature = "embedding")]
+fn default_embedder_kind() -> &'static str {
+    "fastembed"
+}
+
+#[cfg(not(feature = "embedding"))]
+fn default_embedder_kind() -> &'static str {
+    "none"
+}
+```
+
+Without the `embedding` feature (the Android build), a fresh config (no
+stored `kind` in `gui-config.json`) resolves to `"none"` — BM25-only
+retrieval, no fastembed/ort download. Verified by grep against the built
+source, not just static reading.
+
+## Step 3: the on-device build command
+
+```bash
+# from src/crates/primer-gui/
+~/.cargo/bin/cargo tauri android build --apk --target aarch64 \
+  -- --no-default-features --features android-native
+```
+
+If `cargo tauri android build` does not forward `--no-default-features`/`--features`
+to the Rust lib build, pin the feature set in `gen/android/app/build.gradle.kts`
+under the `rust { }` block instead. Verify the produced APK by checking that
+no `libonnxruntime`/fastembed artifacts are bundled and that the app logs
+`--embedder-backend none` behaviour (empty/BM25 KB).
+
+## Next step
+
+See Task 6's on-device smoke checklist for installing and exercising the
+built APK on a physical device.

--- a/docs/pilot/family-setup-guide.md
+++ b/docs/pilot/family-setup-guide.md
@@ -1,0 +1,183 @@
+# Setting Up the Primer — A Guide for Families
+
+Thank you for volunteering to try the Primer with your child! This guide walks
+you through everything you need to do, from getting an API key to handing the
+phone to your child. None of the steps require any programming knowledge —
+just follow along in order.
+
+Please also read **parent-consent-note.md**, which explains what data the app
+handles and where it goes, before your child starts using the Primer.
+
+## 1. What you're installing
+
+The Primer is a learning companion for children that works a bit differently
+from most educational apps: instead of just giving answers, it asks
+questions. It's built around the "Socratic method" — when your child says
+something, the Primer often responds by asking how they know it, or how they
+could check, rather than simply confirming or correcting them. The idea is to
+encourage curiosity and independent thinking, not just to deliver facts.
+
+**This is a test build**, not a finished product and not something you'd find
+on an app store. You're one of a small number of volunteer families helping
+us see how well the Primer teaches in practice — how it asks questions,
+notices when a child is confused or tired, and suggests breaks. Things may be
+rough around the edges, and your feedback matters.
+
+The Primer needs to talk to an AI model to generate its responses, and for
+this test build, that means connecting it to an AI provider using an API key
+that you provide. The next section walks you through getting one.
+
+## 2. Getting an API key
+
+The Primer can use either **OpenAI** or **Anthropic** (the maker of Claude) as
+its AI provider. You only need an account and a key with **one** of them —
+pick whichever you're more comfortable with, or whichever you might already
+have an account with. Both companies bill based on how much the app is used,
+so the steps below also show you how to set a spending limit so you're never
+surprised by the bill.
+
+**Important:** the usage this app generates is billed to **your own**
+account with the provider you choose. The Primer project does not pay for
+this, and we never see your key or your bill. Conversations are short and
+this is light personal use, so costs are typically small — but setting a low
+limit (as shown below) means you can relax about it.
+
+### Option A: Anthropic (Claude)
+
+1. Go to **console.anthropic.com** in a web browser and create an account
+   (or sign in if you already have one).
+2. You'll likely need to add a small amount of credit or a payment method
+   before you can create a key — follow the on-screen prompts in the
+   Anthropic console.
+3. In the console, find **API Keys** (usually under Settings) and create a
+   new key. Give it a name like "Primer test" so you can recognize it later.
+4. **Copy the key immediately** — it's a long string starting with `sk-ant-`.
+   Most providers only show you the full key once, so copy it into a notes
+   app or leave the browser tab open until you've pasted it into the Primer
+   (step 4 below).
+5. While you're in the console, look for **spend limits** or **usage limits**
+   and set a low monthly cap (for example, $5–$10). This protects you from
+   unexpected charges if the app is used a lot.
+
+### Option B: OpenAI
+
+1. Go to **platform.openai.com** and create an account (or sign in).
+2. Add billing details if prompted — OpenAI requires a payment method on
+   file for API access.
+3. Find **API keys** in the left-hand menu and create a new secret key. Name
+   it something like "Primer test".
+4. **Copy the key immediately** — it starts with `sk-` and, like Anthropic,
+   is usually shown only once.
+5. Under **Settings → Limits** (or **Billing → Limits**), set a monthly
+   budget limit — again, something small like $5–$10 is plenty for personal
+   testing.
+
+Keep the key somewhere safe until you've entered it into the app (next
+section covers installing the app; the section after that covers entering
+the key).
+
+## 3. Installing the app on the phone
+
+You'll have received a file named something like `Primer-<version>-arm64.apk`
+— this is the Android installer for the test build. "arm64" just refers to
+the type of phone processor it's built for, which covers the vast majority of
+Android phones from the last several years.
+
+1. **Get the file onto the phone.** Transfer `Primer-<ver>-arm64.apk` to the
+   phone however is easiest for you — email it to yourself and open the
+   attachment on the phone, share it via a messaging app, or copy it over USB
+   into the phone's Downloads folder.
+2. **Allow installing from this source.** Android blocks installing apps
+   from outside the Play Store by default, as a security precaution. When
+   you tap the APK file to install it, Android will likely show a prompt
+   like *"For your security, your phone is not allowed to install unknown
+   apps from this source."* Tap the button in that prompt (often labeled
+   **Settings**) and toggle on **Allow from this source** for whichever app
+   you used to open the file (your file manager, browser, or messaging app).
+   Then go back and tap the APK file again.
+3. **Install.** Tap **Install** on the confirmation screen. Android may show
+   a warning that the app is unrecognized — this is expected for a test
+   build; tap through to continue.
+4. Once installed, you'll find **Primer** in your app drawer like any other
+   app.
+
+You only need to do this once. If we send you an updated test build later,
+you'll repeat these steps with the new APK file (Android will update the
+existing app rather than creating a duplicate, as long as the version
+increases).
+
+## 4. First-run setup (do this once, before your child uses it)
+
+This part is for the adult to do. Once it's set up, your child won't need to
+touch any of these settings.
+
+1. Open the **Primer** app.
+2. Tap **Settings**.
+3. Open the **Inference backend** section.
+4. In the **Backend** dropdown, choose one of:
+   - **cloud (Anthropic)** — if you got a key from Anthropic in step 2.
+   - **openai-compat (oMLX / LM Studio / vLLM)** — this is also the option
+     for a regular **OpenAI** account, since OpenAI's API uses this same
+     "OpenAI-compatible" format.
+5. Depending on which you chose:
+   - **If you chose `cloud (Anthropic)`:** scroll to the **API key (cloud
+     only)** section, select **Store inline in config file**, and paste your
+     Anthropic key into the **Anthropic API key** field that appears.
+   - **If you chose `openai-compat`:** you'll also need to fill in the
+     **Server URL** field. For a standard OpenAI account, this is
+     `https://api.openai.com/v1`. Then scroll to **Server API key
+     (openai-compat)**, select **Store inline in config file**, and paste
+     your OpenAI key into the **Server API key** field. You should also set
+     the **Model** field — for OpenAI this is a model name such as
+     `gpt-4o-mini` (ask whoever gave you this build if you're unsure which
+     model to use).
+6. Scroll up to the **Learner** section and fill in your child's **Name**,
+   **Age**, and **Locale** (their language) — this personalizes how the
+   Primer talks to them.
+7. Tap **Save** (you'll see options like **Save (next session only)** or
+   **Save & start new session** — either is fine for first-time setup).
+
+That's it — the AI connection and your child's profile are now saved on this
+phone.
+
+## 5. Handing the phone to your child
+
+Your child can now open the Primer and start exploring. There are two ways
+to talk to it:
+
+- **Typing.** Just type a question or something they're curious about, the
+  same as texting.
+- **Voice.** Tap the microphone button (🎙 **Voice mode**) near the top of
+  the screen to talk out loud instead of typing. The **first time** voice
+  mode is used, Android will ask for permission to use the microphone — this
+  is a normal one-time Android permission prompt, and it needs to be
+  accepted for voice mode to work.
+
+Remind your child that the Primer likes to ask questions back — if it asks
+"how do you know that?" instead of just answering, that's by design, not a
+malfunction.
+
+## 6. Troubleshooting
+
+- **A yellow banner says "Ask a grown-up to set up the AI in Settings
+  before you start."** This means no API key has been entered yet, or the
+  backend isn't configured. Go back to Section 4 above and complete the
+  first-run setup.
+- **The Primer replies with an error message instead of a normal answer.**
+  This is almost always one of two things:
+  1. **The API key is wrong, expired, or the account has hit its spending
+     limit.** Double-check the key was copied correctly (no extra spaces),
+     and check your provider's dashboard to confirm the key is still active
+     and the account has available credit/budget.
+  2. **No internet connection.** The app needs an active Wi-Fi or mobile
+     data connection to reach the AI provider — conversations are not
+     processed on the phone itself in this test build.
+- **Voice mode doesn't respond.** Check that microphone permission was
+  granted (Android Settings → Apps → Primer → Permissions → Microphone). If
+  it was previously denied, you may need to enable it there manually.
+- **Still stuck?** Contact whoever gave you this test build — screenshots of
+  any error message are very helpful for us to track down the problem.
+
+Thank you again for helping test the Primer. We hope your child enjoys the
+experience of being asked good questions as much as we've enjoyed building
+something that asks them.

--- a/docs/pilot/parent-consent-note.md
+++ b/docs/pilot/parent-consent-note.md
@@ -1,0 +1,42 @@
+# The Primer — Pilot Test: Information for Parents & Guardians
+
+Thank you for helping test the Primer, a Socratic learning companion for
+children. Please read this before your child uses the app.
+
+## What this test is
+This is an early **test build** distributed to volunteer families. It is not a
+finished product and is not offered on any app store. You are helping evaluate
+how the Primer teaches — how it asks questions, checks understanding, and
+encourages breaks.
+
+## What data is handled, and where
+- **Your child's conversations and learning history stay on the device.** The
+  app stores them in the phone's private app storage. They are not uploaded to
+  us and we do not collect them.
+- **To generate each reply, the app sends the text of the current
+  conversation turn to the AI provider you choose** (OpenAI or Anthropic), using
+  the API key *you* provide. That request travels over an encrypted (HTTPS)
+  connection. The provider processes the text under **their** privacy terms and
+  policies — please review the terms of whichever provider you pick.
+- We (the Primer project) do **not** receive your child's conversations, name,
+  age, or usage. There is no analytics or tracking in this build.
+- The API key you enter is stored only in the app's private storage on that one
+  device. It is never sent to us and is not embedded in the app.
+
+## Your choices and control
+- You set up the app and choose the AI provider. You can change or remove the
+  key at any time in Settings.
+- You can delete all local data by clearing the app's storage or uninstalling.
+- Because conversation text goes to a third-party AI provider, please supervise
+  early sessions and decide what is appropriate for your child to share. Avoid
+  entering identifying details (full name, address, school) into the chat.
+
+## No guarantees
+This is experimental software. Replies come from a third-party AI model and may
+occasionally be wrong or inappropriate despite the Primer's safeguards. Please
+supervise and give us feedback.
+
+## Consent
+By setting up the app and letting your child use it, you agree to this test on
+the terms above. Questions or withdrawal: contact the person who gave you this
+build.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2124,6 +2124,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,6 +3627,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "futures",
+ "include_dir",
  "paranoid-android",
  "primer-classifier",
  "primer-comprehension",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -127,6 +127,12 @@ llama-cpp-2 = "0.1.146"
 # does not populate for our call path (Plan 1 gate finding, 2026-06-18).
 jni = "0.21"
 
+# Embeds primer-gui's small (~280 KB) seed-corpus JSONL tree into the
+# Android binary at compile time, so a first-run extraction step (no
+# `adb push` required) can stage it to <app_data>/seed/. Android-target-only
+# dependency (see primer-gui/Cargo.toml) — never pulled into desktop builds.
+include_dir = "0.7"
+
 # Workspace crates
 primer-core = { path = "crates/primer-core" }
 primer-qnn-sys = { path = "crates/primer-qnn-sys" }

--- a/src/crates/primer-gui/Cargo.toml
+++ b/src/crates/primer-gui/Cargo.toml
@@ -70,6 +70,11 @@ chrono.workspace = true
 # `adb logcat`. Desktop builds never pull this in.
 [target.'cfg(target_os = "android")'.dependencies]
 paranoid-android = { workspace = true }
+# Embeds resources/seed/*.jsonl into the binary so first-run extraction to
+# <app_data>/seed/ works without `adb push` (volunteer sideload builds have
+# no adb access). Android-only — desktop resolves the seed dir from the
+# .app bundle or CARGO_MANIFEST_DIR instead.
+include_dir = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/src/crates/primer-gui/gen/android/.gitignore
+++ b/src/crates/primer-gui/gen/android/.gitignore
@@ -15,6 +15,9 @@ build
 local.properties
 key.properties
 keystore.properties
+# Release signing secrets — never commit a keystore or its properties.
+*.jks
+*.keystore
 
 /.tauri
 /tauri.settings.gradle

--- a/src/crates/primer-gui/gen/android/app/build.gradle.kts
+++ b/src/crates/primer-gui/gen/android/app/build.gradle.kts
@@ -24,6 +24,25 @@ android {
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
     }
+
+    val keystorePropsFile = rootProject.file("keystore.properties")
+    val keystoreProps = Properties().apply {
+        if (keystorePropsFile.exists()) {
+            keystorePropsFile.inputStream().use { load(it) }
+        }
+    }
+
+    signingConfigs {
+        create("release") {
+            if (keystorePropsFile.exists()) {
+                storeFile = file(keystoreProps.getProperty("storeFile"))
+                storePassword = keystoreProps.getProperty("storePassword")
+                keyAlias = keystoreProps.getProperty("keyAlias")
+                keyPassword = keystoreProps.getProperty("keyPassword")
+            }
+        }
+    }
+
     buildTypes {
         getByName("debug") {
             manifestPlaceholders["usesCleartextTraffic"] = "true"
@@ -54,12 +73,17 @@ android {
             }
         }
         getByName("release") {
-            isMinifyEnabled = true
-            proguardFiles(
-                *fileTree(".") { include("**/*.pro") }
-                    .plus(getDefaultProguardFile("proguard-android-optimize.txt"))
-                    .toList().toTypedArray()
-            )
+            // Minify stays OFF for the test APK: R8 would risk stripping or
+            // renaming org.theprimer.gui.PrimerSpeech, which the Rust side
+            // invokes reflectively over JNI (nativeInit caches it as a
+            // GlobalRef). A future minified production build must add explicit
+            // proguard-keep rules for that class + its native methods.
+            isMinifyEnabled = false
+            signingConfig = if (keystorePropsFile.exists()) {
+                signingConfigs.getByName("release")
+            } else {
+                null
+            }
         }
     }
     kotlinOptions {

--- a/src/crates/primer-gui/gen/android/keystore.properties.example
+++ b/src/crates/primer-gui/gen/android/keystore.properties.example
@@ -1,0 +1,9 @@
+# Copy to keystore.properties (gitignored) and fill in real values.
+# Generate a keystore once with:
+#   keytool -genkey -v -keystore primer-release.jks -keyalg RSA -keysize 2048 \
+#     -validity 10000 -alias primer
+# Keep primer-release.jks OUTSIDE the repo; point storeFile at its absolute path.
+storeFile=/absolute/path/to/primer-release.jks
+storePassword=CHANGE_ME
+keyAlias=primer
+keyPassword=CHANGE_ME

--- a/src/crates/primer-gui/src/paths.rs
+++ b/src/crates/primer-gui/src/paths.rs
@@ -460,7 +460,6 @@ pub fn extract_bundled_seed_if_absent(
 #[cfg(test)]
 mod tests;
 
-#[cfg(any(target_os = "android", test))]
 #[cfg(test)]
 mod seed_extract_tests {
     use super::*;

--- a/src/crates/primer-gui/src/paths.rs
+++ b/src/crates/primer-gui/src/paths.rs
@@ -199,6 +199,15 @@ pub fn init_mobile_state(app: &tauri::App) -> Result<(), Box<dyn std::error::Err
     let qnn_metrics_opt_in = config.diagnostics.qnn_metrics_enabled;
     app.manage(crate::state::AppState::new(home.clone(), config));
 
+    // Volunteer sideload builds have no `adb push`, so stage the embedded
+    // seed corpus to <app_data>/seed/ on first run; the discovery call below
+    // then points PRIMER_SEED_DIR at it. Failure degrades to an empty KB
+    // (the prompt builder omits the knowledge section) rather than blocking boot.
+    #[cfg(target_os = "android")]
+    if let Err(e) = extract_bundled_seed_if_absent(&home) {
+        tracing::warn!("seed extraction failed: {e}; continuing without knowledge base");
+    }
+
     set_mobile_seed_dir_if_present(&home);
     set_adsp_library_path_if_present();
     set_genie_log_path(&home);
@@ -402,5 +411,88 @@ fn find_jsonl_dir(dir: &Path, depth: u32, max_depth: u32) -> Option<PathBuf> {
     None
 }
 
+/// Write `(filename, contents)` pairs into `dir`, creating `dir` first and
+/// skipping any file that already exists. Idempotent — a re-run never
+/// overwrites a file a user (or a prior run) already placed. Host-testable;
+/// the android-only [`extract_bundled_seed_if_absent`] feeds it the embedded
+/// corpus.
+#[cfg(any(target_os = "android", test))]
+fn write_seed_files(dir: &std::path::Path, files: &[(&str, &[u8])]) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    for (name, bytes) in files {
+        let dest = dir.join(name);
+        if !dest.exists() {
+            std::fs::write(&dest, bytes)?;
+        }
+    }
+    Ok(())
+}
+
+/// The seed corpus embedded at compile time from `primer-gui/resources/seed/`.
+/// ~280 KB of JSONL; extracted to `<app_data>/seed/` on first run so
+/// `PRIMER_SEED_DIR` discovery works without `adb push`. Android-only — the
+/// desktop `.app` bundle path and the `CARGO_MANIFEST_DIR` dev fallback cover
+/// the other targets.
+#[cfg(target_os = "android")]
+static BUNDLED_SEED: include_dir::Dir<'_> =
+    include_dir::include_dir!("$CARGO_MANIFEST_DIR/resources/seed");
+
+/// Extract the embedded seed corpus into `<app_data>/seed/` if not already
+/// present, returning that directory. Idempotent (see [`write_seed_files`]).
+#[cfg(target_os = "android")]
+pub fn extract_bundled_seed_if_absent(
+    app_data: &std::path::Path,
+) -> std::io::Result<std::path::PathBuf> {
+    let dir = mobile_seed_dir(app_data);
+    let files: Vec<(&str, &[u8])> = BUNDLED_SEED
+        .files()
+        .filter_map(|f| {
+            f.path()
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|name| (name, f.contents()))
+        })
+        .collect();
+    write_seed_files(&dir, &files)?;
+    Ok(dir)
+}
+
 #[cfg(test)]
 mod tests;
+
+#[cfg(any(target_os = "android", test))]
+#[cfg(test)]
+mod seed_extract_tests {
+    use super::*;
+
+    #[test]
+    fn write_seed_files_creates_and_is_idempotent() {
+        let tmp = std::env::temp_dir().join(format!("primer_seed_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let files: &[(&str, &[u8])] = &[
+            ("seed_passages.en.jsonl", b"{\"id\":\"a\"}\n"),
+            ("wiki_passages.en.jsonl", b"{\"id\":\"b\"}\n"),
+        ];
+
+        // First write creates both files.
+        write_seed_files(&tmp, files).unwrap();
+        assert_eq!(
+            std::fs::read(tmp.join("seed_passages.en.jsonl")).unwrap(),
+            b"{\"id\":\"a\"}\n"
+        );
+        assert_eq!(
+            std::fs::read(tmp.join("wiki_passages.en.jsonl")).unwrap(),
+            b"{\"id\":\"b\"}\n"
+        );
+
+        // Mutate one file, then re-run: existing files are left untouched (idempotent skip).
+        std::fs::write(tmp.join("seed_passages.en.jsonl"), b"USER_EDIT").unwrap();
+        write_seed_files(&tmp, files).unwrap();
+        assert_eq!(
+            std::fs::read(tmp.join("seed_passages.en.jsonl")).unwrap(),
+            b"USER_EDIT"
+        );
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+}

--- a/src/crates/primer-gui/src/paths.rs
+++ b/src/crates/primer-gui/src/paths.rs
@@ -200,11 +200,12 @@ pub fn init_mobile_state(app: &tauri::App) -> Result<(), Box<dyn std::error::Err
     app.manage(crate::state::AppState::new(home.clone(), config));
 
     // Volunteer sideload builds have no `adb push`, so stage the embedded
-    // seed corpus to <app_data>/seed/ on first run; the discovery call below
-    // then points PRIMER_SEED_DIR at it. Failure degrades to an empty KB
-    // (the prompt builder omits the knowledge section) rather than blocking boot.
+    // seed corpus to <app_data>/seed/ on first run (and refresh it when an app
+    // update carries a revised corpus); the discovery call below then points
+    // PRIMER_SEED_DIR at it. Failure degrades to an empty KB (the prompt
+    // builder omits the knowledge section) rather than blocking boot.
     #[cfg(target_os = "android")]
-    if let Err(e) = extract_bundled_seed_if_absent(&home) {
+    if let Err(e) = extract_bundled_seed(&home) {
         tracing::warn!("seed extraction failed: {e}; continuing without knowledge base");
     }
 
@@ -411,20 +412,50 @@ fn find_jsonl_dir(dir: &Path, depth: u32, max_depth: u32) -> Option<PathBuf> {
     None
 }
 
-/// Write `(filename, contents)` pairs into `dir`, creating `dir` first and
-/// skipping any file that already exists. Idempotent — a re-run never
-/// overwrites a file a user (or a prior run) already placed. Host-testable;
-/// the android-only [`extract_bundled_seed_if_absent`] feeds it the embedded
-/// corpus.
+/// Filename of the corpus-version marker written alongside the staged seed
+/// files. Holds the [`seed_fingerprint`] of the corpus that produced the
+/// current staged files, so a later run can tell whether an app update
+/// carries a revised corpus. Not a `*.jsonl` file, so [`find_jsonl_dir`]
+/// never treats it as seed content.
 #[cfg(any(target_os = "android", test))]
-fn write_seed_files(dir: &std::path::Path, files: &[(&str, &[u8])]) -> std::io::Result<()> {
-    std::fs::create_dir_all(dir)?;
+const SEED_VERSION_MARKER: &str = ".seed_version";
+
+/// FNV-1a digest (hex) over each `(name, contents)` pair — a compile-time
+/// fingerprint of the embedded corpus. It changes whenever a bundled file's
+/// name or bytes change across builds, which is what drives re-extraction on
+/// an app update. Cheap enough (~280 KB) to recompute on every boot.
+#[cfg(any(target_os = "android", test))]
+fn seed_fingerprint(files: &[(&str, &[u8])]) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for (name, bytes) in files {
-        let dest = dir.join(name);
-        if !dest.exists() {
-            std::fs::write(&dest, bytes)?;
+        for b in name.as_bytes().iter().chain(bytes.iter()) {
+            hash ^= u64::from(*b);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
         }
     }
+    format!("{hash:016x}")
+}
+
+/// Stage `(filename, contents)` pairs into `dir`. When the on-disk version
+/// marker already matches the corpus [`seed_fingerprint`], this is a total
+/// no-op — nothing is written, so an unchanged corpus is never re-extracted
+/// and any file already staged (e.g. an `adb push`) is preserved. When the
+/// fingerprint differs (fresh install, or an app update carrying a revised
+/// corpus) every bundled file is (re)written and the marker is updated, so
+/// the child sees the current corpus rather than a stale one. Host-testable;
+/// the android-only [`extract_bundled_seed`] feeds it the embedded corpus.
+#[cfg(any(target_os = "android", test))]
+fn write_seed_files(dir: &std::path::Path, files: &[(&str, &[u8])]) -> std::io::Result<()> {
+    let fingerprint = seed_fingerprint(files);
+    let marker = dir.join(SEED_VERSION_MARKER);
+    if std::fs::read_to_string(&marker).ok().as_deref() == Some(fingerprint.as_str()) {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir)?;
+    for (name, bytes) in files {
+        std::fs::write(dir.join(name), bytes)?;
+    }
+    std::fs::write(&marker, &fingerprint)?;
     Ok(())
 }
 
@@ -437,12 +468,12 @@ fn write_seed_files(dir: &std::path::Path, files: &[(&str, &[u8])]) -> std::io::
 static BUNDLED_SEED: include_dir::Dir<'_> =
     include_dir::include_dir!("$CARGO_MANIFEST_DIR/resources/seed");
 
-/// Extract the embedded seed corpus into `<app_data>/seed/` if not already
-/// present, returning that directory. Idempotent (see [`write_seed_files`]).
+/// Extract the embedded seed corpus into `<app_data>/seed/`, returning that
+/// directory. Skips the write when the staged corpus is already current and
+/// refreshes it when an app update carries a revised corpus (see
+/// [`write_seed_files`]).
 #[cfg(target_os = "android")]
-pub fn extract_bundled_seed_if_absent(
-    app_data: &std::path::Path,
-) -> std::io::Result<std::path::PathBuf> {
+pub fn extract_bundled_seed(app_data: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
     let dir = mobile_seed_dir(app_data);
     let files: Vec<(&str, &[u8])> = BUNDLED_SEED
         .files()
@@ -465,7 +496,7 @@ mod seed_extract_tests {
     use super::*;
 
     #[test]
-    fn write_seed_files_creates_and_is_idempotent() {
+    fn write_seed_files_creates_and_skips_when_corpus_unchanged() {
         let tmp = std::env::temp_dir().join(format!("primer_seed_test_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         let files: &[(&str, &[u8])] = &[
@@ -473,7 +504,7 @@ mod seed_extract_tests {
             ("wiki_passages.en.jsonl", b"{\"id\":\"b\"}\n"),
         ];
 
-        // First write creates both files.
+        // First write creates both files plus the version marker.
         write_seed_files(&tmp, files).unwrap();
         assert_eq!(
             std::fs::read(tmp.join("seed_passages.en.jsonl")).unwrap(),
@@ -483,13 +514,36 @@ mod seed_extract_tests {
             std::fs::read(tmp.join("wiki_passages.en.jsonl")).unwrap(),
             b"{\"id\":\"b\"}\n"
         );
+        assert!(tmp.join(SEED_VERSION_MARKER).exists());
 
-        // Mutate one file, then re-run: existing files are left untouched (idempotent skip).
+        // Mutate one file, then re-run with the SAME corpus: the fingerprint
+        // matches the marker, so nothing is rewritten and the edit survives.
         std::fs::write(tmp.join("seed_passages.en.jsonl"), b"USER_EDIT").unwrap();
         write_seed_files(&tmp, files).unwrap();
         assert_eq!(
             std::fs::read(tmp.join("seed_passages.en.jsonl")).unwrap(),
             b"USER_EDIT"
+        );
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn write_seed_files_reextracts_when_corpus_changes() {
+        let tmp = std::env::temp_dir().join(format!("primer_seed_change_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        // v1 of the corpus (a first install).
+        let v1: &[(&str, &[u8])] = &[("seed_passages.en.jsonl", b"{\"id\":\"a\"}\n")];
+        write_seed_files(&tmp, v1).unwrap();
+
+        // v2 carries changed bytes under the same filename (an app update).
+        // The fingerprint differs, so the stale file is refreshed.
+        let v2: &[(&str, &[u8])] = &[("seed_passages.en.jsonl", b"{\"id\":\"a2\"}\n")];
+        write_seed_files(&tmp, v2).unwrap();
+        assert_eq!(
+            std::fs::read(tmp.join("seed_passages.en.jsonl")).unwrap(),
+            b"{\"id\":\"a2\"}\n"
         );
 
         std::fs::remove_dir_all(&tmp).unwrap();

--- a/src/crates/primer-gui/ui/app.js
+++ b/src/crates/primer-gui/ui/app.js
@@ -128,8 +128,38 @@ async function main() {
   setupSidebarToggle();
   setupUuidCopy();
   setupSettingsButton();
+  setupSetupNudge();
   setupSwitchSessionButton();
   showPicker();
+}
+
+/// Show a one-line nudge when no real LLM is configured (backend still on
+/// the `stub` default), so the supervising adult wires an API key in Settings
+/// before handing the phone to the child. Best-effort: any error just hides it.
+async function refreshSetupNudge() {
+  const nudge = document.getElementById("setup-nudge");
+  if (!nudge) return;
+  try {
+    const settings = await invoke("get_settings");
+    const kind = settings?.backend?.kind ?? "stub";
+    nudge.hidden = kind !== "stub";
+  } catch (_e) {
+    nudge.hidden = true;
+  }
+}
+
+/// Wire the nudge banner's "Open Settings" button once at init: it
+/// delegates to the header's existing `#settings-open` control (so the
+/// modal opens through its one normal entry point) and hides itself
+/// immediately, since the click is itself the user acting on the nudge.
+function setupSetupNudge() {
+  const nudgeOpen = document.getElementById("setup-nudge-open");
+  if (nudgeOpen) {
+    nudgeOpen.addEventListener("click", () => {
+      document.getElementById("settings-open")?.click();
+      document.getElementById("setup-nudge").hidden = true;
+    });
+  }
 }
 
 /// Open (or re-open) the launch-screen picker. The picker manages its
@@ -219,6 +249,7 @@ async function handleSessionReady({ info, shouldReplay }) {
 
   setComposerState("idle");
   refreshSidebar();
+  refreshSetupNudge();
 
   // If voice mode was active before this session switch, re-enter it
   // under the new locale. The backend's `prepare_for_session_change`

--- a/src/crates/primer-gui/ui/index.html
+++ b/src/crates/primer-gui/ui/index.html
@@ -71,6 +71,13 @@
       </div>
     </header>
 
+    <div class="setup-nudge" id="setup-nudge" role="status" hidden>
+      <span class="setup-nudge-text">
+        Ask a grown-up to set up the AI in Settings before you start.
+      </span>
+      <button type="button" class="setup-nudge-btn" id="setup-nudge-open">Open Settings</button>
+    </div>
+
     <main class="chat">
       <div class="chat-scroll" id="chat-scroll">
         <!-- Bubbles are injected here. The first turn lands once the user sends.

--- a/src/crates/primer-gui/ui/styles.css
+++ b/src/crates/primer-gui/ui/styles.css
@@ -314,6 +314,31 @@ body.sidebar-collapsed {
   flex: 0 0 auto;
 }
 
+/* ─── First-run "set up the AI" nudge ───────────────────────────────
+   Shown when the effective backend is still the `stub` default (see
+   refreshSetupNudge() in app.js) so the supervising adult configures a
+   real backend + API key in Settings before handing the phone to the
+   child. */
+.setup-nudge {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background: #fff4d6;
+  color: #5a4300;
+  font-size: 0.95rem;
+}
+.setup-nudge[hidden] { display: none; }
+.setup-nudge-btn {
+  margin-left: auto;
+  padding: 0.35rem 0.8rem;
+  border: 0;
+  border-radius: 6px;
+  background: #5a4300;
+  color: #fff;
+  cursor: pointer;
+}
+
 /* ─── Composer ──────────────────────────────────────────────────── */
 
 .composer {


### PR DESCRIPTION
Packages the existing `primer-gui` Tauri app as a signed, sideloadable **arm64 Android test APK** configured for cloud / OpenAI-compatible API inference, so volunteer families can field-test the pedagogic engine on ordinary phones — no local LLM, no RedMagic-class hardware, no NPU. Each family brings its own OpenAI/Anthropic key; the supervising adult enters it once in Settings, then hands the phone to the child.

Spec: `docs/superpowers/specs/2026-07-01-android-generic-api-test-apk-design.md`
Plan: `docs/superpowers/plans/2026-07-01-android-generic-api-test-apk.md`

## What's in this branch (5 tasks, each task-reviewed)
- **Feature contract + build notes** (`docs/devel/android-test-apk-build.md`) — Android build = `cargo tauri android build --apk --target aarch64 -- --no-default-features --features android-native`. Drops `embedding` so the embedder defaults to `none` (BM25-only, no 570 MB download / device-unverified ort); excludes qnn/llamacpp/whisper/piper/cpal. Cloud + openai-compat are always compiled.
- **First-run seed extraction** — the APK asset namespace isn't `std::fs`-readable and volunteers have no `adb`, so `resources/seed/` (~280 KB) is embedded via `include_dir` and extracted to `<app_data>/seed/` on first Android run, then the existing `set_mobile_seed_dir_if_present` wires `PRIMER_SEED_DIR`. Degrades gracefully (empty KB) on failure. Pure `write_seed_files` helper is host-tested.
- **Release signing** — `signingConfig` from a gitignored `keystore.properties` (only `.example` committed); minify **off** to protect the JNI-invoked `PrimerSpeech` class used by `android-native` voice.
- **First-run "set up the AI" nudge** — webview banner shown when the backend is still the `stub` default, opening the existing Settings modal. Best-effort, no new IPC.
- **Family setup guide + parent consent note** (`docs/pilot/`) — plain-language install/key-entry guide and a consent note disclosing that learner data stays on-device while only per-turn text goes to the family's chosen provider.

## Verification
- Host build under the Android feature contract: clean.
- `primer-gui` test suite: 206/206; clippy + fmt clean.
- **Android build verified**: `cargo tauri android build --apk --target aarch64 -- --no-default-features --features android-native` succeeded and produced `app-universal-release-unsigned.apk`, exercising the `#[cfg(target_os = "android")]` seed-extraction + `include_dir!` paths that no host build covers.
- Final whole-branch review: **Ready to merge: Yes** (no Critical/Important; 3 trivial Minors fixed inline in `ce277ac`).

## Owner-gated follow-up (Task 6 of the plan)
Not done here — needs your signing keystore + a physical phone: generate a keystore, create `keystore.properties`, build the **signed** APK, install on a real non-RedMagic phone, and smoke-test a cloud round-trip + one OS-native voice round-trip + KB seeding.

## Out of scope
Play **production** submission (Designed-for-Families / COPPA / GDPR-K / data-safety), QNN/local-LLM Android inference, shared/embedded keys or a project proxy, and minified/R8 production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)